### PR TITLE
[12.0][FIX] contract: Select the correct sections/notes to be invoiced

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -15,6 +15,7 @@ class ContractLine(models.Model):
     _name = 'contract.line'
     _description = "Contract Line"
     _inherit = 'contract.abstract.contract.line'
+    _order = 'sequence,id'
 
     sequence = fields.Integer(
         string="Sequence",
@@ -654,8 +655,8 @@ class ContractLine(models.Model):
         # have no meaning in certain invoices
         today = fields.Date.context_today(self)
         for rec in self:
-            if (not rec.display_type and
-                    rec.date_start and today >= rec.date_start):
+            if ((not rec.display_type or rec.is_recurring_note)
+                    and rec.date_start and today >= rec.date_start):
                 rec.create_invoice_visibility = bool(rec.recurring_next_date)
             else:
                 rec.create_invoice_visibility = False
@@ -691,6 +692,7 @@ class ContractLine(models.Model):
         name = self._insert_markers(dates[0], dates[1])
         invoice_line_vals.update(
             {
+                'sequence': self.sequence,
                 'name': name,
                 'account_analytic_id': self.analytic_account_id.id,
                 'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],

--- a/contract/views/abstract_contract_line.xml
+++ b/contract/views/abstract_contract_line.xml
@@ -34,6 +34,10 @@
                     <label for="name" string="Note" attrs="{'invisible': [('display_type', '!=', 'line_note')]}"/>
                     <field name="name" nolabel="1"/>
 
+                    <group name="note_invoicing_mode" attrs="{'invisible': [('display_type', '!=', 'line_note')]}">
+                        <field name="note_invoicing_mode" widget="radio"/>
+                    </group>
+
                     <group col="4" attrs="{'invisible': [('display_type', '!=', False)]}">
                         <field colspan="2" name="is_auto_renew"/>
                         <field colspan="2" name="is_canceled" invisible="1"/>
@@ -62,7 +66,7 @@
                             </div>
                         </group>
                     </group>
-                    <group name="recurrence_info" attrs="{'invisible': [('display_type', '!=', False)]}">
+                    <group name="recurrence_info" attrs="{'invisible': ['|', ('display_type', '=', 'line_section'), '&amp;', ('display_type', '=', 'line_note'), ('note_invoicing_mode', '!=', 'custom')]}">
                         <group>
                             <label for="recurring_interval"/>
                             <div class="o_row">


### PR DESCRIPTION
Select the correct sections/notes to be invoiced.
For example: Empty contract line sections shouldn't be invoiced.

Cc @Tecnativa TT23706