### PR TITLE
[FIX] - Group by contract template when creating contracts from SO

### DIFF
--- a/product_contract/models/sale_order.py
+++ b/product_contract/models/sale_order.py
@@ -83,6 +83,7 @@ class SaleOrder(models.Model):
                     'sale_order_line_id'
                 )
             )
+            contract_templates = self.env["contract.template"]
             for order_line in line_to_create_contract:
                 contract_template = order_line.product_id.with_context(
                     force_company=rec.company_id.id
@@ -95,6 +96,8 @@ class SaleOrder(models.Model):
                             rec.company_id.name
                         )
                     )
+                contract_templates |= contract_template
+            for contract_template in contract_templates:
                 order_lines = line_to_create_contract.filtered(
                     lambda r, template=contract_template:
                         r.product_id.with_context(


### PR DESCRIPTION
When creating a contract from SO, the system should group by contract template the
sale order lines and create one contract per contract template.

Actually, it group by contract template but create as many contracts as many
sale order lines and we end with duplicated contracts.

The break was made here https://github.com/OCA/contract/commit/500461396bb304328ee2e91c35c1f6d3f42ab747#diff-7e52e92beab9411dd73aa2b44d0945fdL73. 

I add a unit test to cover this case in the future and change the loop on contract templates instead of order lines