### PR TITLE
[12.0] contract: some refactoring and a UX improvement

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -4,7 +4,7 @@
 # Copyright 2016-2018 Tecnativa - Carlos Dauden
 # Copyright 2017 Tecnativa - Vicent Cubells
 # Copyright 2016-2017 LasLabs Inc.
-# Copyright 2018 ACSONE SA/NV
+# Copyright 2018-2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/contract/migrations/12.0.5.0.0/pre-migration.py
+++ b/contract/migrations/12.0.5.0.0/pre-migration.py
@@ -1,0 +1,10 @@
+def migrate(cr, version):
+    # pre-paid/post-paid becomes significant for monthlylastday too,
+    # make sure it has the value that was implied for previous versions.
+    cr.execute(
+        """\
+            UPDATE contract_line
+            SET recurring_invoicing_type = 'post-paid'
+            WHERE recurring_rule_type = 'monthlylastday'
+        """
+    )

--- a/contract/models/abstract_contract_line.py
+++ b/contract/models/abstract_contract_line.py
@@ -81,7 +81,7 @@ class ContractAbstractContractLine(models.AbstractModel):
         string="Invoicing offset",
         help=(
             "Number of days to offset the invoice from the period end "
-            "date (in post-paid mode) or beginning date (in pre-paid mode)."
+            "date (in post-paid mode) or start date (in pre-paid mode)."
         )
     )
     recurring_interval = fields.Integer(

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -664,7 +664,7 @@ class ContractLine(models.Model):
         self.ensure_one()
         first_date_invoiced = False
         if not recurring_next_date:
-            return first_date_invoiced, last_date_invoiced, recurring_next_date
+            return first_date_invoiced, False, recurring_next_date
         first_date_invoiced = (
             last_date_invoiced + relativedelta(days=1)
             if last_date_invoiced

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -479,6 +479,7 @@ class ContractLine(models.Model):
         'recurring_rule_type',
         'recurring_interval',
         'date_end',
+        'recurring_next_date',
     )
     def _compute_next_period_date_end(self):
         for rec in self:

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -356,7 +356,7 @@ class ContractLine(models.Model):
                     )
 
     @api.model
-    def _compute_first_recurring_next_date(
+    def _get_recurring_next_date(
         self,
         date_start,
         recurring_invoicing_type,
@@ -374,7 +374,7 @@ class ContractLine(models.Model):
         )
 
     @api.model
-    def compute_first_date_end(
+    def _get_first_date_end(
         self, date_start, auto_renew_rule_type, auto_renew_interval
     ):
         return (
@@ -396,7 +396,7 @@ class ContractLine(models.Model):
         auto_renew"""
         for rec in self.filtered('is_auto_renew'):
             if rec.date_start:
-                rec.date_end = self.compute_first_date_end(
+                rec.date_end = self._get_first_date_end(
                     rec.date_start,
                     rec.auto_renew_rule_type,
                     rec.auto_renew_interval,
@@ -410,7 +410,7 @@ class ContractLine(models.Model):
     )
     def _onchange_date_start(self):
         for rec in self.filtered('date_start'):
-            rec.recurring_next_date = self._compute_first_recurring_next_date(
+            rec.recurring_next_date = self._get_recurring_next_date(
                 rec.date_start,
                 rec.recurring_invoicing_type,
                 rec.recurring_rule_type,
@@ -651,7 +651,7 @@ class ContractLine(models.Model):
                     )
                 )
             new_date_start = rec.date_start + delay_delta
-            rec.recurring_next_date = self._compute_first_recurring_next_date(
+            rec.recurring_next_date = self._get_recurring_next_date(
                 new_date_start,
                 rec.recurring_invoicing_type,
                 rec.recurring_rule_type,
@@ -712,7 +712,7 @@ class ContractLine(models.Model):
     ):
         self.ensure_one()
         if not recurring_next_date:
-            recurring_next_date = self._compute_first_recurring_next_date(
+            recurring_next_date = self._get_recurring_next_date(
                 date_start,
                 self.recurring_invoicing_type,
                 self.recurring_rule_type,
@@ -1023,7 +1023,7 @@ class ContractLine(models.Model):
     def _get_renewal_dates(self):
         self.ensure_one()
         date_start = self.date_end + relativedelta(days=1)
-        date_end = self.compute_first_date_end(
+        date_end = self._get_first_date_end(
             date_start, self.auto_renew_rule_type, self.auto_renew_interval
         )
         return date_start, date_end

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -364,6 +364,23 @@ class ContractLine(models.Model):
                     )
 
     @api.model
+    def _compute_first_recurring_next_date(
+        self,
+        date_start,
+        recurring_invoicing_type,
+        recurring_rule_type,
+        recurring_interval
+    ):
+        # deprecated method for backward compatibility
+        return self._get_recurring_next_date(
+            date_start,
+            recurring_invoicing_type,
+            recurring_rule_type,
+            recurring_interval,
+            max_date_end=False,
+        )
+
+    @api.model
     def _get_recurring_next_date(
         self,
         next_period_date_start,

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -667,9 +667,8 @@ class ContractLine(models.Model):
         # TODO this method can now be removed, since
         # TODO self.next_period_date_start/end have the same values
         self.ensure_one()
-        first_date_invoiced = False
         if not recurring_next_date:
-            return first_date_invoiced, False, recurring_next_date
+            return False, False, False
         first_date_invoiced = (
             last_date_invoiced + relativedelta(days=1)
             if last_date_invoiced

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -372,7 +372,7 @@ class ContractLine(models.Model):
         recurring_interval
     ):
         # deprecated method for backward compatibility
-        return self._get_recurring_next_date(
+        return self.get_next_invoice_date(
             date_start,
             recurring_invoicing_type,
             self._get_default_recurring_invoicing_offset(
@@ -384,7 +384,7 @@ class ContractLine(models.Model):
         )
 
     @api.model
-    def _get_recurring_next_date(
+    def get_next_invoice_date(
         self,
         next_period_date_start,
         recurring_invoicing_type,
@@ -539,7 +539,7 @@ class ContractLine(models.Model):
     )
     def _onchange_date_start(self):
         for rec in self.filtered('date_start'):
-            rec.recurring_next_date = self._get_recurring_next_date(
+            rec.recurring_next_date = self.get_next_invoice_date(
                 rec.date_start,
                 rec.recurring_invoicing_type,
                 rec.recurring_invoicing_offset,
@@ -705,7 +705,7 @@ class ContractLine(models.Model):
     def _update_recurring_next_date(self):
         for rec in self:
             last_date_invoiced = rec.next_period_date_end
-            recurring_next_date = rec._get_recurring_next_date(
+            recurring_next_date = rec.get_next_invoice_date(
                 last_date_invoiced + relativedelta(days=1),
                 rec.recurring_invoicing_type,
                 rec.recurring_invoicing_offset,
@@ -782,7 +782,7 @@ class ContractLine(models.Model):
                 new_date_end = rec.date_end + delay_delta
             else:
                 new_date_end = False
-            new_recurring_next_date = self._get_recurring_next_date(
+            new_recurring_next_date = self.get_next_invoice_date(
                 new_date_start,
                 rec.recurring_invoicing_type,
                 rec.recurring_invoicing_offset,
@@ -847,7 +847,7 @@ class ContractLine(models.Model):
     ):
         self.ensure_one()
         if not recurring_next_date:
-            recurring_next_date = self._get_recurring_next_date(
+            recurring_next_date = self.get_next_invoice_date(
                 date_start,
                 self.recurring_invoicing_type,
                 self.recurring_invoicing_offset,

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -614,12 +614,17 @@ class TestContract(TestContractBase):
                  False),
             ),
             (
-                to_date('2018-01-31'),
+                to_date('2018-01-06'),
                 (to_date('2018-01-06'), 'pre-paid', 'monthlylastday', 1,
                  False),
             ),
             (
                 to_date('2018-02-28'),
+                (to_date('2018-01-05'), 'post-paid', 'monthlylastday', 2,
+                 False),
+            ),
+            (
+                to_date('2018-01-05'),
                 (to_date('2018-01-05'), 'pre-paid', 'monthlylastday', 2,
                  False),
             ),
@@ -1363,9 +1368,40 @@ class TestContract(TestContractBase):
             len(invoice_lines),
         )
 
-    def test_get_period_to_invoice_monthlylastday(self):
+    def test_get_period_to_invoice_monthlylastday_postpaid(self):
         self.acct_line.date_start = '2018-01-05'
         self.acct_line.recurring_invoicing_type = 'post-paid'
+        self.acct_line.recurring_rule_type = 'monthlylastday'
+        self.acct_line.date_end = '2018-03-15'
+        self.acct_line._onchange_date_start()
+        first, last, recurring_next_date = \
+            self.acct_line._get_period_to_invoice(
+                self.acct_line.last_date_invoiced,
+                self.acct_line.recurring_next_date,
+            )
+        self.assertEqual(first, to_date('2018-01-05'))
+        self.assertEqual(last, to_date('2018-01-31'))
+        self.contract.recurring_create_invoice()
+        first, last, recurring_next_date = \
+            self.acct_line._get_period_to_invoice(
+                self.acct_line.last_date_invoiced,
+                self.acct_line.recurring_next_date,
+            )
+        self.assertEqual(first, to_date('2018-02-01'))
+        self.assertEqual(last, to_date('2018-02-28'))
+        self.contract.recurring_create_invoice()
+        first, last, recurring_next_date = \
+            self.acct_line._get_period_to_invoice(
+                self.acct_line.last_date_invoiced,
+                self.acct_line.recurring_next_date,
+            )
+        self.assertEqual(first, to_date('2018-03-01'))
+        self.assertEqual(last, to_date('2018-03-15'))
+        self.acct_line.manual_renew_needed = True
+
+    def test_get_period_to_invoice_monthlylastday_prepaid(self):
+        self.acct_line.date_start = '2018-01-05'
+        self.acct_line.recurring_invoicing_type = 'pre-paid'
         self.acct_line.recurring_rule_type = 'monthlylastday'
         self.acct_line.date_end = '2018-03-15'
         self.acct_line._onchange_date_start()

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -2,6 +2,7 @@
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from collections import namedtuple
 from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 from odoo import fields
@@ -679,6 +680,316 @@ class TestContract(TestContractBase):
                     *combination
                 ),
                 error_message(*combination),
+            )
+
+    def test_next_invoicing_period(self):
+        """Test different combination for next invoicing period
+        {
+            (
+                'recurring_next_date',    # date
+                'next_period_date_start', # date
+                'next_period_date_end'    # date
+                ): (
+                date_start,               # date
+                date_end,                 # date
+                last_date_invoiced,       # date
+                recurring_next_date,      # date
+                recurring_invoicing_type, # ('pre-paid','post-paid',)
+                recurring_rule_type,      # ('daily', 'weekly', 'monthly',
+                                          #  'monthlylastday', 'yearly'),
+                recurring_interval,       # integer
+                max_date_end,             # date
+            ),
+        }
+        """
+
+        def _update_contract_line(
+            case,
+            date_start,
+            date_end,
+            last_date_invoiced,
+            recurring_next_date,
+            recurring_invoicing_type,
+            recurring_rule_type,
+            recurring_interval,
+            max_date_end,
+        ):
+            self.acct_line.write(
+                {
+                    'date_start': date_start,
+                    'date_end': date_end,
+                    'last_date_invoiced': last_date_invoiced,
+                    'recurring_next_date': recurring_next_date,
+                    'recurring_invoicing_type': recurring_invoicing_type,
+                    'recurring_rule_type': recurring_rule_type,
+                    'recurring_interval': recurring_interval,
+                    'max_date_end': max_date_end,
+                }
+            )
+
+        def _get_result():
+            return Result(
+                recurring_next_date=self.acct_line.recurring_next_date,
+                next_period_date_start=self.acct_line.next_period_date_start,
+                next_period_date_end=self.acct_line.next_period_date_end,
+            )
+
+        def _error_message(
+            case,
+            date_start,
+            date_end,
+            last_date_invoiced,
+            recurring_next_date,
+            recurring_invoicing_type,
+            recurring_rule_type,
+            recurring_interval,
+            max_date_end,
+        ):
+            return (
+                "Error in case %s:"
+                "date_start: %s, "
+                "date_end: %s, "
+                "last_date_invoiced: %s, "
+                "recurring_next_date: %s, "
+                "recurring_invoicing_type: %s, "
+                "recurring_rule_type: %s, "
+                "recurring_interval: %s, "
+                "max_date_end: %s, "
+            ) % (
+                case,
+                date_start,
+                date_end,
+                last_date_invoiced,
+                recurring_next_date,
+                recurring_invoicing_type,
+                recurring_rule_type,
+                recurring_interval,
+                max_date_end,
+            )
+
+        Result = namedtuple(
+            'Result',
+            [
+                'recurring_next_date',
+                'next_period_date_start',
+                'next_period_date_end',
+            ],
+        )
+        Combination = namedtuple(
+            'Combination',
+            [
+                'case',
+                'date_start',
+                'date_end',
+                'last_date_invoiced',
+                'recurring_next_date',
+                'recurring_invoicing_type',
+                'recurring_rule_type',
+                'recurring_interval',
+                'max_date_end',
+            ],
+        )
+        combinations = {
+            Result(
+                recurring_next_date=to_date('2019-01-01'),
+                next_period_date_start=to_date('2019-01-01'),
+                next_period_date_end=to_date('2019-01-31'),
+            ): Combination(
+                case="1",
+                date_start='2019-01-01',
+                date_end=False,
+                last_date_invoiced=False,
+                recurring_next_date='2019-01-01',
+                recurring_invoicing_type='pre-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2019-01-01'),
+                next_period_date_start=to_date('2019-01-01'),
+                next_period_date_end=to_date('2019-01-15'),
+            ): Combination(
+                case="2",
+                date_start='2019-01-01',
+                date_end='2019-01-15',
+                last_date_invoiced=False,
+                recurring_next_date='2019-01-01',
+                recurring_invoicing_type='pre-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2019-01-05'),
+                next_period_date_start=to_date('2019-01-05'),
+                next_period_date_end=to_date('2019-01-15'),
+            ): Combination(
+                case="3",
+                date_start='2019-01-05',
+                date_end='2019-01-15',
+                last_date_invoiced=False,
+                recurring_next_date='2019-01-05',
+                recurring_invoicing_type='pre-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2019-01-05'),
+                next_period_date_start=to_date('2019-01-01'),
+                next_period_date_end=to_date('2019-01-15'),
+            ): Combination(
+                case="4",
+                date_start='2019-01-01',
+                date_end='2019-01-15',
+                last_date_invoiced=False,
+                recurring_next_date='2019-01-05',
+                recurring_invoicing_type='pre-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2019-02-01'),
+                next_period_date_start=to_date('2019-01-01'),
+                next_period_date_end=to_date('2019-01-31'),
+            ): Combination(
+                case="5",
+                date_start='2019-01-01',
+                date_end=False,
+                last_date_invoiced=False,
+                recurring_next_date='2019-02-01',
+                recurring_invoicing_type='post-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2019-02-01'),
+                next_period_date_start=to_date('2019-01-01'),
+                next_period_date_end=to_date('2019-01-15'),
+            ): Combination(
+                case="6",
+                date_start='2019-01-01',
+                date_end='2019-01-15',
+                last_date_invoiced=False,
+                recurring_next_date='2019-02-01',
+                recurring_invoicing_type='post-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2019-02-01'),
+                next_period_date_start=to_date('2019-01-05'),
+                next_period_date_end=to_date('2019-01-31'),
+            ): Combination(
+                case="7",
+                date_start='2019-01-05',
+                date_end=False,
+                last_date_invoiced=False,
+                recurring_next_date='2019-02-01',
+                recurring_invoicing_type='post-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2019-01-05'),
+                next_period_date_start=to_date('2019-01-01'),
+                next_period_date_end=to_date('2019-01-15'),
+            ): Combination(
+                case="8",
+                date_start='2019-01-01',
+                date_end='2019-01-15',
+                last_date_invoiced=False,
+                recurring_next_date='2019-01-05',
+                recurring_invoicing_type='pre-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2019-01-01'),
+                next_period_date_start=to_date('2018-12-16'),
+                next_period_date_end=to_date('2019-01-31'),
+            ): Combination(
+                case="9",
+                date_start='2018-01-01',
+                date_end='2020-01-15',
+                last_date_invoiced='2018-12-15',
+                recurring_next_date='2019-01-01',
+                recurring_invoicing_type='pre-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2019-01-01'),
+                next_period_date_start=to_date('2018-12-16'),
+                next_period_date_end=to_date('2018-12-31'),
+            ): Combination(
+                case="10",
+                date_start='2018-01-01',
+                date_end='2020-01-15',
+                last_date_invoiced='2018-12-15',
+                recurring_next_date='2019-01-01',
+                recurring_invoicing_type='post-paid',
+                recurring_rule_type='monthly',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2018-12-31'),
+                next_period_date_start=to_date('2018-12-16'),
+                next_period_date_end=to_date('2018-12-31'),
+            ): Combination(
+                case="11",
+                date_start='2018-01-01',
+                date_end='2020-01-15',
+                last_date_invoiced='2018-12-15',
+                recurring_next_date='2018-12-31',
+                recurring_invoicing_type='post-paid',
+                recurring_rule_type='monthlylastday',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2018-12-16'),
+                next_period_date_start=to_date('2018-12-16'),
+                next_period_date_end=to_date('2018-12-31'),
+            ): Combination(
+                case="12",
+                date_start='2018-01-01',
+                date_end='2020-01-15',
+                last_date_invoiced='2018-12-15',
+                recurring_next_date='2018-12-16',
+                recurring_invoicing_type='pre-paid',
+                recurring_rule_type='monthlylastday',
+                recurring_interval=1,
+                max_date_end=False,
+            ),
+            Result(
+                recurring_next_date=to_date('2018-01-05'),
+                next_period_date_start=to_date('2018-01-05'),
+                next_period_date_end=to_date('2018-03-31'),
+            ): Combination(
+                case="12",
+                date_start='2018-01-05',
+                date_end='2020-01-15',
+                last_date_invoiced=False,
+                recurring_next_date='2018-01-05',
+                recurring_invoicing_type='pre-paid',
+                recurring_rule_type='monthlylastday',
+                recurring_interval=3,
+                max_date_end=False,
+            ),
+        }
+        for result, combination in combinations.items():
+            _update_contract_line(*combination)
+            self.assertEqual(
+                result, _get_result(), _error_message(*combination)
             )
 
     def test_recurring_next_date(self):

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -537,6 +537,33 @@ class TestContract(TestContractBase):
             'There was an error and the view couldn\'t be opened.',
         )
 
+    def test_get_default_recurring_invoicing_offset(self):
+        clm = self.env['contract.line']
+        self.assertEqual(
+            clm._get_default_recurring_invoicing_offset(
+                "pre-paid", "monthly"
+            ),
+            0
+        )
+        self.assertEqual(
+            clm._get_default_recurring_invoicing_offset(
+                "post-paid", "monthly"
+            ),
+            1
+        )
+        self.assertEqual(
+            clm._get_default_recurring_invoicing_offset(
+                "pre-paid", "monthlylastday"
+            ),
+            0
+        )
+        self.assertEqual(
+            clm._get_default_recurring_invoicing_offset(
+                "post-paid", "monthlylastday"
+            ),
+            0
+        )
+
     def test_get_recurring_next_date(self):
         """Test different combination to compute recurring_next_date
         Combination format
@@ -555,87 +582,92 @@ class TestContract(TestContractBase):
         def error_message(
             date_start,
             recurring_invoicing_type,
+            recurring_invoicing_offset,
             recurring_rule_type,
             recurring_interval,
             max_date_end,
         ):
-            return "Error in %s every %d %s case, start with %s (max_date_end=%s)" % (
-                recurring_invoicing_type,
-                recurring_interval,
-                recurring_rule_type,
-                date_start,
-                max_date_end,
+            return (
+                "Error in %s-%d every %d %s case, "
+                "start with %s (max_date_end=%s)" % (
+                    recurring_invoicing_type,
+                    recurring_invoicing_offset,
+                    recurring_interval,
+                    recurring_rule_type,
+                    date_start,
+                    max_date_end,
+                )
             )
 
         combinations = [
             (
                 to_date('2018-01-01'),
-                (to_date('2018-01-01'), 'pre-paid', 'monthly', 1,
+                (to_date('2018-01-01'), 'pre-paid', 0, 'monthly', 1,
                  False),
             ),
             (
                 to_date('2018-01-01'),
-                (to_date('2018-01-01'), 'pre-paid', 'monthly', 1,
+                (to_date('2018-01-01'), 'pre-paid', 0, 'monthly', 1,
                  to_date('2018-01-15')),
             ),
             (
                 False,
-                (to_date('2018-01-16'), 'pre-paid', 'monthly', 1,
+                (to_date('2018-01-16'), 'pre-paid', 0, 'monthly', 1,
                  to_date('2018-01-15')),
             ),
             (
                 to_date('2018-01-01'),
-                (to_date('2018-01-01'), 'pre-paid', 'monthly', 2,
+                (to_date('2018-01-01'), 'pre-paid', 0, 'monthly', 2,
                  False),
             ),
             (
                 to_date('2018-02-01'),
-                (to_date('2018-01-01'), 'post-paid', 'monthly', 1,
+                (to_date('2018-01-01'), 'post-paid', 1, 'monthly', 1,
                  False),
             ),
             (
                 to_date('2018-01-16'),
-                (to_date('2018-01-01'), 'post-paid', 'monthly', 1,
+                (to_date('2018-01-01'), 'post-paid', 1, 'monthly', 1,
                  to_date('2018-01-15')),
             ),
             (
                 False,
-                (to_date('2018-01-16'), 'post-paid', 'monthly', 1,
+                (to_date('2018-01-16'), 'post-paid', 1, 'monthly', 1,
                  to_date('2018-01-15')),
             ),
             (
                 to_date('2018-03-01'),
-                (to_date('2018-01-01'), 'post-paid', 'monthly', 2,
+                (to_date('2018-01-01'), 'post-paid', 1, 'monthly', 2,
                  False),
             ),
             (
                 to_date('2018-01-31'),
-                (to_date('2018-01-05'), 'post-paid', 'monthlylastday', 1,
+                (to_date('2018-01-05'), 'post-paid', 0, 'monthlylastday', 1,
                  False),
             ),
             (
                 to_date('2018-01-06'),
-                (to_date('2018-01-06'), 'pre-paid', 'monthlylastday', 1,
+                (to_date('2018-01-06'), 'pre-paid', 0, 'monthlylastday', 1,
                  False),
             ),
             (
                 to_date('2018-02-28'),
-                (to_date('2018-01-05'), 'post-paid', 'monthlylastday', 2,
+                (to_date('2018-01-05'), 'post-paid', 0, 'monthlylastday', 2,
                  False),
             ),
             (
                 to_date('2018-01-05'),
-                (to_date('2018-01-05'), 'pre-paid', 'monthlylastday', 2,
+                (to_date('2018-01-05'), 'pre-paid', 0, 'monthlylastday', 2,
                  False),
             ),
             (
                 to_date('2018-01-05'),
-                (to_date('2018-01-05'), 'pre-paid', 'yearly', 1,
+                (to_date('2018-01-05'), 'pre-paid', 0, 'yearly', 1,
                  False),
             ),
             (
                 to_date('2019-01-05'),
-                (to_date('2018-01-05'), 'post-paid', 'yearly', 1,
+                (to_date('2018-01-05'), 'post-paid', 1, 'yearly', 1,
                  False),
             ),
         ]

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -564,7 +564,7 @@ class TestContract(TestContractBase):
             0
         )
 
-    def test_get_recurring_next_date(self):
+    def test_get_next_invoice_date(self):
         """Test different combination to compute recurring_next_date
         Combination format
         {
@@ -675,7 +675,7 @@ class TestContract(TestContractBase):
         for recurring_next_date, combination in combinations:
             self.assertEqual(
                 recurring_next_date,
-                contract_line_env._get_recurring_next_date(
+                contract_line_env.get_next_invoice_date(
                     *combination
                 ),
                 error_message(*combination),

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -547,6 +547,7 @@ class TestContract(TestContractBase):
                 recurring_rule_type,      # ('daily', 'weekly', 'monthly',
                                           #  'monthlylastday', 'yearly'),
                 recurring_interval,       # integer
+                max_date_end,             # date
             ),
         }
         """
@@ -556,50 +557,81 @@ class TestContract(TestContractBase):
             recurring_invoicing_type,
             recurring_rule_type,
             recurring_interval,
+            max_date_end,
         ):
-            return "Error in %s every %d %s case, start with %s " % (
+            return "Error in %s every %d %s case, start with %s (max_date_end=%s)" % (
                 recurring_invoicing_type,
                 recurring_interval,
                 recurring_rule_type,
                 date_start,
+                max_date_end,
             )
 
         combinations = [
             (
                 to_date('2018-01-01'),
-                (to_date('2018-01-01'), 'pre-paid', 'monthly', 1),
+                (to_date('2018-01-01'), 'pre-paid', 'monthly', 1,
+                 False),
             ),
             (
                 to_date('2018-01-01'),
-                (to_date('2018-01-01'), 'pre-paid', 'monthly', 2),
+                (to_date('2018-01-01'), 'pre-paid', 'monthly', 1,
+                 to_date('2018-01-15')),
+            ),
+            (
+                False,
+                (to_date('2018-01-16'), 'pre-paid', 'monthly', 1,
+                 to_date('2018-01-15')),
+            ),
+            (
+                to_date('2018-01-01'),
+                (to_date('2018-01-01'), 'pre-paid', 'monthly', 2,
+                 False),
             ),
             (
                 to_date('2018-02-01'),
-                (to_date('2018-01-01'), 'post-paid', 'monthly', 1),
+                (to_date('2018-01-01'), 'post-paid', 'monthly', 1,
+                 False),
+            ),
+            (
+                to_date('2018-01-16'),
+                (to_date('2018-01-01'), 'post-paid', 'monthly', 1,
+                 to_date('2018-01-15')),
+            ),
+            (
+                False,
+                (to_date('2018-01-16'), 'post-paid', 'monthly', 1,
+                 to_date('2018-01-15')),
             ),
             (
                 to_date('2018-03-01'),
-                (to_date('2018-01-01'), 'post-paid', 'monthly', 2),
+                (to_date('2018-01-01'), 'post-paid', 'monthly', 2,
+                 False),
             ),
             (
                 to_date('2018-01-31'),
-                (to_date('2018-01-05'), 'post-paid', 'monthlylastday', 1),
+                (to_date('2018-01-05'), 'post-paid', 'monthlylastday', 1,
+                 False),
             ),
             (
                 to_date('2018-01-31'),
-                (to_date('2018-01-06'), 'pre-paid', 'monthlylastday', 1),
+                (to_date('2018-01-06'), 'pre-paid', 'monthlylastday', 1,
+                 False),
             ),
             (
                 to_date('2018-02-28'),
-                (to_date('2018-01-05'), 'pre-paid', 'monthlylastday', 2),
+                (to_date('2018-01-05'), 'pre-paid', 'monthlylastday', 2,
+                 False),
             ),
             (
                 to_date('2018-01-05'),
-                (to_date('2018-01-05'), 'pre-paid', 'yearly', 1),
+                (to_date('2018-01-05'), 'pre-paid', 'yearly', 1,
+                 False),
             ),
             (
                 to_date('2019-01-05'),
-                (to_date('2018-01-05'), 'post-paid', 'yearly', 1),
+                (to_date('2018-01-05'), 'post-paid', 'yearly', 1,
+                 False),
             ),
         ]
         contract_line_env = self.env['contract.line']

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -247,7 +247,7 @@ class TestContract(TestContractBase):
         self.assertEqual(self.acct_line.last_date_invoiced, last_date_invoiced)
 
     def test_contract_monthly_lastday(self):
-        recurring_next_date = to_date('2018-03-31')
+        recurring_next_date = to_date('2018-02-28')
         last_date_invoiced = to_date('2018-02-22')
         self.acct_line.recurring_next_date = '2018-02-22'
         self.acct_line.recurring_invoicing_type = 'post-paid'
@@ -279,7 +279,7 @@ class TestContract(TestContractBase):
         )
         self.contract.recurring_create_invoice()
         self.assertEqual(
-            self.acct_line.recurring_next_date, to_date('2018-04-01')
+            self.acct_line.recurring_next_date, to_date('2018-3-16')
         )
         self.assertEqual(
             self.acct_line.last_date_invoiced, to_date('2018-02-28')

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -1412,6 +1412,10 @@ class TestContract(TestContractBase):
             )
         self.assertEqual(first, to_date('2018-01-05'))
         self.assertEqual(last, to_date('2018-01-31'))
+        self.assertEqual(recurring_next_date, to_date('2018-01-05'))
+        self.assertEqual(
+            self.acct_line.recurring_next_date, to_date('2018-01-05')
+        )
         self.contract.recurring_create_invoice()
         first, last, recurring_next_date = \
             self.acct_line._get_period_to_invoice(
@@ -1420,6 +1424,13 @@ class TestContract(TestContractBase):
             )
         self.assertEqual(first, to_date('2018-02-01'))
         self.assertEqual(last, to_date('2018-02-28'))
+        self.assertEqual(recurring_next_date, to_date('2018-02-01'))
+        self.assertEqual(
+            self.acct_line.recurring_next_date, to_date('2018-02-01')
+        )
+        self.assertEqual(
+            self.acct_line.last_date_invoiced, to_date('2018-01-31')
+        )
         self.contract.recurring_create_invoice()
         first, last, recurring_next_date = \
             self.acct_line._get_period_to_invoice(
@@ -1428,7 +1439,26 @@ class TestContract(TestContractBase):
             )
         self.assertEqual(first, to_date('2018-03-01'))
         self.assertEqual(last, to_date('2018-03-15'))
-        self.acct_line.manual_renew_needed = True
+        self.assertEqual(recurring_next_date, to_date('2018-03-01'))
+        self.assertEqual(
+            self.acct_line.recurring_next_date, to_date('2018-03-01')
+        )
+        self.assertEqual(
+            self.acct_line.last_date_invoiced, to_date('2018-02-28')
+        )
+        self.contract.recurring_create_invoice()
+        first, last, recurring_next_date = \
+            self.acct_line._get_period_to_invoice(
+                self.acct_line.last_date_invoiced,
+                self.acct_line.recurring_next_date,
+            )
+        self.assertFalse(first)
+        self.assertFalse(last)
+        self.assertFalse(recurring_next_date)
+        self.assertFalse(self.acct_line.recurring_next_date)
+        self.assertEqual(
+            self.acct_line.last_date_invoiced, to_date('2018-03-15')
+        )
 
     def test_get_period_to_invoice_monthly_pre_paid_2(self):
         self.acct_line.date_start = '2018-01-05'

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -537,7 +537,7 @@ class TestContract(TestContractBase):
             'There was an error and the view couldn\'t be opened.',
         )
 
-    def test_compute_first_recurring_next_date(self):
+    def test_get_recurring_next_date(self):
         """Test different combination to compute recurring_next_date
         Combination format
         {
@@ -606,7 +606,7 @@ class TestContract(TestContractBase):
         for recurring_next_date, combination in combinations:
             self.assertEqual(
                 recurring_next_date,
-                contract_line_env._compute_first_recurring_next_date(
+                contract_line_env._get_recurring_next_date(
                     *combination
                 ),
                 error_message(*combination),

--- a/contract/views/abstract_contract_line.xml
+++ b/contract/views/abstract_contract_line.xml
@@ -60,6 +60,7 @@
                         </group>
                         <group>
                             <field name="recurring_invoicing_type"/>
+                            <field name="recurring_invoicing_offset"/>
                         </group>
                     </group>
                 </sheet>

--- a/contract/views/abstract_contract_line.xml
+++ b/contract/views/abstract_contract_line.xml
@@ -59,8 +59,7 @@
                             </div>
                         </group>
                         <group>
-                            <field name="recurring_invoicing_type"
-                                   attrs="{'invisible': [('recurring_rule_type', '=', 'monthlylastday')]}"/>
+                            <field name="recurring_invoicing_type"/>
                         </group>
                     </group>
                 </sheet>

--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -15,11 +15,13 @@
                 <group>
                     <field name="create_invoice_visibility" invisible="1"/>
                     <field name="date_start" required="1"/>
+                    <field name="next_period_date_start"/>
                     <field name="recurring_next_date"/>
                 </group>
                 <group>
                     <field name="date_end"
                            attrs="{'required': [('is_auto_renew', '=', True)]}"/>
+                    <field name="next_period_date_end"/>
                 </group>
                 <group groups="base.group_no_one">
                     <field name="last_date_invoiced" readonly="True"/>

--- a/contract_sale_mandate/tests/test_contract_sale_mandate.py
+++ b/contract_sale_mandate/tests/test_contract_sale_mandate.py
@@ -26,6 +26,7 @@ class TestContractSaleMandate(TestContractBase):
                 'is_contract': True,
                 'default_qty': 12,
                 'recurring_rule_type': "monthlylastday",
+                'recurring_invoicing_type': "post-paid",
                 'contract_template_id': cls.contract_template1.id,
             }
         )

--- a/product_contract/migrations/12.0.3.0.0/pre-migration.py
+++ b/product_contract/migrations/12.0.3.0.0/pre-migration.py
@@ -1,0 +1,10 @@
+def migrate(cr, version):
+    # pre-paid/post-paid becomes significant for monthlylastday too,
+    # make sure it has the value that was implied for previous versions.
+    cr.execute(
+        """\
+            UPDATE product_template
+            SET recurring_invoicing_type = 'post-paid'
+            WHERE recurring_rule_type = 'monthlylastday'
+        """
+    )

--- a/product_contract/tests/test_sale_order.py
+++ b/product_contract/tests/test_sale_order.py
@@ -43,6 +43,7 @@ class TestSaleOrder(TransactionCase):
                 'is_contract': True,
                 'default_qty': 12,
                 'recurring_rule_type': "monthlylastday",
+                'recurring_invoicing_type': "post-paid",
                 'contract_template_id': self.contract_template1.id,
             }
         )

--- a/product_contract/views/product_template.xml
+++ b/product_contract/views/product_template.xml
@@ -33,8 +33,7 @@
                         </group>
                         <group>
                             <field name="default_qty"/>
-                            <field name="recurring_invoicing_type"
-                            attrs="{'invisible': [('recurring_rule_type', '=', 'monthlylastday')]}"/>
+                            <field name="recurring_invoicing_type"/>
                         </group>
                     </group>
                     <group>

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -58,8 +58,7 @@
                     <field name="recurring_rule_type"/>
                 </group>
                 <group attrs="{'invisible': [('is_contract', '=', False)]}">
-                    <field name="recurring_invoicing_type"
-                           attrs="{'invisible': [('recurring_rule_type', '=', 'monthlylastday')]}"/>
+                    <field name="recurring_invoicing_type"/>
                 </group>
                 <group attrs="{'invisible': [('is_contract', '=', False)]}">
                     <field name="date_start"


### PR DESCRIPTION
Some simple refactoring of the contract module. The main idea is to split the computation of the next invoice date in two parts: the computation of the next period, followed by the computation of the next invoice date (aka `recurring_next_date`) based on the next period dates.

This is best reviewed one commit at a time to understand individual changes.

There is also a UX improvement: display the next period start and end date on the contract line form, so the user does not need to deduce it from other parameters.

Finally, `monthlylastday` now supports `pre-paid`/`post-paid`. This could be a breaking change
if there is code that creates `monthlylastday` contract lines without setting them to `post-paid` mode.

fixes: #428