### PR TITLE
[12.0][FIX] contract & contract_sale - security fix

### DIFF
--- a/contract/views/res_partner_view.xml
+++ b/contract/views/res_partner_view.xml
@@ -6,6 +6,7 @@
     <record id="view_partner_form" model="ir.ui.view">
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="model">res.partner</field>
+        <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
         <field type="xml" name="arch">
         <xpath expr="//div[@name='button_box']" position="inside">
             <button name="act_show_contract" type="object" class="oe_stat_button"

--- a/contract_sale/__manifest__.py
+++ b/contract_sale/__manifest__.py
@@ -19,6 +19,7 @@
         'views/contract.xml',
         'views/contract_line.xml',
         'views/contract_template.xml',
+        'views/res_partner_view.xml',
     ],
     'license': 'AGPL-3',
     'installable': True,

--- a/contract_sale/views/res_partner_view.xml
+++ b/contract_sale/views/res_partner_view.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="contract.view_partner_form" model="ir.ui.view">
+        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The lowest model access for contract.contract model is group_account_invoice group. However the addon adds two smart buttons to res.partner view without any security restrictions and without compute_sudo attribute on computed fields.
This causes the view to crash when a user without the proper permissions tries to access the res.partner form view.
The solution adds groups_id to the partner form views in which the buttons are added, so the only loads when the user has proper permissions.
Other way to solve it would be to add compute_sudo attribute to the relevant fields, but this causes an access error when the user clicks on the smart buttons.