### PR TITLE
[10.0][IMP] contract. Enable automatic invoice generation before invoice date.

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -5,7 +5,7 @@
 # Copyright 2016-2017 Tecnativa - Carlos Dauden
 # Copyright 2017 Tecnativa - Vicent Cubells
 # Copyright 2016-2017 LasLabs Inc.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     'name': 'Contracts Management - Recurring',
@@ -29,6 +29,7 @@
         'views/account_analytic_contract_view.xml',
         'views/account_invoice_view.xml',
         'views/res_partner_view.xml',
+        'views/res_company.xml',
     ],
     'installable': True,
 }

--- a/contract/models/__init__.py
+++ b/contract/models/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import account_analytic_contract
 from . import account_analytic_account
@@ -7,3 +7,4 @@ from . import account_analytic_contract_line
 from . import account_analytic_invoice_line
 from . import account_invoice
 from . import res_partner
+from . import res_company

--- a/contract/models/account_analytic_account.py
+++ b/contract/models/account_analytic_account.py
@@ -4,7 +4,7 @@
 # Copyright 2015 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2016-2017 Carlos Dauden <carlos.dauden@tecnativa.com>
 # Copyright 2016-2017 LasLabs Inc.
-# Copyright 2018 Therp BV <https://therp.nl>.
+# Copyright 2018-2019 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 # pylint: disable=no-member
 
@@ -14,6 +14,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools.translate import _
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 
 
 class AccountAnalyticAccount(models.Model):
@@ -353,8 +354,9 @@ class AccountAnalyticAccount(models.Model):
         company_model = self.env['res.company']
         for company in company_model.search([]):
             days_before = company.contract_pregenerate_days or 0
-            cutoffdate = (today + relativedelta(days=days_before)).strftime(
-                '%Y-%m-%d')
+            cutoffdate = (
+                today + relativedelta(days=days_before)
+            ).strftime(DEFAULT_SERVER_DATE_FORMAT)
             contracts = self.with_context(cron=True).search([
                 ('company_id', '=', company.id),
                 ('recurring_invoices', '=', True),

--- a/contract/models/res_company.py
+++ b/contract/models/res_company.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 - Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    contract_pregenerate_days = fields.Integer(
+        string='Days to prepare invoices',
+        help="Days before next invoice date to generate draft invoices.\n"
+             "This allows users to check the invoices before confirmation,\n"
+             " and to send invoices to customers, before the invoice date.")

--- a/contract/views/res_company.xml
+++ b/contract/views/res_company.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_company_form" model="ir.ui.view">
+        <field name="inherit_id" ref="base.view_company_form" />
+        <field name="model">res.company</field>
+        <field type="xml" name="arch">
+            <field name="currency_id" position="after">
+                <field name="contract_pregenerate_days" />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Implements the functional enhancement requested here: https://github.com/OCA/contract/issues/137

Per company it will be possible to specify how many days before the next invoice date the invoices for recurring contracts will be generated.