### PR TITLE
[12.0][FIX] contract_sale_invoicing fix moved field account_analytic_id

### DIFF
--- a/contract_sale_invoicing/models/contract.py
+++ b/contract_sale_invoicing/models/contract.py
@@ -19,7 +19,7 @@ class ContractContract(models.Model):
         if not self.invoicing_sales:
             return invoices
         sales = self.env['sale.order'].search([
-            ('analytic_account_id', '=', self.analytic_account_id.id),
+            ('analytic_account_id', '=', self.group_id.id),
             ('partner_invoice_id', 'child_of',
              self.partner_id.commercial_partner_id.ids),
             ('invoice_status', '=', 'to invoice'),

--- a/contract_sale_invoicing/tests/test_contract_sale_invoicing.py
+++ b/contract_sale_invoicing/tests/test_contract_sale_invoicing.py
@@ -8,7 +8,7 @@ class TestContractSaleInvoicing(TestContractBase):
     @classmethod
     def setUpClass(cls):
         super(TestContractSaleInvoicing, cls).setUpClass()
-        cls.contract.analytic_account_id = \
+        cls.contract.group_id = \
             cls.env['account.analytic.account'].search([], limit=1)
         cls.product_so = cls.env.ref(
             'product.product_product_1')
@@ -23,7 +23,7 @@ class TestContractSaleInvoicing(TestContractBase):
                                    'product_uom': cls.product_so.uom_id.id,
                                    'price_unit': cls.product_so.list_price})],
             'pricelist_id': cls.partner.property_product_pricelist.id,
-            'analytic_account_id': cls.contract.analytic_account_id.id,
+            'analytic_account_id': cls.contract.group_id.id,
             'date_order': '2016-02-15',
         })
 


### PR DESCRIPTION
Since that commit : https://github.com/OCA/contract/blob/09d860ba178b61f27d540d1b4f6de808b43fa151/contract/models/contract.py, field account_analytic_id has been moved to group_id.