### PR TITLE
[10.0][IMP] New module contract_line_extended.

### DIFF
--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -169,6 +169,8 @@ class TestContract(TestContractBase):
         journal.write({'type': 'general'})
         with self.assertRaises(ValidationError):
             contract_no_journal.recurring_create_invoice()
+        # Is the system not supposed to be back in orginal state after test?
+        journal.write({'type': 'sale'})
 
     def test_check_date_end(self):
         with self.assertRaises(ValidationError):

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -12,6 +12,23 @@ class TestContractBase(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super(TestContractBase, cls).setUpClass()
+        # Make sure a sale journal is present for tests
+        sequence_model = cls.env['ir.sequence']
+        contract_sequence = sequence_model.create({
+            'company_id': cls.env.user.company_id.id,
+            'code': 'contract',
+            'name': 'contract sequence',
+            'number_next': 1,
+            'implementation': 'standard',
+            'padding': 3,
+            'number_increment': 1})
+        journal_model = cls.env['account.journal']
+        journal_model.create({
+            'company_id': cls.env.user.company_id.id,
+            'code': 'contract',
+            'name': 'contract journal',
+            'sequence_id': contract_sequence.id,
+            'type': 'sale'})
         cls.partner = cls.env.ref('base.res_partner_2')
         cls.product = cls.env.ref('product.product_product_2')
         cls.product.taxes_id += cls.env['account.tax'].search(
@@ -169,8 +186,6 @@ class TestContract(TestContractBase):
         journal.write({'type': 'general'})
         with self.assertRaises(ValidationError):
             contract_no_journal.recurring_create_invoice()
-        # Is the system not supposed to be back in orginal state after test?
-        journal.write({'type': 'sale'})
 
     def test_check_date_end(self):
         with self.assertRaises(ValidationError):

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -285,10 +285,14 @@ class TestContract(TestContractBase):
         line = self._add_template_line()
         line.product_id.description_sale = 'Test'
         line._onchange_product_id()
-        self.assertEqual(line.name,
-                         '\n'.join([line.product_id.name,
-                                    line.product_id.description_sale,
-                                    ]))
+        # Make sure we use same language settings as in tested code: 
+        product = line.product_id.with_context(
+            lang=self.partner.lang,
+            partner=self.partner.id)
+        product_name = product.name_get()[0][1]
+        self.assertEqual(
+            line.name,
+            '\n'.join([product_name, line.product_id.description_sale]))
 
     def test_contract_count(self):
         """It should return contract count."""

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -9,6 +9,10 @@ from odoo.tests import common
 
 
 class TestContractBase(common.SavepointCase):
+
+    post_install = True
+    at_install = False
+
     @classmethod
     def setUpClass(cls):
         super(TestContractBase, cls).setUpClass()

--- a/contract_line_extended/README.rst
+++ b/contract_line_extended/README.rst
@@ -1,0 +1,65 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+======================
+Contract line extended
+======================
+
+Restores the link between account_analytic_invoice_line and
+account_analytic_account (overwritten by inherit in account.contract.line)
+and defines a number of related fields from account_analytic_account to
+make it easy to search/select contract lines on partner, or start/end date
+of the contract.
+
+Configuration
+=============
+
+There is no specific configuration for this module.
+
+Usage
+=====
+
+This module is a technical module, needed for modules that need to select
+contract lines by partner, or from other referential fields from the
+contract.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/110/10.0
+
+Known issues / Roadmap
+======================
+
+None.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/contract/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Ronald Portier <ronald@therp.nl>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/contract_line_extended/__init__.py
+++ b/contract_line_extended/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Therp BV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import models

--- a/contract_line_extended/__manifest__.py
+++ b/contract_line_extended/__manifest__.py
@@ -10,6 +10,7 @@
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/oca/contract',
     'depends': [
+        'base_active_date',
         'contract',
     ],
     'data': [

--- a/contract_line_extended/__manifest__.py
+++ b/contract_line_extended/__manifest__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Therp BV.
+# Copyright 2017-2018 Therp BV.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Contract Line Extended',
@@ -11,6 +11,9 @@
     'website': 'https://github.com/oca/contract',
     'depends': [
         'contract',
+    ],
+    'data': [
+        'views/account_analytic_account.xml',
     ],
     'installable': True,
 }

--- a/contract_line_extended/__manifest__.py
+++ b/contract_line_extended/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Therp BV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Contract Line Extended',
+    'version': '10.0.1.0.0',
+    'category': 'Contract Management',
+    'license': 'AGPL-3',
+    'author': "Therp BV, "
+              "Odoo Community Association (OCA)",
+    'website': 'https://github.com/oca/contract',
+    'depends': [
+        'contract',
+    ],
+    'installable': True,
+}

--- a/contract_line_extended/models/__init__.py
+++ b/contract_line_extended/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Therp BV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import account_analytic_invoice_line

--- a/contract_line_extended/models/__init__.py
+++ b/contract_line_extended/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Therp BV.
+# Copyright 2017-2018 Therp BV.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import account_analytic_invoice_line
+from . import account_analytic_account

--- a/contract_line_extended/models/account_analytic_account.py
+++ b/contract_line_extended/models/account_analytic_account.py
@@ -23,8 +23,8 @@ class AccountAnalyticAccount(models.Model):
         invoice_vals = self._prepare_invoice()
         invoice = self.env['account.invoice'].create(invoice_vals)
         for line in self.recurring_invoice_line_ids:
-            if line.date_start <= self.recurring_next_date and \
-                    line.date_end >= self.recurring_next_date:
+            if line.active_date_start <= self.recurring_next_date and \
+                    line.active_date_end >= self.recurring_next_date:
                 invoice_line_vals = self._prepare_invoice_line(
                     line, invoice.id)
                 self.env['account.invoice.line'].create(invoice_line_vals)

--- a/contract_line_extended/models/account_analytic_account.py
+++ b/contract_line_extended/models/account_analytic_account.py
@@ -36,7 +36,7 @@ class AccountAnalyticAccount(models.Model):
         """Keep lines within date limits of contract."""
         for this in self:
             for line in this.recurring_invoice_line_ids:
-                line._update_dates()
+                line._limit_dates()
 
     @api.model
     def create(self, vals):

--- a/contract_line_extended/models/account_analytic_account.py
+++ b/contract_line_extended/models/account_analytic_account.py
@@ -42,7 +42,7 @@ class AccountAnalyticAccount(models.Model):
     def create(self, vals):
         result = super(AccountAnalyticAccount, self).create(vals)
         if 'recurring_invoice_line_ids' in vals:
-            result.update_lines()
+            result._update_lines()
         return result
 
     @api.multi
@@ -51,5 +51,5 @@ class AccountAnalyticAccount(models.Model):
         # keep line date_start and date_end within contract limits:
         if 'date_start' in vals or 'date_end' in vals or \
                 'recurring_invoice_line_ids' in vals:
-            self.update_lines()
+            self._update_lines()
         return result

--- a/contract_line_extended/models/account_analytic_account.py
+++ b/contract_line_extended/models/account_analytic_account.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = 'account.analytic.account'
+
+    @api.multi
+    def _create_invoice(self):
+        """Fully override super method to only take into account current
+        lines.
+
+        FIXME: The whole invoice creation should really look at periods
+        already invoiced and periods still to be invoiced, combined with
+        pre or post payment. This would also allow partial invoicing if
+        an end or start date makes the contract period not a multiple
+        of the invoicing period. For instance a yearly contract is
+        cancelled during the year.
+        """
+        self.ensure_one()
+        invoice_vals = self._prepare_invoice()
+        invoice = self.env['account.invoice'].create(invoice_vals)
+        for line in self.recurring_invoice_line_ids:
+            if line.date_start <= self.recurring_next_date and \
+                    line.date_end >= self.recurring_next_date:
+                invoice_line_vals = self._prepare_invoice_line(
+                    line, invoice.id)
+                self.env['account.invoice.line'].create(invoice_line_vals)
+        invoice.compute_taxes()
+        return invoice
+
+    @api.multi
+    def _update_lines(self):
+        """Keep lines within date limits of contract."""
+        for this in self:
+            for line in this.recurring_invoice_line_ids:
+                line._update_dates()
+
+    @api.model
+    def create(self, vals):
+        result = super(AccountAnalyticAccount, self).create(vals)
+        if 'recurring_invoice_line_ids' in vals:
+            result.update_lines()
+        return result
+
+    @api.multi
+    def write(self, vals):
+        result = super(AccountAnalyticAccount, self).write(vals)
+        # keep line date_start and date_end within contract limits:
+        if 'date_start' in vals or 'date_end' in vals or \
+                'recurring_invoice_line_ids' in vals:
+            self.update_lines()
+        return result

--- a/contract_line_extended/models/account_analytic_account.py
+++ b/contract_line_extended/models/account_analytic_account.py
@@ -23,8 +23,7 @@ class AccountAnalyticAccount(models.Model):
         invoice_vals = self._prepare_invoice()
         invoice = self.env['account.invoice'].create(invoice_vals)
         for line in self.recurring_invoice_line_ids:
-            if line.active_date_start <= self.recurring_next_date and \
-                    line.active_date_end >= self.recurring_next_date:
+            if line.active:
                 invoice_line_vals = self._prepare_invoice_line(
                     line, invoice.id)
                 self.env['account.invoice.line'].create(invoice_line_vals)

--- a/contract_line_extended/models/account_analytic_account.py
+++ b/contract_line_extended/models/account_analytic_account.py
@@ -35,7 +35,7 @@ class AccountAnalyticAccount(models.Model):
         """Keep lines within date limits of contract."""
         for this in self:
             for line in this.recurring_invoice_line_ids:
-                line._limit_dates()
+                line._sync_with_contract()
 
     @api.model
     def create(self, vals):

--- a/contract_line_extended/models/account_analytic_invoice_line.py
+++ b/contract_line_extended/models/account_analytic_invoice_line.py
@@ -79,7 +79,7 @@ class AccountAnalyticInvoiceLine(models.Model):
         maintained and dates stay within limit of contract."""
         vals['contract_id'] = vals['analytic_account_id']
         result = super(AccountAnalyticInvoiceLine, self).create(vals)
-        new_line._limit_dates()
+        result._limit_dates()
         return result
 
     @api.multi

--- a/contract_line_extended/models/account_analytic_invoice_line.py
+++ b/contract_line_extended/models/account_analytic_invoice_line.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Therp BV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+SQL_SYNCHRONIZE1 = \
+    """UPDATE account_analytic_invoice_line
+ SET contract_id = analytic_account_id
+ WHERE contract_id IS NULL"""
+
+SQL_SYNCHRONIZE2 = \
+    """UPDATE account_analytic_invoice_line
+SET partner_id=subquery.partner_id,
+    date_start=subquery.date_start,
+    date_end=subquery.date_end
+ FROM (SELECT l.id, c.partner_id, c.date_start, c.date_end
+      FROM account_analytic_invoice_line l
+      JOIN account_analytic_account c
+      ON l.contract_id = c.id
+    WHERE (l.partner_id is NULL AND NOT c.partner_id IS NULL)
+    OR (l.date_start is NULL AND NOT c.date_start IS NULL)
+    OR (l.date_end is NULL AND NOT c.date_end IS NULL))
+ AS subquery
+ WHERE subquery.id = account_analytic_invoice_line.id"""
+
+
+class AccountAnalyticInvoiceLine(models.Model):
+    _inherit = 'account.analytic.invoice.line'
+
+    # We already had analytic_account_id to refer to the contract to which
+    # this line belongs. Unfortunately this is overwritten by
+    # account.analytic.contract.line which (ab)uses the same field to refer
+    # to the contract template.
+    contract_id = fields.Many2one(
+        comodel_name='account.analytic.account',
+        string='Contract',
+        readonly=True,
+        ondelete='cascade',
+        index=True,
+        store=True)
+    partner_id = fields.Many2one(
+        comodel_name='res.partner',
+        string='Partner',
+        readonly=True,
+        store=True,
+        related='contract_id.partner_id')
+    date_start = fields.Date(
+        string='Contract start date',
+        readonly=True,
+        store=True,
+        related='contract_id.date_start')
+    date_end = fields.Date(
+        string='Contract end date',
+        readonly=True,
+        store=True,
+        related='contract_id.date_end')
+
+    @api.model
+    def create(self, vals):
+        """Make sure link between contract lines and contract is
+        maintained."""
+        vals['contract_id'] = vals['analytic_account_id']
+        return super(AccountAnalyticInvoiceLine, self).create(vals)
+
+    @api.model_cr
+    def _register_hook(self):
+        """Update existing contract lines to restore link with contract."""
+        self.env.cr.execute(SQL_SYNCHRONIZE1)
+        self.env.cr.execute(SQL_SYNCHRONIZE2)

--- a/contract_line_extended/models/account_analytic_invoice_line.py
+++ b/contract_line_extended/models/account_analytic_invoice_line.py
@@ -72,6 +72,9 @@ class AccountAnalyticInvoiceLine(models.Model):
     def create(self, vals):
         """Make sure link between contract lines and contract is
         maintained and dates stay within limit of contract."""
+        if self._name != 'account.analytic.invoice.line':
+            # template contract line
+            return super(AccountAnalyticInvoiceLine, self).create(vals)
         vals['contract_id'] = vals['analytic_account_id']
         result = super(AccountAnalyticInvoiceLine, self).create(vals)
         result._limit_dates()
@@ -80,6 +83,9 @@ class AccountAnalyticInvoiceLine(models.Model):
     @api.multi
     def write(self, vals):
         """Keep line dates within contract dates on write."""
+        if self._name != 'account.analytic.invoice.line':
+            # template contract line
+            return super(AccountAnalyticInvoiceLine, self).write(vals)
         result = super(AccountAnalyticInvoiceLine, self).write(vals)
         self._limit_dates()
         return result

--- a/contract_line_extended/models/account_analytic_invoice_line.py
+++ b/contract_line_extended/models/account_analytic_invoice_line.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Therp BV.
+# Copyright 2017-2018 Therp BV.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
 
@@ -15,6 +15,8 @@ SET partner_id=subquery.partner_id,
     date_start=subquery.date_start,
     date_end=subquery.date_end
  FROM (SELECT l.id, c.partner_id, c.date_start, c.date_end
+        GREATEST(c.date_start, l.date_start) AS date_start,
+        LEAST(c.date_end, l.date_end) AS date_end
       FROM account_analytic_invoice_line l
       JOIN account_analytic_account c
       ON l.contract_id = c.id
@@ -45,23 +47,45 @@ class AccountAnalyticInvoiceLine(models.Model):
         readonly=True,
         store=True,
         related='contract_id.partner_id')
-    date_start = fields.Date(
-        string='Contract start date',
-        readonly=True,
-        store=True,
-        related='contract_id.date_start')
-    date_end = fields.Date(
-        string='Contract end date',
-        readonly=True,
-        store=True,
-        related='contract_id.date_end')
+    # date_start and date_end are normally the same as on the contract.
+    # However, making them not reference fields, but updating those if
+    # needed when the contract changes allows to update a contract by changing
+    # its lines.
+    date_start = fields.Date(string='Line start date')
+    date_end = fields.Date(string='Line end date')
+
+    @api.multi
+    def _limit_dates(self):
+        """Keep line dates within contract dates."""
+        for this in self:
+            contract = this.contract_id
+            line_vals = {}
+            if contract.date_start:
+                if (not this.date_start) or \
+                        this.date_start < contract.date_start:
+                    line_vals['date_start'] = contract.date_start
+            if contract.date_end:
+                if (not this.date_end) or \
+                        this.date_end > contract.date_end:
+                    line_vals['date_end'] = contract.date_end
+            if line_vals:
+                super(AccountAnalyticInvoiceLine, this).write(line_vals)
 
     @api.model
     def create(self, vals):
         """Make sure link between contract lines and contract is
-        maintained."""
+        maintained and dates stay within limit of contract."""
         vals['contract_id'] = vals['analytic_account_id']
-        return super(AccountAnalyticInvoiceLine, self).create(vals)
+        result = super(AccountAnalyticInvoiceLine, self).create(vals)
+        new_line._limit_dates()
+        return result
+
+    @api.multi
+    def write(self, vals):
+        """Keep line dates within contract dates on write."""
+        result = super(AccountAnalyticInvoiceLine, self).write(vals)
+        self._limit_dates()
+        return result
 
     @api.model_cr
     def _register_hook(self):

--- a/contract_line_extended/models/account_analytic_invoice_line.py
+++ b/contract_line_extended/models/account_analytic_invoice_line.py
@@ -14,7 +14,9 @@ SQL_SYNCHRONIZE2 = \
 SET partner_id=subquery.partner_id,
     date_start=subquery.date_start,
     date_end=subquery.date_end
- FROM (SELECT l.id, c.partner_id, c.date_start, c.date_end
+ FROM (SELECT
+        l.id,
+        c.partner_id,
         GREATEST(c.date_start, l.date_start) AS date_start,
         LEAST(c.date_end, l.date_end) AS date_end
       FROM account_analytic_invoice_line l

--- a/contract_line_extended/tests/__init__.py
+++ b/contract_line_extended/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Therp BV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import account_analytic_invoice_line

--- a/contract_line_extended/tests/account_analytic_invoice_line.py
+++ b/contract_line_extended/tests/account_analytic_invoice_line.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Therp BV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api
+from odoo.tests import common
+
+
+class TestContractLine(common.SavepointCase):
+
+    @api.multi
+    def test_contract_line(self):
+        partner = self.env.ref('base.res_partner_2')
+        product = self.env.ref('product.product_product_2')
+        template = self.env['account.analytic.contract'].create({
+            'name': 'Test Template',
+            'recurring_invoices': True,
+            'recurring_rule_type': 'yearly',
+            'recurring_interval': 1})
+        self.env['account.analytic.contract.line'].create({
+            'analytic_account_id': template.id,
+            'product_id': product.id,
+            'name': 'Template Line',
+            'quantity': 1,
+            'uom_id': product.uom_id.id,
+            'price_unit': 90})
+        contract = self.env['account.analytic.account'].create({
+            'name': 'Test Contract',
+            'contract_template_id': template.id,
+            'partner_id': partner.id,
+            'recurring_invoices': True,
+            'recurring_rule_type': 'yearly',
+            'recurring_interval': 1,
+            'date_start': '2016-02-15',
+            'recurring_next_date': '2016-02-29'})
+        contract_line = self.env['account.analytic.invoice.line'].create({
+            'analytic_account_id': contract.id,
+            'product_id': product.id,
+            'name': 'Services from #START# to #END#',
+            'quantity': 1,
+            'uom_id': product.uom_id.id,
+            'price_unit': 100})
+        self.assertEqual(contract_line.contract_id.id, contract.id)
+        self.assertEqual(contract_line.partner_id.id, contract.partner_id.id)
+        self.assertEqual(contract_line.date_start, contract.date_start)

--- a/contract_line_extended/views/account_analytic_account.xml
+++ b/contract_line_extended/views/account_analytic_account.xml
@@ -13,6 +13,7 @@
             <!-- Also show inactive contract lines -->
             <field name="recurring_invoice_line_ids" position="attributes">
                 <attribute name="context">{'active_test': False}</attribute>
+                <attribute name="domain">['|',('active','=',False)('active','=',True)]</attribute>
             </field>
             <!-- Next fields are added to contract line -->
             <field name="price_subtotal" position="after">

--- a/contract_line_extended/views/account_analytic_account.xml
+++ b/contract_line_extended/views/account_analytic_account.xml
@@ -10,6 +10,10 @@
             ref="contract.account_analytic_account_recurring_form_form"
             />
         <field name="arch" type="xml">
+            <!-- Also show inactive contract lines -->
+            <field name="recurring_invoice_line_ids" position="attributes">
+                <attribute name="context">{'active_test': False}</attribute>
+            </field>
             <!-- Next fields are added to contract line -->
             <field name="price_subtotal" position="after">
                 <field name="active_date_start"/>

--- a/contract_line_extended/views/account_analytic_account.xml
+++ b/contract_line_extended/views/account_analytic_account.xml
@@ -12,8 +12,8 @@
         <field name="arch" type="xml">
             <!-- Next fields are added to contract line -->
             <field name="price_subtotal" position="after">
-                <field name="date_start"/>
-                <field name="date_end"/>
+                <field name="active_date_start"/>
+                <field name="active_date_end"/>
             </field>
         </field>
     </record>

--- a/contract_line_extended/views/account_analytic_account.xml
+++ b/contract_line_extended/views/account_analytic_account.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record
+        id="account_analytic_account_recurring_form_form"
+        model="ir.ui.view"
+        >
+        <field name="model">account.analytic.account</field>
+        <field
+            name="inherit_id"
+            ref="contract.account_analytic_account_recurring_form_form"
+            />
+        <field name="arch" type="xml">
+            <!-- Next fields are added to contract line -->
+            <field name="price_subtotal" position="after">
+                <field name="date_start"/>
+                <field name="date_end"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Restores link between contract line (account.analytic.invoice.line) and contract
(account.analytic.account).
Also adds reference fields partner_id, date_start and date_end to contract line.