### PR TITLE
[IMP][10.0] Add 'Date of Next Invoice' in contract list view

### DIFF
--- a/contract/views/account_analytic_account_view.xml
+++ b/contract/views/account_analytic_account_view.xml
@@ -81,6 +81,9 @@
             <field name="partner_id" position="before">
                 <field name="journal_id" groups="account.group_account_user"/>
             </field>
+            <field name="partner_id" position="after">
+                <field name="recurring_next_date" invisible="not context.get('is_contract', False)"/>
+            </field>
         </field>
     </record>
 
@@ -113,7 +116,7 @@
         <field name="res_model">account.analytic.account</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
-        <field name="context">{'search_default_active':1, 'search_default_recurring_invoices':1}</field>
+        <field name="context">{'is_contract':1, 'search_default_active':1, 'search_default_recurring_invoices':1}</field>
         <field name="search_view_id" ref="analytic.view_account_analytic_account_search"/>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">


### PR DESCRIPTION
This simple PR is a proposal to add the field 'Date of Next Invoice' (recurring_next_date) in the view 'account.analytic.account.list' for Contracts.
It seems that field is a very useful information to be displayed on Contracts list.