### PR TITLE
[fix_migration_script_contract_module]-Move all account_analytic_acco…

### DIFF
--- a/contract/migrations/12.0.4.0.0/pre-migration.py
+++ b/contract/migrations/12.0.4.0.0/pre-migration.py
@@ -96,7 +96,7 @@ def create_contract_records(cr):
         cr, sql.SQL("""
         INSERT INTO contract_contract
         SELECT * FROM account_analytic_account
-        WHERE id IN (SELECT DISTINCT {} FROM contract_line)
+        WHERE id IN (SELECT DISTINCT {} FROM contract_line UNION SELECT contract_id FROM account_invoice)
         """).format(
             sql.Identifier(contract_field_name),
         ),


### PR DESCRIPTION
Currently, Migration script doesn't take into account the contract(`contract_id`) on invoice which don't have any  `account.analytic.invoice.line` line.