### PR TITLE
[11.0][FIX] contract: Other field for contract then for invoice and total on account form

### DIFF
--- a/contract/README.rst
+++ b/contract/README.rst
@@ -107,6 +107,7 @@ Contributors
 * Dave Lasley <dave@laslabs.com>
 * Vicent Cubells <vicent.cubells@tecnativa.com>
 * Miquel Raïch <miquel.raich@eficent.com>
+* Dennis Sluijk <d.sluijk@onestein.nl>
 
 Maintainers
 ~~~~~~~~~~~

--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Contracts Management - Recurring',
-    'version': '11.0.4.0.0',
+    'version': '11.0.4.0.1',
     'category': 'Contract Management',
     'license': 'AGPL-3',
     'author': "OpenERP SA, "

--- a/contract/migrations/11.0.4.0.1/post-migration.py
+++ b/contract/migrations/11.0.4.0.1/post-migration.py
@@ -1,0 +1,8 @@
+# Copyright 2018 Onestein
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    """Copy the name to name_on_contract."""
+    cr.execute("""UPDATE account_analytic_contract_line 
+        SET name_on_contract = name""")

--- a/contract/migrations/11.0.4.0.1/post-migration.py
+++ b/contract/migrations/11.0.4.0.1/post-migration.py
@@ -4,5 +4,5 @@
 
 def migrate(cr, version):
     """Copy the name to name_on_contract."""
-    cr.execute("""UPDATE account_analytic_contract_line 
+    cr.execute("""UPDATE account_analytic_contract_line
         SET name_on_contract = name""")

--- a/contract/migrations/11.0.4.0.1/post-migration.py
+++ b/contract/migrations/11.0.4.0.1/post-migration.py
@@ -1,8 +1,0 @@
-# Copyright 2018 Onestein
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-
-def migrate(cr, version):
-    """Copy the name to name_on_contract."""
-    cr.execute("""UPDATE account_analytic_contract_line
-        SET name_on_contract = name""")

--- a/contract/models/account_analytic_account.py
+++ b/contract/models/account_analytic_account.py
@@ -28,6 +28,12 @@ class AccountAnalyticAccount(models.Model):
         inverse_name='analytic_account_id',
         copy=True,
     )
+    recurring_invoice_total = fields.Monetary(
+        string='Total',
+        store=True,
+        readonly=True,
+        compute='_compute_recurring_invoice_total'
+    )
     date_start = fields.Date(
         string='Date Start',
         default=fields.Date.context_today,
@@ -53,6 +59,14 @@ class AccountAnalyticAccount(models.Model):
     create_invoice_visibility = fields.Boolean(
         compute='_compute_create_invoice_visibility',
     )
+
+    @api.depends('recurring_invoice_line_ids',
+                 'recurring_invoice_line_ids.price_subtotal')
+    def _compute_recurring_invoice_total(self):
+        for account in self:
+            account.recurring_invoice_total = sum(
+                [l.price_subtotal for l in account.recurring_invoice_line_ids]
+            )
 
     @api.depends('recurring_next_date', 'date_end')
     def _compute_create_invoice_visibility(self):

--- a/contract/models/account_analytic_contract_line.py
+++ b/contract/models/account_analytic_contract_line.py
@@ -224,3 +224,10 @@ class AccountAnalyticContractLine(models.Model):
         vals['price_unit'] = product.price
         self.update(vals)
         return {'domain': domain}
+
+    @api.model
+    def create(self, vals):
+        if 'name_on_contract' not in vals or not vals['name_on_contract']:
+            vals['name_on_contract'] = vals['name']
+
+        return super(AccountAnalyticContractLine, self).create(vals)

--- a/contract/models/account_analytic_contract_line.py
+++ b/contract/models/account_analytic_contract_line.py
@@ -33,6 +33,10 @@ class AccountAnalyticContractLine(models.Model):
         string='Description',
         required=True,
     )
+    name_on_contract = fields.Text(
+        string='Description (on contract)',
+        required=True,
+    )
     quantity = fields.Float(
         default=1.0,
         required=True,
@@ -215,6 +219,7 @@ class AccountAnalyticContractLine(models.Model):
         if product.description_sale:
             name += '\n' + product.description_sale
         vals['name'] = name
+        vals['name_on_contract'] = name
 
         vals['price_unit'] = product.price
         self.update(vals)

--- a/contract/models/account_analytic_contract_line.py
+++ b/contract/models/account_analytic_contract_line.py
@@ -35,7 +35,6 @@ class AccountAnalyticContractLine(models.Model):
     )
     name_on_contract = fields.Text(
         string='Description (on contract)',
-        required=True,
     )
     quantity = fields.Float(
         default=1.0,

--- a/contract/readme/CONTRIBUTORS.rst
+++ b/contract/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * Dave Lasley <dave@laslabs.com>
 * Vicent Cubells <vicent.cubells@tecnativa.com>
 * Miquel Raïch <miquel.raich@eficent.com>
+* Dennis Sluijk <d.sluijk@onestein.nl>

--- a/contract/report/report_contract.xml
+++ b/contract/report/report_contract.xml
@@ -56,7 +56,7 @@
                                     <tr class="border-black">
                                         <td><strong>Total</strong></td>
                                         <td class="text-right">
-                                            <span t-esc="recurring_invoice_total" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                            <span t-esc="o.recurring_invoice_total" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                         </td>
                                     </tr>
                                 </table>

--- a/contract/report/report_contract.xml
+++ b/contract/report/report_contract.xml
@@ -22,9 +22,7 @@
                             </div>
                         </div>
                         <div class="row" id="invoice_info">
-                            <t t-set="total" t-value="0"/>
                             <div class="col-xs-12">
-                                <t t-set="total" t-value="0"/>
                                 <p id="services_info"><strong>Recurring Items</strong></p>
                                 <table class="table table-condensed">
                                     <thead>
@@ -49,7 +47,6 @@
                                             <td class="text-right">
                                                 <span t-field="l.price_subtotal" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                             </td>
-                                            <t t-set="total" t-value="total + l.price_subtotal"/>
                                         </tr>
                                     </tbody>
                                 </table>
@@ -59,7 +56,7 @@
                                     <tr class="border-black">
                                         <td><strong>Total</strong></td>
                                         <td class="text-right">
-                                            <span t-esc="total" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                            <span t-esc="recurring_invoice_total" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                         </td>
                                     </tr>
                                 </table>

--- a/contract/report/report_contract.xml
+++ b/contract/report/report_contract.xml
@@ -38,7 +38,7 @@
                                     <tbody>
                                         <tr t-foreach="o.recurring_invoice_line_ids" t-as="l">
                                             <td>
-                                                <span t-field="l.name"/>
+                                                <span t-field="l.name_on_contract"/>
                                             </td>
                                             <td class="text-right">
                                                 <span t-field="l.quantity"/>

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -24,13 +24,6 @@ class TestContractBase(common.SavepointCase):
         cls.template = cls.env['account.analytic.contract'].create(
             cls.template_vals,
         )
-        # For being sure of the applied price
-        cls.env['product.pricelist.item'].create({
-            'pricelist_id': cls.partner.property_product_pricelist.id,
-            'product_id': cls.product.id,
-            'compute_price': 'formula',
-            'base': 'list_price',
-        })
         cls.contract = cls.env['account.analytic.account'].create({
             'name': 'Test Contract',
             'partner_id': cls.partner.id,

--- a/contract/views/account_analytic_account_view.xml
+++ b/contract/views/account_analytic_account_view.xml
@@ -79,6 +79,7 @@
                             <field name="sequence" widget="handle" />
                             <field name="product_id"/>
                             <field name="name"/>
+                            <field name="name_on_contract" />
                             <field name="quantity"/>
                             <field name="uom_id"/>
                             <field name="automatic_price"/>

--- a/contract/views/account_analytic_account_view.xml
+++ b/contract/views/account_analytic_account_view.xml
@@ -90,6 +90,9 @@
                         </tree>
                     </field>
                 </div>
+                <group class="oe_subtotal_footer oe_right" attrs="{'invisible': [('recurring_invoices','!=',True)]}">
+                    <field name="recurring_invoice_total" class="oe_subtotal_footer_separator"/>
+                </group>
                 <group string="Legend (for the markers inside invoice lines description)"
                        name="group_legend" attrs="{'invisible': [('recurring_invoices','!=',True)]}">
                     <p colspan="2"> <strong>#START#</strong>: Start date of the invoiced period</p>

--- a/contract/views/account_analytic_account_view.xml
+++ b/contract/views/account_analytic_account_view.xml
@@ -79,7 +79,7 @@
                             <field name="sequence" widget="handle" />
                             <field name="product_id"/>
                             <field name="name"/>
-                            <field name="name_on_contract" />
+                            <field name="name_on_contract" required="1" />
                             <field name="quantity"/>
                             <field name="uom_id"/>
                             <field name="automatic_price"/>

--- a/contract/views/account_analytic_contract_view.xml
+++ b/contract/views/account_analytic_contract_view.xml
@@ -37,7 +37,7 @@
                             <field name="sequence" widget="handle" />
                             <field name="product_id" />
                             <field name="name" />
-                            <field name="name_on_contract" />
+                            <field name="name_on_contract" required="1" />
                             <field name="quantity" />
                             <field name="uom_id" />
                             <field name="automatic_price" attrs="{'column_invisible': [('parent.contract_type','=','purchase')]}"/>

--- a/contract/views/account_analytic_contract_view.xml
+++ b/contract/views/account_analytic_contract_view.xml
@@ -37,6 +37,7 @@
                             <field name="sequence" widget="handle" />
                             <field name="product_id" />
                             <field name="name" />
+                            <field name="name_on_contract" />
                             <field name="quantity" />
                             <field name="uom_id" />
                             <field name="automatic_price" attrs="{'column_invisible': [('parent.contract_type','=','purchase')]}"/>


### PR DESCRIPTION
Currently the name field is used for the invoice, and contract report. So if you use #START# and #END# to get the invoicing period on the invoice, it will be visible on the contract report too. So what you'll get is e.g. "Phone bill #START to #END".

This change adds a separate description field for the contract (name_on_contract).
It also adds the total of the contract on the form. This will come in handy when contracts have many lines.

![image](https://user-images.githubusercontent.com/10028499/50151134-49fffb80-02c0-11e9-9beb-3c26ecc2c80e.png)
