### PR TITLE
[11.0][FIX] Set encoding for *.py files

### DIFF
--- a/contract/__init__.py
+++ b/contract/__init__.py
@@ -1,1 +1,3 @@
+# -*- coding: utf-8 -*-
+
 from . import models

--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright 2004-2010 OpenERP SA
 # Copyright 2014-2017 Tecnativa - Pedro M. Baeza
 # Copyright 2015 Domatix

--- a/contract/models/__init__.py
+++ b/contract/models/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import account_analytic_contract

--- a/contract/models/account_analytic_account.py
+++ b/contract/models/account_analytic_account.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright 2004-2010 OpenERP SA
 # Copyright 2014 Angel Moya <angel.moya@domatix.com>
 # Copyright 2015 Pedro M. Baeza <pedro.baeza@tecnativa.com>

--- a/contract/models/account_analytic_contract.py
+++ b/contract/models/account_analytic_contract.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # © 2004-2010 OpenERP SA
 # © 2014 Angel Moya <angel.moya@domatix.com>
 # © 2015 Pedro M. Baeza <pedro.baeza@tecnativa.com>

--- a/contract/models/account_analytic_contract_line.py
+++ b/contract/models/account_analytic_contract_line.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright 2017 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/contract/models/account_analytic_invoice_line.py
+++ b/contract/models/account_analytic_invoice_line.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # © 2004-2010 OpenERP SA
 # © 2014 Angel Moya <angel.moya@domatix.com>
 # © 2015 Pedro M. Baeza <pedro.baeza@tecnativa.com>

--- a/contract/models/account_invoice.py
+++ b/contract/models/account_invoice.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # © 2016 Carlos Dauden <carlos.dauden@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/contract/models/res_partner.py
+++ b/contract/models/res_partner.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright 2017 Carlos Dauden <carlos.dauden@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/contract/tests/__init__.py
+++ b/contract/tests/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # © 2016 Carlos Dauden <carlos.dauden@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright 2016 Tecnativa - Carlos Dauden
 # Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).


### PR DESCRIPTION
In some python files copyright-sign is used, and if encodning is not set, module cannot be imported on some platforms.