### PR TITLE
[12.0][FIX] - forecast period for auto renew contract lines

### DIFF
--- a/contract_forecast/models/contract_line.py
+++ b/contract_forecast/models/contract_line.py
@@ -74,6 +74,7 @@ class ContractLine(models.Model):
                     if rec.last_date_invoiced
                     else rec.date_start - relativedelta(days=1)
                 )
+                max_date_end = rec.date_end if not rec.is_auto_renew else False
                 while (
                     period_date_end
                     and rec._get_generate_forecast_periods_criteria(
@@ -85,7 +86,7 @@ class ContractLine(models.Model):
                         period_date_start,
                         rec.recurring_rule_type,
                         rec.recurring_interval,
-                        max_date_end=rec.date_end,
+                        max_date_end=max_date_end,
                     )
                     recurring_next_date = rec.get_next_invoice_date(
                         period_date_start,
@@ -93,7 +94,7 @@ class ContractLine(models.Model):
                         rec.recurring_invoicing_offset,
                         rec.recurring_rule_type,
                         rec.recurring_interval,
-                        rec.date_end,
+                        max_date_end=max_date_end,
                     )
                     if period_date_end and recurring_next_date:
                         values.append(

--- a/contract_forecast/tests/test_contract_line_forecast_period.py
+++ b/contract_forecast/tests/test_contract_line_forecast_period.py
@@ -284,3 +284,26 @@ class TestContractLineForecastPeriod(TestContractBase):
         self.acct_line.write({'is_auto_renew': True})
         self.assertTrue(self.acct_line.forecast_period_ids)
         self.assertEqual(len(self.acct_line.forecast_period_ids), 37)
+
+    @mute_logger("odoo.addons.queue_job.models.base")
+    def test_forecast_period_for_undefined_date_end_contract(self):
+        """If a contract line have and undefined date end the forecast should
+        continue to the company forecast period"""
+        self.acct_line.contract_id.company_id.contract_forecast_interval = 36
+        self.acct_line.write(
+            {
+                'date_start': Date.today(),
+                'recurring_next_date': Date.today(),
+                'date_end': Date.today() + relativedelta(years=1),
+                'recurring_rule_type': "monthlylastday",
+                'last_date_invoiced': False,
+                'recurring_invoicing_type': 'pre-paid',
+                'is_auto_renew': False,
+            }
+        )
+        self.assertTrue(self.acct_line.forecast_period_ids)
+        self.assertEqual(len(self.acct_line.forecast_period_ids), 13)
+
+        self.acct_line.write({'date_end': False})
+        self.assertTrue(self.acct_line.forecast_period_ids)
+        self.assertEqual(len(self.acct_line.forecast_period_ids), 37)

--- a/contract_forecast/tests/test_contract_line_forecast_period.py
+++ b/contract_forecast/tests/test_contract_line_forecast_period.py
@@ -260,3 +260,27 @@ class TestContractLineForecastPeriod(TestContractBase):
                 Date.to_date("2020-01-01"),
             ),
         )
+
+    @mute_logger("odoo.addons.queue_job.models.base")
+    def test_forecast_period_for_auto_renew_contract(self):
+        """If a contract line is set to auto renew the forecast should continue
+        after the date end and stop at the company forecast period"""
+        # Set the company forecast period to three years
+        self.acct_line.contract_id.company_id.contract_forecast_interval = 36
+        self.acct_line.write(
+            {
+                'date_start': Date.today(),
+                'recurring_next_date': Date.today(),
+                'date_end': Date.today() + relativedelta(years=1),
+                'recurring_rule_type': "monthlylastday",
+                'last_date_invoiced': False,
+                'recurring_invoicing_type': 'pre-paid',
+                'is_auto_renew': False,
+            }
+        )
+        self.assertTrue(self.acct_line.forecast_period_ids)
+        self.assertEqual(len(self.acct_line.forecast_period_ids), 13)
+
+        self.acct_line.write({'is_auto_renew': True})
+        self.assertTrue(self.acct_line.forecast_period_ids)
+        self.assertEqual(len(self.acct_line.forecast_period_ids), 37)

--- a/contract_forecast/tests/test_contract_line_forecast_period.py
+++ b/contract_forecast/tests/test_contract_line_forecast_period.py
@@ -135,12 +135,15 @@ class TestContractLineForecastPeriod(TestContractBase):
                 'date_end': Date.today() + relativedelta(months=3),
                 'recurring_rule_type': "monthlylastday",
                 'recurring_invoicing_type': 'pre-paid',
-                'is_auto_renew': True,
+                'is_auto_renew': False,
             }
         )
         self.acct_line._onchange_date_start()
         self.assertTrue(self.acct_line.forecast_period_ids)
         self.assertEqual(len(self.acct_line.forecast_period_ids), 4)
+        self.acct_line.write({'is_auto_renew': True})
+        self.assertTrue(self.acct_line.forecast_period_ids)
+        self.assertEqual(len(self.acct_line.forecast_period_ids), 13)
 
     @mute_logger("odoo.addons.queue_job.models.base")
     def test_forecast_period_on_contract_line_update_8(self):


### PR DESCRIPTION
The contract forecast is a simulation of the upcoming invoices that we can expect from a contract based on different parameters like the start date, end date, ..

A special case is for contract line with an undefined end date or set to auto-renew, we can't decide when to stop the forecast.

A company paramétré was added to define the forecast end date for those cases.  

If a contract line is set to auto-renew the forecast should continue  after the date end and stop at the company forecast period and the same for contract lines with an undefined end date