### PR TITLE
[11.0][contract] fix errors in navigation to customer invoices / vendor bills

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Contracts Management - Recurring',
-    'version': '11.0.4.0.0',
+    'version': '11.0.4.1.0',
     'category': 'Contract Management',
     'license': 'AGPL-3',
     'author': "OpenERP SA, "

--- a/contract/models/account_analytic_account.py
+++ b/contract/models/account_analytic_account.py
@@ -354,3 +354,14 @@ class AccountAnalyticAccount(models.Model):
             'target': 'new',
             'context': ctx,
         }
+
+    @api.multi
+    def button_show_recurring_invoices(self):
+        self.ensure_one()
+        if self.contract_type == 'sale':
+            action = self.env.ref(
+                'contract.act_recurring_invoices')
+        else:
+            action = self.env.ref(
+                'contract.act_purchase_recurring_invoices')
+        return action.read()[0]

--- a/contract/views/account_analytic_account_view.xml
+++ b/contract/views/account_analytic_account_view.xml
@@ -35,8 +35,8 @@
                             groups="base.group_no_one"
                             args='0'
                             />
-                    <button name="contract.act_recurring_invoices"
-                            type="action"
+                    <button name="button_show_recurring_invoices"
+                            type="object"
                             attrs="{'invisible': [('recurring_invoices','!=',True)]}"
                             string="⇒ Show recurring invoices"
                             class="oe_link"
@@ -45,6 +45,7 @@
                 <group col="4" attrs="{'invisible': [('recurring_invoices','!=',True)]}">
                     <field name="contract_template_id" colspan="4" domain="['|', ('contract_type', '=', contract_type), ('contract_type', '=', False)]" context="{'default_contract_type': contract_type}"/>
                     <field name="journal_id"
+                           domain="[('type', '=', contract_type),('company_id', '=', company_id)]"
                            attrs="{'required': [('recurring_invoices', '=', True)]}"
                     />
                     <field name="pricelist_id"/>
@@ -112,7 +113,7 @@
                 <attribute name="context">{'default_customer': True, 'default_supplier': False}</attribute>
             </field>
             <field name="journal_id" position="attributes">
-                <attribute name="domain">[('type', '=', 'sale')]</attribute>
+                <attribute name="domain">[('type', '=', 'sale'),('company_id', '=', company_id)]</attribute>
             </field>
             <field name="product_id" position="attributes">
                 <attribute name="domain">[('sale_ok', '=', True)]</attribute>
@@ -133,7 +134,7 @@
                 <attribute name="context">{'default_customer': False, 'default_supplier': True}</attribute>
             </field>
             <field name="journal_id" position="attributes">
-                <attribute name="domain">[('type', '=', 'purchase')]</attribute>
+                <attribute name="domain">[('type', '=', 'purchase'),('company_id', '=', company_id)]</attribute>
             </field>
             <field name="product_id" position="attributes">
                 <attribute name="domain">[('purchase_ok', '=', True)]</attribute>

--- a/contract/views/account_invoice_view.xml
+++ b/contract/views/account_invoice_view.xml
@@ -24,6 +24,21 @@
             'search_default_contract_id': [active_id],
             'default_contract_id': active_id}
         </field>
+        <field name="domain">[('type','in', ['out_invoice', 'out_refund'])]</field>
+    </record>
+
+    <record id="act_purchase_recurring_invoices" model="ir.actions.act_window">
+        <field name="name">Vendor Bills</field>
+        <field name="res_model">account.invoice</field>
+        <field name="view_ids"
+               eval="[(5, 0, 0),
+                      (0, 0, {'view_mode': 'tree', 'view_id': ref('account.invoice_supplier_tree')}),
+                      (0, 0, {'view_mode': 'form', 'view_id': ref('account.invoice_supplier_form')})]"/>
+        <field name="context">{
+            'search_default_contract_id': [active_id],
+            'default_contract_id': active_id}
+        </field>
+        <field name="domain">[('type','in', ['in_invoice', 'in_refund'])]</field>
     </record>
 
 </odoo>

--- a/contract/views/res_partner_view.xml
+++ b/contract/views/res_partner_view.xml
@@ -9,12 +9,14 @@
         <field type="xml" name="arch">
         <xpath expr="//div[@name='button_box']" position="inside">
             <button name="act_show_contract" type="object" class="oe_stat_button"
-                    icon="fa-book" context="{'contract_type': 'sale'}"
+                    icon="fa-book" context="{'default_contract_type': 'sale', 'contract_type': 'sale'}"
+                    attrs="{'invisible': [('customer','=',False)]}"
                     help="Show the sale contracts for this partner">
                 <field name="sale_contract_count" widget="statinfo" string="Sale Contracts"/>
             </button>
             <button name="act_show_contract" type="object" class="oe_stat_button"
-                    icon="fa-book" context="{'contract_type': 'purchase'}"
+                    icon="fa-book" context="{'default_contract_type': 'purchase', 'contract_type': 'purchase'}"
+                    attrs="{'invisible': [('supplier','=',False)]}"
                     help="Show the purchase contracts for this partner">
                 <field name="purchase_contract_count" widget="statinfo" string="Purchase Contracts"/>
             </button>


### PR DESCRIPTION
This PR fixes:
-  When you navigate from the partner to Sale / Purchase contract, propose the correct default contract type.
- When are in a contract and press '=> Show recurring invoices' navigate to the correct customer invoice / vendor bill view, depending on the contract type.