### PR TITLE
[IMP] allow content to include values from the agreement

### DIFF
--- a/agreement/models/agreement.py
+++ b/agreement/models/agreement.py
@@ -40,7 +40,8 @@ class Agreement(models.Model):
         track_visibility='onchange',
         help="Description of the agreement"
     )
-    dynamic_description = fields.Text(compute="_compute_dynamic_description",
+    dynamic_description = fields.Text(
+        compute="_compute_dynamic_description",
         string="Dynamic Description",
         help='compute dynamic description')
     start_date = fields.Date(
@@ -332,8 +333,8 @@ class Agreement(models.Model):
         MailTemplates = self.env['mail.template']
         for agreement in self:
             lang = agreement.partner_id.lang or 'en_US'
-            description = \
-            MailTemplates.with_context(lang=lang).render_template(
+            description = MailTemplates.with_context(
+                lang=lang).render_template(
                 agreement.description, 'agreement', agreement.id)
             agreement.dynamic_description = description
 

--- a/agreement/models/agreement.py
+++ b/agreement/models/agreement.py
@@ -40,6 +40,9 @@ class Agreement(models.Model):
         track_visibility='onchange',
         help="Description of the agreement"
     )
+    dynamic_description = fields.Text(compute="_compute_dynamic_description",
+        string="Dynamic Description",
+        help='compute dynamic description')
     start_date = fields.Date(
         string="Start Date",
         track_visibility='onchange',
@@ -323,12 +326,23 @@ class Agreement(models.Model):
         track_visibility='always'
     )
 
+    # compute the dynamic content for mako expression
+    @api.multi
+    def _compute_dynamic_description(self):
+        MailTemplates = self.env['mail.template']
+        for agreement in self:
+            lang = agreement.partner_id.lang or 'en_US'
+            description = \
+            MailTemplates.with_context(lang=lang).render_template(
+                agreement.description, 'agreement', agreement.id)
+            agreement.dynamic_description = description
+
     # compute contract_value field
     @api.depends('total_customer_mrc', 'total_customer_nrc', 'term')
     def _compute_contract_value(self):
         for record in self:
-            record.contract_value =\
-                (record.total_customer_mrc * record.term) +\
+            record.contract_value = \
+                (record.total_customer_mrc * record.term) + \
                 record.total_customer_nrc
 
     # compute total_company_mrc field

--- a/agreement/models/agreement_appendix.py
+++ b/agreement/models/agreement_appendix.py
@@ -15,7 +15,8 @@ class AgreementAppendix(models.Model):
                              "The name is not.")
     sequence = fields.Integer(string="Sequence", default=10)
     content = fields.Html(string="Content")
-    dynamic_content = fields.Html(compute="_compute_dynamic_content",
+    dynamic_content = fields.Html(
+        compute="_compute_dynamic_content",
         string="Dynamic Content",
         help='compute dynamic Content')
     agreement_id = fields.Many2one('agreement', string="Agreement",
@@ -33,7 +34,7 @@ class AgreementAppendix(models.Model):
         for appendix in self:
             lang = appendix.agreement_id and \
                 appendix.agreement_id.partner_id.lang or 'en_US'
-            content = \
-            MailTemplates.with_context(lang=lang).render_template(
+            content = MailTemplates.with_context(
+                lang=lang).render_template(
                 appendix.content, 'agreement.appendix', appendix.id)
             appendix.dynamic_content = content

--- a/agreement/models/agreement_appendix.py
+++ b/agreement/models/agreement_appendix.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 - TODAY, Pavlov Media
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AgreementAppendix(models.Model):
@@ -15,6 +15,9 @@ class AgreementAppendix(models.Model):
                              "The name is not.")
     sequence = fields.Integer(string="Sequence", default=10)
     content = fields.Html(string="Content")
+    dynamic_content = fields.Html(compute="_compute_dynamic_content",
+        string="Dynamic Content",
+        help='compute dynamic Content')
     agreement_id = fields.Many2one('agreement', string="Agreement",
                                    ondelete="cascade")
     active = fields.Boolean(
@@ -22,3 +25,15 @@ class AgreementAppendix(models.Model):
         default=True,
         help="If unchecked, it will allow you to hide this appendix without "
              "removing it.")
+
+    # compute the dynamic content for mako expression
+    @api.multi
+    def _compute_dynamic_content(self):
+        MailTemplates = self.env['mail.template']
+        for appendix in self:
+            lang = appendix.agreement_id and \
+                appendix.agreement_id.partner_id.lang or 'en_US'
+            content = \
+            MailTemplates.with_context(lang=lang).render_template(
+                appendix.content, 'agreement.appendix', appendix.id)
+            appendix.dynamic_content = content

--- a/agreement/models/agreement_clause.py
+++ b/agreement/models/agreement_clause.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 - TODAY, Pavlov Media
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AgreementClause(models.Model):
@@ -25,9 +25,24 @@ class AgreementClause(models.Model):
         ondelete="cascade"
     )
     content = fields.Html(string="Clause Content")
+    dynamic_content = fields.Html(compute="_compute_dynamic_content",
+        string="Dynamic Content",
+        help='compute dynamic Content')
     active = fields.Boolean(
         string="Active",
         default=True,
         help="If unchecked, it will allow you to hide the agreement without "
              "removing it."
     )
+
+    # compute the dynamic content for mako expression
+    @api.multi
+    def _compute_dynamic_content(self):
+        MailTemplates = self.env['mail.template']
+        for clause in self:
+            lang = clause.agreement_id and \
+                clause.agreement_id.partner_id.lang or 'en_US'
+            content = \
+            MailTemplates.with_context(lang=lang).render_template(
+                clause.content, 'agreement.clause', clause.id)
+            clause.dynamic_content = content

--- a/agreement/models/agreement_clause.py
+++ b/agreement/models/agreement_clause.py
@@ -25,7 +25,8 @@ class AgreementClause(models.Model):
         ondelete="cascade"
     )
     content = fields.Html(string="Clause Content")
-    dynamic_content = fields.Html(compute="_compute_dynamic_content",
+    dynamic_content = fields.Html(
+        compute="_compute_dynamic_content",
         string="Dynamic Content",
         help='compute dynamic Content')
     active = fields.Boolean(
@@ -42,7 +43,7 @@ class AgreementClause(models.Model):
         for clause in self:
             lang = clause.agreement_id and \
                 clause.agreement_id.partner_id.lang or 'en_US'
-            content = \
-            MailTemplates.with_context(lang=lang).render_template(
+            content = MailTemplates.with_context(
+                lang=lang).render_template(
                 clause.content, 'agreement.clause', clause.id)
             clause.dynamic_content = content

--- a/agreement/models/agreement_recital.py
+++ b/agreement/models/agreement_recital.py
@@ -15,7 +15,8 @@ class AgreementRecital(models.Model):
                              "The name is not.")
     sequence = fields.Integer(string="Sequence", default=10)
     content = fields.Html(string="Content")
-    dynamic_content = fields.Html(compute="_compute_dynamic_content",
+    dynamic_content = fields.Html(
+        compute="_compute_dynamic_content",
         string="Dynamic Content",
         help='compute dynamic Content')
     agreement_id = fields.Many2one('agreement', string="Agreement",
@@ -33,7 +34,7 @@ class AgreementRecital(models.Model):
         for recital in self:
             lang = recital.agreement_id and \
                 recital.agreement_id.partner_id.lang or 'en_US'
-            content = \
-            MailTemplates.with_context(lang=lang).render_template(
+            content = MailTemplates.with_context(
+                lang=lang).render_template(
                 recital.content, 'agreement.recital', recital.id)
             recital.dynamic_content = content

--- a/agreement/models/agreement_section.py
+++ b/agreement/models/agreement_section.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 - TODAY, Pavlov Media
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AgreementSection(models.Model):
@@ -25,9 +25,24 @@ class AgreementSection(models.Model):
         string="Clauses"
     )
     content = fields.Html(string="Section Content")
+    dynamic_content = fields.Html(compute="_compute_dynamic_content",
+        string="Dynamic Content",
+        help='compute dynamic Content')
     active = fields.Boolean(
         string="Active",
         default=True,
         help="If unchecked, it will allow you to hide the agreement without "
              "removing it."
     )
+
+    # compute the dynamic content for mako expression
+    @api.multi
+    def _compute_dynamic_content(self):
+        MailTemplates = self.env['mail.template']
+        for section in self:
+            lang = section.agreement_id and \
+                section.agreement_id.partner_id.lang or 'en_US'
+            content = \
+            MailTemplates.with_context(lang=lang).render_template(
+                section.content, 'agreement.section', section.id)
+            section.dynamic_content = content

--- a/agreement/models/agreement_section.py
+++ b/agreement/models/agreement_section.py
@@ -25,7 +25,8 @@ class AgreementSection(models.Model):
         string="Clauses"
     )
     content = fields.Html(string="Section Content")
-    dynamic_content = fields.Html(compute="_compute_dynamic_content",
+    dynamic_content = fields.Html(
+        compute="_compute_dynamic_content",
         string="Dynamic Content",
         help='compute dynamic Content')
     active = fields.Boolean(
@@ -42,7 +43,7 @@ class AgreementSection(models.Model):
         for section in self:
             lang = section.agreement_id and \
                 section.agreement_id.partner_id.lang or 'en_US'
-            content = \
-            MailTemplates.with_context(lang=lang).render_template(
+            content = MailTemplates.with_context(
+                lang=lang).render_template(
                 section.content, 'agreement.section', section.id)
             section.dynamic_content = content

--- a/agreement/readme/CONTRIBUTORS.rst
+++ b/agreement/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Bhavesh Odedra <bodedra@opensourceintegrators.com>
 * Wolfgang Hall <whall@opensourceintegrators.com>
 * Maxime Chambreuil <mchambreuil@opensourceintegrators.com>
+* Sandip Mangukiya <smangukiya@opensourceintegrators.com>

--- a/agreement/report/agreement.xml
+++ b/agreement/report/agreement.xml
@@ -25,7 +25,7 @@
                         <div class="page">
                             <h1 t-field="doc.name"/>
                             <div name="description">
-                                <p t-field="doc.description"/>
+                                <p t-field="doc.dynamic_description"/>
                             </div>
                             <h2>Parties</h2>
                             <h3>Company Information</h3>
@@ -55,7 +55,7 @@
                                                     <t t-if="r.title">
                                                         <h3 t-field="r.title"/>
                                                     </t>
-                                                    <p t-field="r.content"/>
+                                                    <p t-field="r.dynamic_content"/>
                                                 </li>
                                             </ol>
                                         </td>
@@ -71,13 +71,13 @@
                                                     <t t-if="s.title">
                                                         <h3 t-field="s.title"/>
                                                     </t>
-                                                    <p t-field="s.content"/>
+                                                    <p t-field="s.dynamic_content"/>
                                                     <ol>
                                                         <li t-foreach="s.clauses_ids" t-as="c">
                                                             <t t-if="c.title">
                                                                 <h4 t-field="c.title"/>
                                                             </t>
-                                                            <p t-field="c.content"/>
+                                                            <p t-field="c.dynamic_content"/>
                                                         </li>
                                                     </ol>
                                                 </li>
@@ -132,7 +132,7 @@
                             <div class="page">
                                 <h1 t-field="a.title"
                                     style="page-break-before: always;"/>
-                                <p t-field="a.content"/>
+                                <p t-field="a.dynamic_content"/>
                             </div>
                         </div>
                     </t>

--- a/agreement/views/agreement.xml
+++ b/agreement/views/agreement.xml
@@ -63,6 +63,13 @@
                                required="True"
                                nolabel="1"/>
                     </group>
+                    <div class="oe_edit_only">
+                        <p>
+                            For dynamic content use mako expression '${expression}'. For ex:
+                             1. object's field name: ${object.field_name} or
+                             2. many2one field name: ${object.many2one_field_id.field_name}
+                        </p>
+                    </div>
                     <group name="parties" string="Parties">
                         <group name="partner"
                                string="Partner">

--- a/agreement/views/agreement_appendix.xml
+++ b/agreement/views/agreement_appendix.xml
@@ -42,6 +42,13 @@
                         </group>
                     </group>
                     <field name="content" widget="html"/>
+                    <div class="oe_edit_only">
+                        <p>
+                            For dynamic content use mako expression '${expression}'. For ex:
+                             1. object's field name: ${object.field_name} or
+                             2. many2one field name: ${object.many2one_field_id.field_name}
+                        </p>
+                    </div>
                 </sheet>
             </form>
         </field>

--- a/agreement/views/agreement_clause.xml
+++ b/agreement/views/agreement_clause.xml
@@ -44,6 +44,13 @@
                         </group>
                     </group>
                     <field name="content" widget="html"/>
+                    <div class="oe_edit_only">
+                        <p>
+                            For dynamic content use mako expression '${expression}'. For ex:
+                             1. object's field name: ${object.field_name} or
+                             2. many2one field name: ${object.many2one_field_id.field_name}
+                        </p>
+                    </div>
                 </sheet>
             </form>
         </field>

--- a/agreement/views/agreement_recital.xml
+++ b/agreement/views/agreement_recital.xml
@@ -42,6 +42,13 @@
                         </group>
                     </group>
                     <field name="content" widget="html"/>
+                    <div class="oe_edit_only">
+                        <p>
+                            For dynamic content use mako expression '${expression}'. For ex:
+                             1. object's field name: ${object.field_name} or
+                             2. many2one field name: ${object.many2one_field_id.field_name}
+                        </p>
+                    </div>
                 </sheet>
             </form>
         </field>

--- a/agreement/views/agreement_section.xml
+++ b/agreement/views/agreement_section.xml
@@ -44,6 +44,13 @@
                     <notebook>
                         <page string="Content">
                             <field name='content' nolabel="1"/>
+                            <div class="oe_edit_only">
+                                <p>
+                                    For dynamic content use mako expression '${expression}'. For ex:
+                                     1. object's field name: ${object.field_name} or
+                                     2. many2one field name: ${object.many2one_field_id.field_name}
+                                </p>
+                            </div>
                         </page>
                         <page string="Clauses">
                             <field name="clauses_ids"

--- a/agreement/views/menu.xml
+++ b/agreement/views/menu.xml
@@ -124,6 +124,12 @@
             sequence="30"
             action="partner_agreement_action_renewaltype"/>
     <menuitem
+            name="Increase Types"
+            id="agreement_increamenttypes"
+            parent="agreement_configuration"
+            sequence="31"
+            action="partner_agreement_action_increasetype"/>
+    <menuitem
             name="Stages"
             id="agreement_stages"
             parent="agreement_configuration"


### PR DESCRIPTION
Ref: https://github.com/OCA/contract/issues/216
## agreement.recital
> Allow the content to include values from the agreement

## agreement.appendix
> Allow the content to include values from the agreement

## agreement.section
> Allow the content to include values from the agreement

## agreement.clause
> Allow the content to include values from the agreement

## agreement.recital
> Modify the pdf report to have:
> - the dynamic content replaced by the values of the agreement

- Add menu for "Increase Types" after Agreements>Configuration>Renewal Types