### PR TITLE
Decimal precision in Quantity of Contract Lines

### DIFF
--- a/contract/models/account_analytic_contract_line.py
+++ b/contract/models/account_analytic_contract_line.py
@@ -35,6 +35,7 @@ class AccountAnalyticContractLine(models.Model):
     )
     quantity = fields.Float(
         default=1.0,
+        digits=dp.get_precision('Product Unit of Measure'),
         required=True,
     )
     uom_id = fields.Many2one(


### PR DESCRIPTION
We need to define the decimal precision in `quantity` of Contract Lines as in the `price` attribute.

We expect the same behavior as in the invoice line `quantity`.

-----------------

I am not sure that this repository was the correct place to put this data, I found [the other same data in the Odoo code / OCB repository](
https://github.com/OCA/OCB/blob/11.0/addons/product/data/product_data.xml#L32), but I think that has more sense that the data was here if it is used in this module. If this reflexion is wrong, please tell me. Thanks!

