### PR TITLE
[FIX] contract_payment_auto: transaction create must always get a token

### DIFF
--- a/contract_payment_auto/__manifest__.py
+++ b/contract_payment_auto/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Contract - Auto Payment",
     "summary": "Adds automatic payments to contracts.",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Contract Management",
     "license": "AGPL-3",
     "author": "LasLabs, "

--- a/contract_payment_auto/models/account_analytic_account.py
+++ b/contract_payment_auto/models/account_analytic_account.py
@@ -91,7 +91,7 @@ class AccountAnalyticAccount(models.Model):
             return
 
         transaction = self.env['payment.transaction'].create(
-            self._get_tx_vals(invoice),
+            self._get_tx_vals(invoice, token),
         )
         valid_states = ['authorized', 'done']
 
@@ -136,10 +136,9 @@ class AccountAnalyticAccount(models.Model):
         return
 
     @api.multi
-    def _get_tx_vals(self, invoice):
+    def _get_tx_vals(self, invoice, token):
         """ Return values for create of payment.transaction for invoice."""
         amount_due = invoice.residual
-        token = self.payment_token_id
         partner = token.partner_id
         reference = self.env['payment.transaction'].get_next_reference(
             invoice.number,


### PR DESCRIPTION
When a contrat had no payment token but the corresponding partner had
one, the transaction was created without an acquirer, leading to an
integrity error in postgres.

This change makes sure the token used to test the ability to pay an
invoice is passed along to the transaction creation call.

Tests were also added to check the ability to use the contract token if
present, but the partner's in the opposite case.

This change fixes #165.