### PR TITLE
[12.0][FIX] agreement_legal: Change partner_id domain in agreement view

### DIFF
--- a/agreement_legal/views/agreement.xml
+++ b/agreement_legal/views/agreement.xml
@@ -102,7 +102,7 @@
                                string="Partner">
                             <div class="o_address_format">
                                 <field name="partner_id"
-                                       domain="[('customer', '=', True)]"
+                                       domain="['|',('customer', '=', True),('supplier', '=', True)]"
                                        context="{'show_address': 1}"
                                        options="{&quot;always_reload&quot;: True}"/>
                             </div>


### PR DESCRIPTION
Previous this commit users can't select a vendor in the agreement form, this is not the behavior described in the help. This commit changes the domain to allow select a vendor.

cc @tecnativa TT22264