### PR TITLE
[12.0][FIX] agreement_legal: avoid error of two field with same label

### DIFF
--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -129,7 +129,8 @@ class Agreement(models.Model):
     use_parties_content = fields.Boolean(
         string="Use parties content",
         help="Use custom content for parties")
-    company_partner_id = fields.Many2one(related="company_id.partner_id")
+    company_partner_id = fields.Many2one(
+        related="company_id.partner_id", string="Company's Partner")
 
     def _get_default_parties(self):
         deftext = """


### PR DESCRIPTION
Avoid warning in runbot:

![Selection_114](https://user-images.githubusercontent.com/25005517/74737756-cb04ab00-5255-11ea-9200-3fab62b30f99.png)

This field is not seen in any view, so it doesn't matter which label it has.

Fast-track.