### PR TITLE
[IMP] agreement_legal_sale: Allow Multiple SP's From SO Line

### DIFF
--- a/agreement_legal_sale/__manifest__.py
+++ b/agreement_legal_sale/__manifest__.py
@@ -12,6 +12,7 @@
     'depends': [
         'agreement_legal',
         'agreement_sale',
+        'agreement_serviceprofile'
     ],
     'data': [
         'views/agreement.xml',

--- a/agreement_legal_sale/models/sale_order.py
+++ b/agreement_legal_sale/models/sale_order.py
@@ -40,7 +40,7 @@ class SaleOrder(models.Model):
         """ Create line.product_uom_qty SP's """
         if line.product_id.product_tmpl_id.is_serviceprofile:
             for i in range(1, int(line.product_uom_qty)+1):
-                sp = self.env['agreement.serviceprofile'].\
+                self.env['agreement.serviceprofile'].\
                     create(self._get_sp_vals(line, order, i))
 
     def _get_agreement_line_vals(self, line):


### PR DESCRIPTION
The following PR makes changes to the agreement_legal_sale module so if a user orders 3 units of a product that is_serviceprofile then 3 Service Profiles are created. This PR also adjusts the structure of the methods so they are more easily inherited. This module also needs to depend on agreement_serviceprofile or else when running by itself it will generate a key error.