### PR TITLE
[12.0][IMP] - Contract: Add a new field to compute the next period end date

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Recurring - Contracts Management',
-    'version': '12.0.4.2.5',
+    'version': '12.0.5.0.0',
     'category': 'Contract Management',
     'license': 'AGPL-3',
     'author': "OpenERP SA, "

--- a/contract/migrations/12.0.5.0.0/post-migration.py
+++ b/contract/migrations/12.0.5.0.0/post-migration.py
@@ -1,0 +1,29 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+from dateutil.relativedelta import relativedelta
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Init next_period_end_date field")
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        cl_model = env['contract.line']
+        contract_lines = cl_model.search([])
+        for cl in contract_lines:
+            if cl.date_end and cl.last_date_invoiced == cl.date_end:
+                continue  # Finished lines
+            next_period_start_date = (
+                cl.last_date_invoiced + relativedelta(days=1)
+                if cl.last_date_invoiced
+                else cl.date_start
+            )
+            cl.next_period_end_date = cl_model._get_next_period_end_date(
+                next_period_start_date,
+                cl.recurring_rule_type,
+                cl.recurring_interval,
+            )

--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -15,14 +15,15 @@
                 <group>
                     <field name="create_invoice_visibility" invisible="1"/>
                     <field name="date_start" required="1"/>
+                    <field name="last_date_invoiced" readonly="True"/>
                     <field name="recurring_next_date"/>
                 </group>
                 <group>
                     <field name="date_end"
                            attrs="{'required': [('is_auto_renew', '=', True)]}"/>
+                    <field name="next_period_end_date"/>
                 </group>
                 <group groups="base.group_no_one">
-                    <field name="last_date_invoiced" readonly="True"/>
                     <field name="termination_notice_date" readonly="True"/>
                 </group>
                 <group>

--- a/contract_mandate/tests/test_contract_mandate.py
+++ b/contract_mandate/tests/test_contract_mandate.py
@@ -40,6 +40,7 @@ class TestContractMandate(TestContractBase):
                 'mandate_id': cls.mandate.id,
             }
         )
+        cls.contract_with_mandate.contract_line_ids._onchange_date_start()
 
     def test_contract_mandate(self):
         new_invoice = self.contract_with_mandate.recurring_create_invoice()

--- a/contract_payment_mode/tests/test_contract_payment.py
+++ b/contract_payment_mode/tests/test_contract_payment.py
@@ -82,6 +82,7 @@ class TestContractPaymentInit(odoo.tests.HttpCase):
                 'is_auto_renew': False,
             })]
         })
+        self.contract.contract_line_ids._onchange_date_start()
         self.contract.recurring_create_invoice()
         new_invoice = self.contract._get_related_invoices()
         self.assertTrue(new_invoice)

--- a/contract_variable_qty_timesheet/tests/test_contract_variable_qty_timesheet.py
+++ b/contract_variable_qty_timesheet/tests/test_contract_variable_qty_timesheet.py
@@ -35,6 +35,7 @@ class TestContractVariableQtyTimesheet(common.SavepointCase):
         }
         cls.contract_line = cls.env['contract.line'].create(
             contract_line_vals)
+        cls.contract_line._onchange_date_start()
         cls.project = cls.env['project.project'].create({
             'name': 'Test project',
             'analytic_account_id': cls.analytic_account.id,

--- a/contract_variable_quantity/tests/test_contract_variable_quantity.py
+++ b/contract_variable_quantity/tests/test_contract_variable_quantity.py
@@ -56,6 +56,7 @@ class TestContractVariableQuantity(odoo.tests.HttpCase):
                 'recurring_next_date': '2016-02-29',
             }
         )
+        self.contract_line._onchange_date_start()
 
     def test_check_invalid_code(self):
         with self.assertRaises(exceptions.ValidationError):

--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -108,7 +108,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         recurring_next_date = self.env[
             'contract.line'
-        ]._compute_first_recurring_next_date(
+        ]._get_recurring_next_date(
             self.date_start or fields.Date.today(),
             self.recurring_invoicing_type,
             self.recurring_rule_type,


### PR DESCRIPTION
An alternative solution for #428 is to make the invoicing period independent from the invoice date. Original idea of @pedrobaeza ([see](https://github.com/OCA/contract/issues/426#issuecomment-558668082))

This PR add a new filed to store the next period end date. With the field `last_date_invoiced` the user can easily see and change the invoicing period.

A migration script was added to initialize the new field.

What we can add to this PR:
-  add an integer field offset to shift the invoice date 
-  make the next invoice date a computed field based on
    -  invoicing_type: pre-paid/post-paid
    -  first and last period dates
    -  offset field
- make the `monthlylastday`  a check box to be used to compute the next invoice date

CC/ @pedrobaeza , @sbidoul , @gva-acsone, @carlosdauden 