### PR TITLE
[12.0][FIX] contract: Currency is not editable + pricelist from partner

### DIFF
--- a/contract/models/abstract_contract_line.py
+++ b/contract/models/abstract_contract_line.py
@@ -191,12 +191,18 @@ class ContractAbstractContractLine(models.AbstractModel):
         """
         for line in self:
             if line.automatic_price:
+                pricelist = (
+                    line.contract_id.pricelist_id or
+                    line.contract_id.partner_id.with_context(
+                        force_company=line.contract_id.company_id.id,
+                    ).property_product_pricelist
+                )
                 product = line.product_id.with_context(
                     quantity=line.env.context.get(
                         'contract_line_qty',
                         line.quantity,
                     ),
-                    pricelist=line.contract_id.pricelist_id.id,
+                    pricelist=pricelist.id,
                     partner=line.contract_id.partner_id.id,
                     date=line.env.context.get(
                         'old_date', fields.Date.context_today(line)

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -178,8 +178,6 @@
                                        options="{'no_create': True}"
                                        groups="base.group_multi_company"/>
                                 <field name="currency_id"
-                                       attrs="{'readonly': [('is_terminated','=',True)]}"
-                                       options="{'no_create': True}"
                                        groups="base.group_multi_currency"/>
                                 <field name="invoice_partner_id"
                                        attrs="{'readonly': [('is_terminated','=',True)]}"


### PR DESCRIPTION
Previous related field was not accurated nor editable. Now the field is got properly from a computed field.

Reviewing this, as the currency was taken (and it continues being taken) from the partner pricelist if no pricelist is explicitly set, automatic price should use the same logic for using partner pricelist.

cc @Tecnativa TT24071