### PR TITLE
[IMP] travis: Remove `UNIT_TEST` build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="odoo/odoo" UNIT_TEST="1"
   - TESTS="1" ODOO_REPO="OCA/OCB"
   - TRANSIFEX="1"
 


### PR DESCRIPTION
TBH I'm not 100% why this is like this, but IMO it's just wasting Travis power by testing a subset of the same thing.