### PR TITLE
[12.0][FIX] - Run onchange contract_type when changing the contract template

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -209,7 +209,8 @@ class ContractContract(models.Model):
                     field.name in self.NO_SYNC,
                 )
             ):
-                self[field_name] = self.contract_template_id[field_name]
+                if self.contract_template_id[field_name]:
+                    self[field_name] = self.contract_template_id[field_name]
 
     @api.onchange('partner_id')
     def _onchange_partner_id(self):

--- a/product_contract/models/sale_order.py
+++ b/product_contract/models/sale_order.py
@@ -82,6 +82,7 @@ class SaleOrder(models.Model):
                 )
                 contracts |= contract
                 contract._onchange_contract_template_id()
+                contract._onchange_contract_type()
                 order_lines.create_contract_line(contract)
                 order_lines.write({'contract_id': contract.id})
             for line in line_to_update_contract:


### PR DESCRIPTION
Fix this use-case:

If the contract journal is not set on the contract template the contract is created
without a journal when confirming the sale order