### PR TITLE
[10.0][IMP] Add variable qty to contract template view

### DIFF
--- a/contract_variable_quantity/__manifest__.py
+++ b/contract_variable_quantity/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Variable quantity in contract recurrent invoicing',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.1.0',
     'category': 'Contract Management',
     'license': 'AGPL-3',
     'author': "Tecnativa,"

--- a/contract_variable_quantity/__manifest__.py
+++ b/contract_variable_quantity/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Variable quantity in contract recurrent invoicing',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Contract Management',
     'license': 'AGPL-3',
     'author': "Tecnativa,"

--- a/contract_variable_quantity/views/contract_view.xml
+++ b/contract_variable_quantity/views/contract_view.xml
@@ -1,6 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="account_analytic_contract_view_form" model="ir.ui.view">
+        <field name="name">Contract Template Variable Qty</field>
+        <field name="model">account.analytic.contract</field>
+        <field name="inherit_id" ref="contract.account_analytic_contract_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='recurring_invoice_line_ids']//field[@name='quantity']" position="before">
+                <field name="qty_type"/>
+            </xpath>
+            <xpath expr="//field[@name='recurring_invoice_line_ids']//field[@name='quantity']" position="after">
+                <field name="qty_formula_id"
+                       attrs="{'required': [('qty_type', '=', 'variable')], 'invisible': [('qty_type', '!=', 'variable')]}"
+                />
+            </xpath>
+            <xpath expr="//field[@name='recurring_invoice_line_ids']//field[@name='quantity']" position="attributes">
+                <attribute name="attrs">{'required': [('qty_type', '=', 'fixed')], 'invisible': [('qty_type', '!=', 'fixed')]}</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="account_analytic_account_recurring_form_form" model="ir.ui.view">
         <field name="model">account.analytic.account</field>
         <field name="inherit_id" ref="contract.account_analytic_account_recurring_form_form"/>


### PR DESCRIPTION
Allows templating of the variable qty lines by updating the `account.analytic.contract` view.