### PR TITLE
[12.0][FIX+IMP] contract: Handle properly multi-company setups

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -281,7 +281,9 @@ class ContractContract(models.Model):
         invoice_type = 'out_invoice'
         if self.contract_type == 'purchase':
             invoice_type = 'in_invoice'
-        vinvoice = self.env['account.invoice'].new({
+        vinvoice = self.env['account.invoice'].with_context(
+            force_company=self.company_id.id,
+        ).new({
             'partner_id': self.invoice_partner_id.id,
             'type': invoice_type,
         })
@@ -343,7 +345,9 @@ class ContractContract(models.Model):
         # taken from the invoice's journal in _onchange_product_id
         # This code is not in finalize_creation_from_contract because it's
         # not possible to create an invoice line with no account
-        new_invoice = self.env['account.invoice'].new(invoice_values)
+        new_invoice = self.env['account.invoice'].with_context(
+            force_company=invoice_values['company_id'],
+        ).new(invoice_values)
         for invoice_line in new_invoice.invoice_line_ids:
             name = invoice_line.name
             account_analytic_id = invoice_line.account_analytic_id

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -658,7 +658,9 @@ class ContractLine(models.Model):
         }
         if invoice_id:
             invoice_line_vals['invoice_id'] = invoice_id.id
-        invoice_line = self.env['account.invoice.line'].new(invoice_line_vals)
+        invoice_line = self.env['account.invoice.line'].with_context(
+            force_company=self.contract_id.company_id.id,
+        ).new(invoice_line_vals)
         # Get other invoice line values from product onchange
         invoice_line._onchange_product_id()
         invoice_line_vals = invoice_line._convert_to_write(invoice_line._cache)


### PR DESCRIPTION
If you have contracts in several companies, cron will create all of them, but property fields will be populated with incorrect data as the taken company is the main from the cron user (usually admin).

@Tecnativa TT21285