### PR TITLE
[10.0][IMP] contract: Performance boost 🚀 

### DIFF
--- a/contract/README.rst
+++ b/contract/README.rst
@@ -16,6 +16,25 @@ Configuration
 
 To view discount field set *Discount on lines* in user access rights.
 
+You might find that generating all pending invoices at once takes too much
+time and produces some performance problems, mostly in cases where you
+generate a lot of invoices in little time (i.e. when invoicing thousands
+of contracts yearly, and you get to January 1st of the next year). To avoid
+this bottleneck, the trick is to **increase the cron frequence and decrease
+the contracts batch size**. The counterpart is that some invoices could not
+be generated in the exact day you expected. To configure that:
+
+#. Go to *Settings > Activate the developer mode*.
+#. Go to *Settings > Technical > Automation > Scheduled Actions >
+   Generate Recurring Invoices from Contracts > Edit > Information*.
+#. Set a lower interval. For example, change *Interval Unit* to *Hours*.
+#. Go to the *Technical Data* tab, and add a batch size in *Arguments*.
+   For example, it should look like ``(20,)``.
+#. Save.
+
+That's it! From now on, only 20 invoices per hour will be generated.
+That should take only a few seconds each hour, and shouln't block other users.
+
 Usage
 =====
 


### PR DESCRIPTION
With this patch we save about 83% of the execution time when generating invoices in batch.

# Optimizations made

## Recompute once at the end of the batch

This part avoids recomputing many fields per record. Instead, global recomputations are triggered at the end of the block:

```python
with _self.env.norecompute():
    ...
    invoices.compute_taxes()
_self.recompute()
```

Notice the explicit call to `compute_taxes()`, which was explicit before also, but it was done once per invoice, losing batch-computing boost.

## Disabling prefetch for extra fields

It's done in this part:

```python
_self = self.with_context(prefetch_fields=False)
```

Prefetching makes sense when we are going to use a lot of fields for a model that has only a few.

In our case, we are using not much fields, but the models involved have lots of them.

This produces more queries to get those fields, but the queries are noticeably smaller. At the end of the day, it saves a lot of time, which is what matters.

## Disabling track mail creation

This part does it:

```diff
         ctx.update({
+            'mail_notrack': True,
             'next_date': next_date,
```

It makes that when creating invoices, we don't create the "Invoice created" message.

## Precomputing price

Obtaining `price_unit` from `contract.recurring_invoice_line_ids` was quite expenisve in terms of CPU, and it was being made once per line, each one in a different context, which means also a different cache.

Instead of that, lines now share a single context, and are computed before starting the batch.

This code precomputes stuff:

```python
# Precompute expensive computed fields in batch
recurring_lines = _self.mapped("recurring_invoice_line_ids")
recurring_lines._fields["price_unit"].determine_value(recurring_lines)
```

And the usage of 2 different environments done inside `_create_invoice()` (`self` and `_self`) guarantee that the invoices are filled with the correct data, but also that the lines use the cached precomputed value instead of having to compute it each time.

# Some fire :fire: 

Some comparisons to view execution complexity:

At the left, you have a batch of just 5 invoices generated, with latest code since #240 was merged. At the right, the new code, with a batch of 20 invoices. The part that appears in pink (and that is seen summarized in each picture's bottom-right corner) is whatever matches the search for: `_prefetch_field|compute_value|message_post`. Notice that the most pink part is at the beginning and the end of the batch (due to precomputing the expensive fields, and delaying recomputation of others to the end), to scale better. See:

| Before | After |
| --- | --- |
| ![captura de pantalla de 2019-01-24 13-46-08](https://user-images.githubusercontent.com/973709/51682143-8a991600-1fde-11e9-9331-774a9332aa20.png) | ![captura de pantalla de 2019-01-24 13-46-21](https://user-images.githubusercontent.com/973709/51682121-7bb26380-1fde-11e9-828b-ac6ef88bfdb5.png) |

Now, you can see the search for `execute`, which is the method that communicates with Postgres. Since most python code is optimized, now 71.4% of the time we are waiting for queries, instead of only the 1.8% as before. Most of the queries are under `_create_invoice` as you can see, so possibly we will be able to dramatically reduce that once we migrate to v12, where the creation queries can be sent in batch also (right now the framework simply doesn't let us do that):

| Before | After |
| --- | --- |
| ![captura de pantalla de 2019-01-24 13-43-51](https://user-images.githubusercontent.com/973709/51681997-2fffba00-1fde-11e9-9e0c-f045a86cece6.png) | ![captura de pantalla de 2019-01-24 13-44-01](https://user-images.githubusercontent.com/973709/51682010-35f59b00-1fde-11e9-95c6-ad9e7d26ff88.png) |

# Performance gain summary

According to my tests, **generating 10 invoices took 62 seconds before, and it takes about 18 seconds now**. The improvements are made to scale, so the more invoices involved, the better is the performance improvement.


@Tecnativa