### PR TITLE
[8.0][IMP][contract_payment_mode] Copy partner payment mode to contracts when installing

### DIFF
--- a/contract_payment_mode/README.rst
+++ b/contract_payment_mode/README.rst
@@ -34,6 +34,7 @@ Contributors
 ------------
 
 * Ángel Moya <angel.moya@domatix.com>
+* Antonio Espinosa <antonioea@antiun.com>
 
 
 Maintainer

--- a/contract_payment_mode/__init__.py
+++ b/contract_payment_mode/__init__.py
@@ -1,2 +1,6 @@
 # -*- coding: utf-8 -*-
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import models
+from .hooks import post_init_hook

--- a/contract_payment_mode/__openerp__.py
+++ b/contract_payment_mode/__openerp__.py
@@ -35,6 +35,7 @@
         'views/contract_view.xml',
     ],
     'test': ['test/contract_payment_mode.yml'],
+    'post_init_hook': 'post_init_hook',
     'installable': True,
     'auto_install': True,
 }

--- a/contract_payment_mode/hooks.py
+++ b/contract_payment_mode/hooks.py
@@ -13,7 +13,10 @@ def post_init_hook(cr, registry):
     with api.Environment.manage():
         env = api.Environment(cr, SUPERUSER_ID, {})
         m_contract = env['account.analytic.account']
-        contracts = m_contract.search([('type', '=', 'contract')])
+        contracts = m_contract.search([
+            ('type', '=', 'contract'),
+            ('payment_mode_id', '=', False),
+        ])
         if contracts:
             _logger.info('Setting payment mode: %d contracts' %
                          len(contracts))

--- a/contract_payment_mode/hooks.py
+++ b/contract_payment_mode/hooks.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, SUPERUSER_ID
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(cr, registry):
+    """Copy payment mode from partner to the new field at contract."""
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        m_contract = env['account.analytic.account']
+        contracts = m_contract.search([('type', '=', 'contract')])
+        if contracts:
+            _logger.info('Setting payment mode: %d contracts' %
+                         len(contracts))
+        for contract in contracts:
+            payment_mode = contract.partner_id.customer_payment_mode
+            if payment_mode:
+                contract.payment_mode_id = payment_mode.id
+        _logger.info('Setting payment mode: Done')

--- a/contract_payment_mode/tests/__init__.py
+++ b/contract_payment_mode/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_contract_payment_init

--- a/contract_payment_mode/tests/test_contract_payment_init.py
+++ b/contract_payment_mode/tests/test_contract_payment_init.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# © 2015 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+from ..hooks import post_init_hook
+
+
+class TestContractPaymentInit(TransactionCase):
+    # Use case : Prepare some data for current test case
+    def setUp(self):
+        super(TestContractPaymentInit, self).setUp()
+        self.payment_mode = self.env.ref('account_payment.payment_mode_1')
+        self.partner = self.env['res.partner'].create({
+            'name': 'Test contract partner',
+            'customer_payment_mode': self.payment_mode.id,
+        })
+
+    def _contract_payment_mode_id(self, contract_id):
+        contract = self.env['account.analytic.account'].search([
+            ('id', '=', contract_id),
+        ])
+        return contract.payment_mode_id.id
+
+    def test_post_init_hook(self):
+        contract = self.env['account.analytic.account'].create({
+            'name': 'Test contract',
+            'type': 'contract',
+            'partner_id': self.partner.id,
+            'payment_mode_id': self.payment_mode.id,
+        })
+        self.assertEqual(self._contract_payment_mode_id(contract.id),
+                         self.payment_mode.id)
+
+        contract.payment_mode_id = False
+        self.assertEqual(self._contract_payment_mode_id(contract.id), False)
+
+        post_init_hook(self.cr, self.env)
+        self.assertEqual(self._contract_payment_mode_id(contract.id),
+                         self.payment_mode.id)


### PR DESCRIPTION
This improvement copies payment mode (configured in customer) to contracts when installing the addon.
