### PR TITLE
[12.0][FIX] agreement_legal: Change company_contact_id domain

### DIFF
--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -129,6 +129,7 @@ class Agreement(models.Model):
     use_parties_content = fields.Boolean(
         string="Use parties content",
         help="Use custom content for parties")
+    company_partner_id = fields.Many2one(related="company_id.partner_id")
 
     def _get_default_parties(self):
         deftext = """

--- a/agreement_legal/views/agreement.xml
+++ b/agreement_legal/views/agreement.xml
@@ -115,6 +115,7 @@
                                        context="{'show_address': 1}"
                                        options="{&quot;always_reload&quot;: True}"/>
                             </div>
+                            <field name="company_partner_id" invisible="1" />
                         </group>
                         <group name="partner_left" string="Primary Contact">
                             <field name="partner_contact_id" domain="[('parent_id', '=', partner_id)]" nolabel="1"/>
@@ -122,7 +123,7 @@
                             <field name="partner_contact_email" widget="email" readonly="1" nolabel="1"/>
                         </group>
                         <group name="contact_right" string="Primary Contact">
-                            <field name="company_contact_id" domain="[('parent_id', '=', company_id.partner_id)]" nolabel="1"/>
+                            <field name="company_contact_id" domain="[('parent_id', '=', company_partner_id)]" nolabel="1"/>
                             <field name="company_contact_phone" widget="phone" readonly="1" nolabel="1"/>
                             <field name="company_contact_email" widget="email" readonly="1" nolabel="1"/>
                         </group>
@@ -136,7 +137,7 @@
                             <field name="end_date" attrs="{'required': [('is_template', '=', False)], 'invisible': [('is_template', '=', True)]}"/>
                             <field name="expiration_notice"/>
                             <field name="change_notice"/>
-                            <field name="notification_address_id" domain="['|', ('parent_id', '=', partner_id), ('parent_id', '=', company_id.partner_id)]"/>
+                            <field name="notification_address_id" domain="['|', ('parent_id', '=', partner_id), ('parent_id', '=', company_partner_id)]"/>
                             <field name="termination_requested"/>
                             <field name="termination_date"/>
                         </group>


### PR DESCRIPTION
Before this commit, the view of agreement uses a dotted domain on the 'right leaf' in the company_conact_id field causing an javascript error.

cc @tecnativa TT22261