### PR TITLE
[IMP] move some notions from agreement_legal to agreement

### DIFF
--- a/agreement/__manifest__.py
+++ b/agreement/__manifest__.py
@@ -16,6 +16,7 @@
         'security/ir.model.access.csv',
         'security/agreement_security.xml',
         'views/agreement.xml',
+        'views/agreement_type.xml',
         ],
     'demo': ['demo/demo.xml'],
     'development_status': 'Beta',

--- a/agreement/models/__init__.py
+++ b/agreement/models/__init__.py
@@ -1,1 +1,2 @@
 from . import agreement
+from . import agreement_type

--- a/agreement/models/agreement.py
+++ b/agreement/models/agreement.py
@@ -12,11 +12,23 @@ class Agreement(models.Model):
     code = fields.Char(required=True, copy=False)
     name = fields.Char(required=True)
     partner_id = fields.Many2one(
-        'res.partner', string='Partner', ondelete='restrict', required=True,
+        'res.partner', string='Partner', ondelete='restrict',
         domain=[('parent_id', '=', False)])
     company_id = fields.Many2one(
         'res.company', string='Company',
         default=lambda self: self.env['res.company']._company_default_get())
+    is_template = fields.Boolean(
+        string="Is a Template?",
+        default=False,
+        copy=False,
+        help="Set if the agreement is a template. "
+        "Template agreements don't require a partner."
+    )
+    agreement_type_id = fields.Many2one(
+        'agreement.type',
+        string="Agreement Type",
+        help="Select the type of agreement",
+    )
     active = fields.Boolean(default=True)
     signature_date = fields.Date()
     start_date = fields.Date()

--- a/agreement/models/agreement_type.py
+++ b/agreement/models/agreement_type.py
@@ -5,11 +5,8 @@ from odoo import fields, models
 
 
 class AgreementType(models.Model):
-    _inherit = "agreement.type"
+    _name = "agreement.type"
     _description = "Agreement Types"
 
-    agreement_subtypes_ids = fields.One2many(
-        "agreement.subtype",
-        "agreement_type_id",
-        string="Subtypes"
-    )
+    name = fields.Char(string="Name", required=True)
+    active = fields.Boolean(default=True)

--- a/agreement/readme/CONTRIBUTORS.rst
+++ b/agreement/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Alexis de Lattre <alexis.delattre@akretion.com>
 * Yves Goldberg <yves@ygol.com>
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>

--- a/agreement/readme/DESCRIPTION.rst
+++ b/agreement/readme/DESCRIPTION.rst
@@ -6,3 +6,9 @@ This module adds an *Agreement* object with the following properties:
 * signature date.
 * start date.
 * end date.
+
+Optionally, you can also enable using:
+* agreement types
+* a flag to set an agreement as a template agreement
+
+(Install agreement_sale to get the configuration settings for these).

--- a/agreement/security/agreement_security.xml
+++ b/agreement/security/agreement_security.xml
@@ -13,5 +13,14 @@
     <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
 </record>
 
+<record id="group_use_agreement_type" model="res.groups">
+    <field name="name">Use agreement type</field>
+    <field name="category_id" ref="base.module_category_hidden"/>
+</record>
+
+<record id="group_use_agreement_template" model="res.groups">
+    <field name="name">Use agreement template</field>
+    <field name="category_id" ref="base.module_category_hidden"/>
+</record>
 
 </odoo>

--- a/agreement/views/agreement.xml
+++ b/agreement/views/agreement.xml
@@ -21,7 +21,11 @@
             </div>
             <group name="main">
                 <group name="left">
-                    <field name="partner_id"/>
+                    <field name="agreement_type_id"
+                           groups="agreement.group_use_agreement_type"/>
+                    <field name="is_template" groups="agreement.group_use_agreement_template"/>
+                    <field name="partner_id"
+                           attrs="{'required': [('is_template', '=', False)]}"/>
                     <field name="name"/>
                     <field name="signature_date"/>
                 </group>

--- a/agreement/views/agreement_type.xml
+++ b/agreement/views/agreement_type.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Agreement Type List View-->
+    <record model="ir.ui.view" id="agreement_type_list_view">
+        <field name="name">Agreement Type List</field>
+        <field name="model">agreement.type</field>
+        <field name="arch" type="xml">
+            <tree string="Agreement Types" default_order="name">
+                <field name="name" string="Type Name"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Agreement Type Form View -->
+    <record model="ir.ui.view" id="agreement_type_form_view">
+        <field name="name">Agreement Type Form</field>
+        <field name="model">agreement.type</field>
+        <field name="arch" type="xml">
+            <form string="Agreement Type">
+                <div class="oe_button_box" name="button_box">
+                    <button name="toggle_active" type="object"
+                            class="oe_stat_button" icon="fa-archive">
+                        <field name="active" widget="boolean_button"
+                               options='{"terminology": "archive"}'/>
+                    </button>
+                </div>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name" class="oe_edit_only"/>
+                        <h1><field name="name"/></h1>
+                    </div>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="agreement_type_search" model="ir.ui.view">
+        <field name="name">agreement.type.search</field>
+        <field name="model">agreement.type</field>
+        <field name="arch" type="xml">
+            <search string="Agreement Type">
+                <field name="name"/>
+                <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+            </search>
+        </field>
+    </record>
+
+    <!-- Actions opening views on models -->
+    <record model="ir.actions.act_window" id="agreement_type_action">
+        <field name="name">Agreement Types</field>
+        <field name="res_model">agreement.type</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -10,11 +10,6 @@ class Agreement(models.Model):
 
     # General
     name = fields.Char(string="Title", required=True)
-    is_template = fields.Boolean(
-        string="Is a Template?",
-        default=False,
-        copy=False,
-        help="Make this agreement a template.")
     version = fields.Integer(
         string="Version",
         default=1,
@@ -170,10 +165,8 @@ class Agreement(models.Model):
         string="Dynamic Parties",
         help="Compute dynamic parties")
     agreement_type_id = fields.Many2one(
-        "agreement.type",
-        string="Agreement Type",
         track_visibility="onchange",
-        help="Select the type of agreement.")
+    )
     agreement_subtype_id = fields.Many2one(
         "agreement.subtype",
         string="Agreement Sub-type",

--- a/agreement_legal/security/res_groups.xml
+++ b/agreement_legal/security/res_groups.xml
@@ -9,7 +9,7 @@
     <record id="group_agreement_readonly" model="res.groups">
         <field name="name">Read-Only Users</field>
         <field name="category_id" ref="module_agreement_legal_category"/>
-        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+        <field name="implied_ids" eval="[(4, ref('base.group_user')), (4, ref('agreement.group_use_agreement_type')), (4, ref('agreement.group_use_agreement_template'))]"/>
     </record>
 
     <!-- User group -->

--- a/agreement_legal/views/agreement_type.xml
+++ b/agreement_legal/views/agreement_type.xml
@@ -5,33 +5,28 @@
     <record model="ir.ui.view" id="partner_agreement_type_list_view">
         <field name="name">Agreement Type List</field>
         <field name="model">agreement.type</field>
+        <field name="inherit_id" ref="agreement.agreement_type_list_view"/>
         <field name="arch" type="xml">
-            <tree string="Agreement Types" default_order='name'>
-                <field name="name" string="Type Name"/>
+            <field name="name" position="after">
                 <field name="agreement_subtypes_ids" string="Sub-Types"/>
-            </tree>
-        </field>
+            </field>
+       </field>
     </record>
 
     <!-- Agreement Type Form View -->
     <record model="ir.ui.view" id="partner_agreement_type_form_view">
         <field name="name">Agreement Type Form</field>
         <field name="model">agreement.type</field>
+        <field name="inherit_id" ref="agreement.agreement_type_form_view"/>
         <field name="arch" type="xml">
-            <form string="Agreement Type">
-                <sheet>
-                    <div class="oe_title">
-                        <label for="name" class="oe_edit_only"/>
-                        <h1><field name="name"/></h1>
-                    </div>
-                    <field name="agreement_subtypes_ids"
-                           nolabel="1">
-                        <tree editable="bottom">
-                            <field name="name"/>
-                        </tree>
-                    </field>
-                </sheet>
-            </form>
+            <xpath expr="//sheet" position="inside">
+                <field name="agreement_subtypes_ids"
+                       nolabel="1">
+                    <tree editable="bottom">
+                        <field name="name"/>
+                    </tree>
+                </field>
+            </xpath>
         </field>
     </record>
 

--- a/agreement_legal_sale/views/sale_order.xml
+++ b/agreement_legal_sale/views/sale_order.xml
@@ -7,12 +7,11 @@
     <record id="sale_order_agreement_form_view" model="ir.ui.view">
         <field name="name">sale.order.agreement.form.view</field>
         <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="inherit_id" ref="agreement_sale.sale_order_agreement_form_view"/>
         <field name="arch" type="xml">
-            <field name="client_order_ref" position="after">
-                <field name="agreement_id"
-                       readonly="1"
-                       attrs="{'invisible': [('agreement_id', '=', False)]}"/>
+            <field name="agreement_id" position="attributes">
+                <attribute name="readonly" eval='1'/>
+                <attribute name="attrs">{'invisible': [('agreement_id', '=', False)]}</attribute>
             </field>
             <field name="partner_id" position="after">
                 <field name="agreement_template_id"/>

--- a/agreement_sale/__manifest__.py
+++ b/agreement_sale/__manifest__.py
@@ -17,6 +17,8 @@
     'data': [
         'security/ir.model.access.csv',
         'views/agreement.xml',
+        'views/sale_order.xml',
+        'views/res_config_settings.xml',
         ],
     'development_status': 'Beta',
     'maintainers': [

--- a/agreement_sale/models/__init__.py
+++ b/agreement_sale/models/__init__.py
@@ -1,1 +1,2 @@
 from . import sale
+from . import res_config_settings

--- a/agreement_sale/models/res_config_settings.py
+++ b/agreement_sale/models/res_config_settings.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    group_use_agreement_type = fields.Boolean(
+        'Use agreement types',
+        implied_group='agreement.group_use_agreement_type'
+    )
+    group_use_agreement_template = fields.Boolean(
+        'Use agreement template',
+        implied_group='agreement.group_use_agreement_template'
+    )

--- a/agreement_sale/models/sale.py
+++ b/agreement_sale/models/sale.py
@@ -12,3 +12,9 @@ class SaleOrder(models.Model):
         comodel_name='agreement', string='Agreement', ondelete='restrict',
         track_visibility='onchange', readonly=True, copy=False,
         states={'draft': [('readonly', False)], 'sent': [('readonly', False)]})
+
+    agreement_type_id = fields.Many2one(
+        comodel_name="agreement.type", string="Agreement Type",
+        ondelete="restrict",
+        track_visibility='onchange', readonly=True, copy=True,
+        states={'draft': [('readonly', False)], 'sent': [('readonly', False)]})

--- a/agreement_sale/security/ir.model.access.csv
+++ b/agreement_sale/security/ir.model.access.csv
@@ -1,2 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 agreement.access_agreement_full,Full access on agreement grp,agreement.model_agreement,sales_team.group_sale_manager,1,1,1,1
+agreement_sale.access_agreement_type_full,Full access on agreement type grp,agreement.model_agreement_type,sales_team.group_sale_manager,1,1,1,1
+agreement_sale.access_agreement_type_read,Read access on agreement grp,agreement.model_agreement_type,base.group_user,1,0,0,0

--- a/agreement_sale/views/agreement.xml
+++ b/agreement_sale/views/agreement.xml
@@ -2,7 +2,9 @@
 
 <odoo>
 
-    <menuitem id="agreement.agreement_menu" action="agreement.agreement_action" 
+    <menuitem id="agreement.agreement_menu" action="agreement.agreement_action"
               parent="sale.menu_sale_config" sequence="100"/>
+    <menuitem id="agreement.agreement_type_menu" action="agreement.agreement_type_action"
+              parent="sale.menu_sale_config" sequence="101" groups="agreement.group_use_agreement_type"/>
 
 </odoo>

--- a/agreement_sale/views/res_config_settings.xml
+++ b/agreement_sale/views/res_config_settings.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.agreement</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="11"/>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='sale_management']" position="inside">
+                <h2>Agreements</h2>
+                <div class="row mt16 o_settings_container">
+                    <div id="sales_settings_agreement_type_group"
+                         class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="group_use_agreement_type"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="group_use_agreement_type"/>
+                            <div class="text-muted">
+                                Manage agreements by types
+                            </div>
+                            <div class="content-group" attrs="{'invisible': [('group_use_agreement_type','=',False)]}">
+                                <div class="mt16">
+                                    <button name="%(agreement.agreement_type_action)d" icon="fa-arrow-right" type="action" string="Agreement types" class="btn-link"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-6 o_setting_box"
+                         id="sales_settings_agreement_template_group">
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="group_use_agreement_template"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="group_use_agreement_template"/>
+                                <div class="text-muted">
+                                    Have a special kind of agreements which act as templates
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/agreement_sale/views/sale_order.xml
+++ b/agreement_sale/views/sale_order.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sale_order_agreement_form_view" model="ir.ui.view">
+        <field name="name">sale.order.agreement.form.view</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <field name="client_order_ref" position="after">
+                <field name="agreement_id"/>
+            </field>
+            <field name="partner_id" position="after">
+                <field name="agreement_type_id"
+                       groups="agreement.group_use_agreement_type"
+                       />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
we move the `is_template` field definition and the `agreement.type` model from
the `agreement_legal` module to the `agreement` module.

The fields are not displayed by default, unless the feature is enabled through a
technical feature group, this is configurable in the `agreement_sale` module (because agreement
in itself has no UI, and `agreement_legal` enables the feature by default)

Closes: #382 