### PR TITLE
[11.0][FIX] contract. Prevent wrong contract count.

### DIFF
--- a/contract/models/res_partner.py
+++ b/contract/models/res_partner.py
@@ -18,10 +18,12 @@ class ResPartner(models.Model):
 
     def _compute_contract_count(self):
         contract_model = self.env['account.analytic.account']
-        today = fields.Date.today()
+        # localized date is also the default for date_start.
+        today = fields.Date.context_today(contract_model)
         fetch_data = contract_model.read_group([
             ('recurring_invoices', '=', True),
             ('partner_id', 'child_of', self.ids),
+            ('date_start', '<=', today),  # required for contracts
             '|',
             ('date_end', '=', False),
             ('date_end', '>=', today)],


### PR DESCRIPTION
This is a cherry-pick of a merged fix for 10.0. However some of the logic in contract counts changed (now separate accounts for purchase and sale contracts). In this change I think the start_date was accidentally admitted from the domain. I put it back.

Contract count could be wrong if the current date for the user is not the
UTC date.

So a contract created in for instance the Amsterdam timezone just after
midnight, would get maybe the 16th of july as date_start. but
_compute_contract_count would look for contracts valid on the 15th of july.