### PR TITLE
[12.0][product_contract] [FIX]contract_count == len(active contracts)

### DIFF
--- a/product_contract/models/sale_order.py
+++ b/product_contract/models/sale_order.py
@@ -103,7 +103,9 @@ class SaleOrder(models.Model):
     @api.depends("order_line")
     def _compute_contract_count(self):
         for rec in self:
-            rec.contract_count = len(rec.order_line.mapped('contract_id'))
+            rec.contract_count = len(
+                rec.order_line.mapped('contract_id').filtered(
+                    lambda r: r.active))
 
     @api.multi
     def action_show_contracts(self):

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -23,7 +23,7 @@
                 <button name="action_show_contracts"
                         type="object" icon="fa-book"
                         class="oe_stat_button"
-                        attrs="{'invisible': ['|', ('is_contract', '!=', True), ('state', 'not in', ['sale', 'done'])]}">
+                        attrs="{'invisible': ['|', '|', ('is_contract', '!=', True), ('state', 'not in', ['sale', 'done']), ('contract_count', '=', 0)]}">
                     <field string="Contracts"
                            name="contract_count"
                            widget="statinfo"/>


### PR DESCRIPTION
Hi, I'm Óscar from SDi <https://sdi.es>
I have found this issue: In a sale.order, when the smartbutton appers, with the contracts, if I archive the contracts, the smartbutton not put a cero, the button counts active and not active contracts.
And the button not dessapears.

Thanks a lot.