### PR TITLE
[FIX] contract_payment_auto, contract_payment_mode, contract_sale_generation, contract_variable_quantity: Fix wkhtmltopdf freeze

### DIFF
--- a/contract/models/account_analytic_account.py
+++ b/contract/models/account_analytic_account.py
@@ -206,7 +206,7 @@ class AccountAnalyticAccount(models.Model):
     @api.multi
     def recurring_create_invoice(self):
         """
-        Create invoices from contracts
+        Create invoices or sales from contracts
         :return: invoices created
         """
         # NOTE: Don't use a browse because here there are 2 types of records:

--- a/contract_payment_auto/tests/test_account_analytic_account.py
+++ b/contract_payment_auto/tests/test_account_analytic_account.py
@@ -6,14 +6,16 @@ import mock
 
 from contextlib import contextmanager
 
+import odoo.tests
 from odoo import fields
 from odoo.tools import mute_logger
-from odoo.tests.common import TransactionCase
 
 from ..models import account_analytic_account
 
 
-class TestAccountAnalyticAccount(TransactionCase):
+@odoo.tests.at_install(False)
+@odoo.tests.post_install(True)
+class TestAccountAnalyticAccount(odoo.tests.HttpCase):
 
     def setUp(self):
         super(TestAccountAnalyticAccount, self).setUp()

--- a/contract_payment_mode/tests/test_contract_payment.py
+++ b/contract_payment_mode/tests/test_contract_payment.py
@@ -4,42 +4,44 @@
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests import common
+import odoo.tests
 from ..hooks import post_init_hook
 
 
-class TestContractPaymentInit(common.SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super(TestContractPaymentInit, cls).setUpClass()
+@odoo.tests.post_install(True)
+@odoo.tests.at_install(False)
+class TestContractPaymentInit(odoo.tests.HttpCase):
 
-        cls.payment_method = cls.env['account.payment.method'].create({
+    def setUp(self):
+        super(TestContractPaymentInit, self).setUp()
+
+        self.payment_method = self.env['account.payment.method'].create({
             'name': 'Test Payment Method',
             'code': 'Test',
             'payment_type': 'inbound',
         })
-        cls.payment_mode = cls.env['account.payment.mode'].create({
+        self.payment_mode = self.env['account.payment.mode'].create({
             'name': 'Test payment mode',
             'active': True,
-            'payment_method_id': cls.payment_method.id,
+            'payment_method_id': self.payment_method.id,
             'bank_account_link': 'variable',
         })
-        cls.partner = cls.env['res.partner'].create({
+        self.partner = self.env['res.partner'].create({
             'name': 'Test contract partner',
-            'customer_payment_mode_id': cls.payment_mode,
+            'customer_payment_mode_id': self.payment_mode,
         })
-        cls.product = cls.env['product.product'].create({
+        self.product = self.env['product.product'].create({
             'name': 'Custom Service',
             'type': 'service',
-            'uom_id': cls.env.ref('product.product_uom_hour').id,
-            'uom_po_id': cls.env.ref('product.product_uom_hour').id,
+            'uom_id': self.env.ref('product.product_uom_hour').id,
+            'uom_po_id': self.env.ref('product.product_uom_hour').id,
             'sale_ok': True,
         })
-        cls.contract = cls.env['account.analytic.account'].create({
+        self.contract = self.env['account.analytic.account'].create({
             'name': 'Maintenance of Servers',
         })
-        company = cls.env.ref('base.main_company')
-        cls.journal = cls.env['account.journal'].create({
+        company = self.env.ref('base.main_company')
+        self.journal = self.env['account.journal'].create({
             'name': 'Sale Journal - Test',
             'code': 'HRTSJ',
             'type': 'sale',

--- a/contract_sale_generation/tests/test_contract_invoice.py
+++ b/contract_sale_generation/tests/test_contract_invoice.py
@@ -4,11 +4,13 @@
 # Copyright 2017 Angel Moya <angel.moya@pesol.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import odoo.tests
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
 
 
-class TestContractInvoice(TransactionCase):
+@odoo.tests.at_install(False)
+@odoo.tests.post_install(True)
+class TestContractInvoice(odoo.tests.HttpCase):
     # Use case : Prepare some data for current test case
 
     def setUp(self):

--- a/contract_variable_quantity/tests/test_contract_variable_quantity.py
+++ b/contract_variable_quantity/tests/test_contract_variable_quantity.py
@@ -2,27 +2,28 @@
 # © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import common
+import odoo.tests
 from odoo import exceptions
 
 
-class TestContractVariableQuantity(common.SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super(TestContractVariableQuantity, cls).setUpClass()
-        cls.partner = cls.env['res.partner'].create({
+@odoo.tests.at_install(False)
+@odoo.tests.post_install(True)
+class TestContractVariableQuantity(odoo.tests.HttpCase):
+    def setUp(self):
+        super(TestContractVariableQuantity, self).setUp()
+        self.partner = self.env['res.partner'].create({
             'name': 'Test partner',
         })
-        cls.product = cls.env['product.product'].create({
+        self.product = self.env['product.product'].create({
             'name': 'Test product',
         })
-        cls.contract = cls.env['account.analytic.account'].create({
+        self.contract = self.env['account.analytic.account'].create({
             'name': 'Test Contract',
-            'partner_id': cls.partner.id,
-            'pricelist_id': cls.partner.property_product_pricelist.id,
+            'partner_id': self.partner.id,
+            'pricelist_id': self.partner.property_product_pricelist.id,
             'recurring_invoices': True,
         })
-        cls.formula = cls.env['contract.line.qty.formula'].create({
+        self.formula = self.env['contract.line.qty.formula'].create({
             'name': 'Test formula',
             # For testing each of the possible variables
             'code': 'env["res.users"]\n'
@@ -33,14 +34,14 @@ class TestContractVariableQuantity(common.SavepointCase):
                     'invoice.id\n'
                     'result = 12',
         })
-        cls.contract_line = cls.env['account.analytic.invoice.line'].create({
-            'analytic_account_id': cls.contract.id,
-            'product_id': cls.product.id,
+        self.contract_line = self.env['account.analytic.invoice.line'].create({
+            'analytic_account_id': self.contract.id,
+            'product_id': self.product.id,
             'name': 'Test',
             'qty_type': 'variable',
-            'qty_formula_id': cls.formula.id,
+            'qty_formula_id': self.formula.id,
             'quantity': 1,
-            'uom_id': cls.product.uom_id.id,
+            'uom_id': self.product.uom_id.id,
             'price_unit': 100,
             'discount': 50,
         })


### PR DESCRIPTION
The test uses wkhtmltopdf, wkhtmltopdf uses html connection to get data from odoo.
If you have a instance starting and you try use it you will have a freezed browse, with wkhtmltopdf is the same.
So is required run this tests after start odoo and use a session, the session is created from HttpCase.SetUp method.

Fix https://github.com/OCA/maintainer-quality-tools/issues/509

In your local machine you can bypass this issue if you have a session stored (a previous /web/login before of run the tests), that is the reason that with the CI fails because anyone start a session or login instance before run the tests.

NOTE: Please, delete the branch if is merged
NOTE2: Please, merge with squash
NOTE3: There is a unrelated issue after run the tests correctly: https://github.com/OCA/contract/issues/117