### PR TITLE
[IMP] agreement,agreement_legal: support activities

### DIFF
--- a/agreement/__manifest__.py
+++ b/agreement/__manifest__.py
@@ -11,7 +11,7 @@
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/oca/contract',
     'license': 'AGPL-3',
-    'depends': ['base'],
+    'depends': ['mail'],
     'data': [
         'security/ir.model.access.csv',
         'security/agreement_security.xml',

--- a/agreement/models/agreement.py
+++ b/agreement/models/agreement.py
@@ -8,6 +8,7 @@ from odoo import models, fields
 class Agreement(models.Model):
     _name = 'agreement'
     _description = 'Agreement'
+    _inherit = ["mail.thread", "mail.activity.mixin"]
 
     code = fields.Char(required=True, copy=False)
     name = fields.Char(required=True)

--- a/agreement/views/agreement.xml
+++ b/agreement/views/agreement.xml
@@ -12,33 +12,40 @@
     <field name="model">agreement</field>
     <field name="arch" type="xml">
         <form string="Agreement">
-            <div class="oe_button_box" name="button_box">
-                <button name="toggle_active" type="object"
-                    class="oe_stat_button" icon="fa-archive">
-                    <field name="active" widget="boolean_button"
-                        options='{"terminology": "archive"}'/>
-                </button>
+            <sheet>
+                <div class="oe_button_box" name="button_box">
+                    <button name="toggle_active" type="object"
+                        class="oe_stat_button" icon="fa-archive">
+                        <field name="active" widget="boolean_button"
+                            options='{"terminology": "archive"}'/>
+                    </button>
+                </div>
+                <group name="main">
+                    <group name="left">
+                        <field name="agreement_type_id"
+                            groups="agreement.group_use_agreement_type"/>
+                        <field name="is_template" groups="agreement.group_use_agreement_template"/>
+                        <field name="partner_id"
+                            attrs="{'required': [('is_template', '=', False)]}"/>
+                        <field name="name"/>
+                        <field name="signature_date"/>
+                    </group>
+                    <group name="right">
+                        <field name="start_date"/>
+                        <field name="end_date"/>
+                        <field name="code"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
+                    </group>
+                </group>
+                <notebook>
+                    <page name="config" string="Configuration" attrs="{'invisible': True}"/>
+                </notebook>
+            </sheet>
+            <div class="oe_chatter">
+                <field name="message_follower_ids" widget="mail_followers"/>
+                <field name="activity_ids" widget="mail_activity"/>
+                <field name="message_ids" widget="mail_thread"/>
             </div>
-            <group name="main">
-                <group name="left">
-                    <field name="agreement_type_id"
-                           groups="agreement.group_use_agreement_type"/>
-                    <field name="is_template" groups="agreement.group_use_agreement_template"/>
-                    <field name="partner_id"
-                           attrs="{'required': [('is_template', '=', False)]}"/>
-                    <field name="name"/>
-                    <field name="signature_date"/>
-                </group>
-                <group name="right">
-                    <field name="start_date"/>
-                    <field name="end_date"/>
-                    <field name="code"/>
-                    <field name="company_id" groups="base.group_multi_company"/>
-                </group>
-            </group>
-          <notebook>
-            <page name="config" string="Configuration" attrs="{'invisible': True}"/>
-          </notebook>
         </form>
     </field>
 </record>

--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -5,8 +5,7 @@ from odoo import _, api, fields, models
 
 
 class Agreement(models.Model):
-    _name = "agreement"
-    _inherit = ["agreement", "mail.thread"]
+    _inherit = "agreement"
 
     # General
     name = fields.Char(string="Title", required=True)

--- a/agreement_legal/views/agreement.xml
+++ b/agreement_legal/views/agreement.xml
@@ -234,6 +234,7 @@
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="activity_ids" widget="mail_activity"/>
                     <field name="message_ids" widget="mail_thread"/>
                 </div>
             </form>


### PR DESCRIPTION
- The `agreement` model now features mail and activities from its base module.
- The `agreement_legal` module doesn't need to add mail support now.

@Tecnativa TT22477