### PR TITLE
[12.0][FIX] - contract_mandate: fix inherited method call _prepare_invoice

### DIFF
--- a/contract_mandate/models/contract.py
+++ b/contract_mandate/models/contract.py
@@ -34,7 +34,7 @@ class ContractContract(models.Model):
     @api.multi
     def _prepare_invoice(self, date_invoice, journal=None):
         invoice_vals = super(ContractContract, self)._prepare_invoice(
-            date_invoice, journal
+            date_invoice, journal=journal
         )
         if self.mandate_id:
             invoice_vals['mandate_id'] = self.mandate_id.id

--- a/contract_mandate/models/contract.py
+++ b/contract_mandate/models/contract.py
@@ -32,8 +32,10 @@ class ContractContract(models.Model):
             self.mandate_id = False
 
     @api.multi
-    def _prepare_invoice(self, date_ref=False):
-        invoice_vals = super(ContractContract, self)._prepare_invoice(date_ref)
+    def _prepare_invoice(self, date_invoice, journal=None):
+        invoice_vals = super(ContractContract, self)._prepare_invoice(
+            date_invoice, journal
+        )
         if self.mandate_id:
             invoice_vals['mandate_id'] = self.mandate_id.id
         elif self.payment_mode_id.payment_method_id.mandate_required:


### PR DESCRIPTION
there is an inconsistency between the inherited method and base one

look [here](https://github.com/OCA/contract/blob/12.0/contract/models/contract.py#L256)