### PR TITLE
[12.0][FIX] - When creating a contract from a sale order, contract company must be the same as the sale order

### DIFF
--- a/contract/models/abstract_contract.py
+++ b/contract/models/abstract_contract.py
@@ -14,7 +14,7 @@ class ContractAbstractContract(models.AbstractModel):
     _description = 'Abstract Recurring Contract'
 
     # These fields will not be synced to the contract
-    NO_SYNC = ['name', 'partner_id']
+    NO_SYNC = ['name', 'partner_id', 'company_id']
 
     name = fields.Char(required=True)
     # Needed for avoiding errors on several inherited behaviors

--- a/product_contract/models/sale_order.py
+++ b/product_contract/models/sale_order.py
@@ -46,6 +46,7 @@ class SaleOrder(models.Model):
                 template_name=contract_template.name, sale_name=self.name
             ),
             'partner_id': self.partner_id.id,
+            'company_id': self.company_id.id,
             'contract_template_id': contract_template.id,
             'user_id': self.user_id.id,
             'payment_term_id': self.payment_term_id.id,

--- a/product_contract/tests/test_sale_order.py
+++ b/product_contract/tests/test_sale_order.py
@@ -110,6 +110,19 @@ class TestSaleOrder(TransactionCase):
             contract_line.recurring_next_date, Date.to_date('2018-01-31')
         )
 
+    def test_contract_company(self):
+        """
+        contract company must be the sale order company and not the user one
+        """
+        self.assertTrue(self.sale.company_id)
+        other_company = self.env['res.company'].create(
+            {'name': 'other company', 'parent_id': self.sale.company_id.id}
+        )
+        self.sale.company_id = other_company
+        self.sale.action_confirm()
+        contracts = self.sale.order_line.mapped('contract_id')
+        self.assertEqual(contracts.mapped('company_id'), other_company)
+
     def test_sale_order_invoice_status(self):
         """
         sale line linked to contracts must not be invoiced from sale order


### PR DESCRIPTION
When creating a contract from a sale order the company must be the sale order
company and not the user company