### PR TITLE
contract: Add "Generate before" (days) optional field

### DIFF
--- a/contract/models/account_analytic_account.py
+++ b/contract/models/account_analytic_account.py
@@ -253,7 +253,7 @@ class AccountAnalyticAccount(models.Model):
             'currency_id': currency.id,
             'journal_id': journal.id,
             'date_invoice': self.recurring_next_date
-                - date.timedelta(self.generate_before),
+            - date.timedelta(self.generate_before),
             'origin': self.name,
             'company_id': self.company_id.id,
             'contract_id': self.id,

--- a/contract/models/account_analytic_account.py
+++ b/contract/models/account_analytic_account.py
@@ -55,8 +55,8 @@ class AccountAnalyticAccount(models.Model):
         compute='_compute_create_invoice_visibility',
     )
     generate_before = fields.Integer(
-        string = "Generate before",
-        help = "Days before how many to generate invoice",
+        string="Generate before",
+        help="Days before how many to generate invoice",
     )
     generate_invoice_date = fields.Date(
         compute='_compute_generate_before_date',
@@ -68,7 +68,8 @@ class AccountAnalyticAccount(models.Model):
     @api.depends('recurring_next_date', 'generate_before')
     def _compute_generate_before_date(self):
         for contract in self:
-            contract.generate_invoice_date = contract.recurring_next_date - date.timedelta(contract.generate_before)
+            contract.generate_invoice_date = contract.recurring_next_date - \
+                date.timedelta(contract.generate_before)
 
     @api.depends('recurring_next_date', 'date_end')
     def _compute_create_invoice_visibility(self):
@@ -251,7 +252,8 @@ class AccountAnalyticAccount(models.Model):
                 ['invoice'])['invoice'],
             'currency_id': currency.id,
             'journal_id': journal.id,
-            'date_invoice': self.recurring_next_date - date.timedelta(self.generate_before),
+            'date_invoice': self.recurring_next_date
+                - date.timedelta(self.generate_before),
             'origin': self.name,
             'company_id': self.company_id.id,
             'contract_id': self.id,

--- a/contract/views/account_analytic_account_view.xml
+++ b/contract/views/account_analytic_account_view.xml
@@ -70,6 +70,7 @@
                     <field name="recurring_next_date"
                            attrs="{'required': [('recurring_invoices', '=', True)]}"
                     />
+                    <field name="generate_before"/>
                 </group>
                 <label for="recurring_invoice_line_ids"
                        attrs="{'invisible': [('recurring_invoices','=',False)]}"


### PR DESCRIPTION
It is sometimes required to be able to generate an invoice some amount of days before the actual date on the invoice itself. Before this PR, `contract` module doesn't allow this while auto-generating. 
This PR adds an optional integer field `generate_before` that is checked by the cron job, to allow this functionality.

![image](https://user-images.githubusercontent.com/17097810/64522257-43a82880-d302-11e9-9037-96cf732c278d.png)
