### PR TITLE
[FIX] Adding arguments in the UI call of recurring_create_invoice

### DIFF
--- a/contract/views/account_analytic_account_view.xml
+++ b/contract/views/account_analytic_account_view.xml
@@ -33,6 +33,7 @@
                             string="Create invoices"
                             class="oe_link"
                             groups="base.group_no_one"
+                            args='0'
                             />
                     <button name="contract.act_recurring_invoices"
                             type="action"


### PR DESCRIPTION
Added parameter to UI call of `recurring_create_invoice` so that the arg `limit` doesn't get parsed as context.