### PR TITLE
[IMP] contract,contract_payment_auto: do not rollback the whole trans…

### DIFF
--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -10,8 +10,7 @@ from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import common
 
-from odoo.addons.contract.models.account_analytic_account \
-    import _logger as aaa_logger
+from ..models.account_analytic_account import _logger as aaa_logger
 
 
 class TestContractBase(common.SavepointCase):

--- a/contract_payment_auto/models/account_analytic_account.py
+++ b/contract_payment_auto/models/account_analytic_account.py
@@ -3,7 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import logging
-import traceback
 
 from datetime import datetime, timedelta
 
@@ -53,13 +52,13 @@ class AccountAnalyticAccount(models.Model):
 
             with self.logged_exception_savepoint(error_msg_tmpl, invoice.id):
 
-                fail_time = fields.Datetime.from_string(invoice.auto_pay_failed)
+                fail_time = fields.Datetime.from_string(
+                    invoice.auto_pay_failed)
                 retry_delta = timedelta(hours=account.auto_pay_retry_hours)
                 retry_time = fail_time + retry_delta
 
                 if retry_time < now:
                     account._do_auto_pay(invoice)
-
 
     @api.multi
     def _create_invoice(self):


### PR DESCRIPTION
…action on recurring invoice creation and auto pay retry errors

Fixes #166.

Rather save the database state before each invoice creation (or auto pay
retry) so that only those in failure are rollbacked.

Before the change, the whole transaction was rollbacked on error
although the recurring invoice creations (resp. auto pay retries) are
independant operations.

This was leading to specially bad bugs when using an HTTP-driven service
for auto payments, as the service could register payments that odoo would
rollback on a later invoice creation crash in the same cron execution,
thus auto paying them again at next cron execution although they were
already registered as paid in the distant service.