### PR TITLE
[FIX] contract_variable_quantity: Allow to propagate variable qty fields from template

### DIFF
--- a/contract_variable_quantity/__manifest__.py
+++ b/contract_variable_quantity/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Tecnativa - Pedro M. Baeza
+# Copyright 2016-2019 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Tecnativa - Carlos Dauden
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -16,6 +16,7 @@
         'security/ir.model.access.csv',
         'views/abstract_contract_line.xml',
         'views/contract_line_formula.xml',
+        'views/contract_line_views.xml',
         'views/contract_template.xml',
         'views/contract.xml',
     ],

--- a/contract_variable_quantity/views/contract_line_views.xml
+++ b/contract_variable_quantity/views/contract_line_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="contract_line_tree_view" model="ir.ui.view">
+        <field name="name">contract.line tree view (in contract) - Add variable qty fields</field>
+        <field name="model">contract.line</field>
+        <field name="inherit_id" ref="contract.contract_line_tree_view"/>
+        <field name="arch" type="xml">
+            <field name="quantity" position="before">
+                <field name="qty_type"/>
+                <field
+                    name="qty_formula_id"
+                    attrs="{'invisible': [('qty_type', '!=', 'variable')]}"
+                />
+            </field>
+            <field name="quantity" position="attributes">
+                <attribute name="attrs">{'invisible': [('qty_type', '!=', 'fixed')]}</attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
**Steps to reproduce the problem**

- Define a contract template with one line with variable quantity and formula.
- Use that template in a new contract.
- Variable quantity type and formula are not transferred from template to contract.

This is due to the lack of that fields in the tree view that prevents web client to fetch and store them.

We solve it adding those fields to the contract line tree view, also providing some visibility logic for not showing the corresponding fields according the type.

No regression test is provided, as this is only reproducible with web client, not through code.

cc @Tecnativa TT19260