### PR TITLE
[10.0][FIX] contract: propagate contract reference to invoices

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Contracts Management - Recurring',
-    'version': '10.0.4.1.1',
+    'version': '10.0.4.1.2',
     'category': 'Contract Management',
     'license': 'AGPL-3',
     'author': "OpenERP SA, "

--- a/contract/models/account_analytic_account.py
+++ b/contract/models/account_analytic_account.py
@@ -232,14 +232,14 @@ class AccountAnalyticAccount(models.Model):
             self.company_id.currency_id
         )
         invoice = self.env['account.invoice'].new({
-            'reference': self.code,
+            'reference': self.name,
             'type': 'out_invoice',
             'partner_id': self.partner_id.address_get(
                 ['invoice'])['invoice'],
             'currency_id': currency.id,
             'journal_id': journal.id,
             'date_invoice': self.recurring_next_date,
-            'origin': self.name,
+            'origin': self.code,
             'company_id': self.company_id.id,
             'contract_id': self.id,
             'user_id': self.partner_id.user_id.id,


### PR DESCRIPTION
As It's done with sales and purchase orders, now contract's reference is propagated to invoices if is setted.

cc @Tecnativa