### PR TITLE
Added correct domain for supplier contract's on payment mode (squashed #468)

### DIFF
--- a/contract_payment_mode/views/contract_view.xml
+++ b/contract_payment_mode/views/contract_view.xml
@@ -36,5 +36,19 @@
             </field>
         </field>
     </record>
+    
+    
+        <!--Supplier FORM view-->
+    <record id="contract_contract_supplier_form_view" model="ir.ui.view">
+        <field name="name">contract.contract supplier form view (in contract_payment_mode)</field>
+        <field name="model">contract.contract</field>
+		<field name="priority">18</field>
+        <field name="inherit_id" ref="contract.contract_contract_supplier_form_view"/>
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+               <field name="payment_mode_id" domain="[('payment_type', '=', 'outbound')]"/>
+            </field>
+        </field>
+    </record>
 
 </odoo>


### PR DESCRIPTION
Added view for supplier contracts, respecting the domain for payment_type.
Before was showing the inbound types in the supplier payment

Supersedes #468