### PR TITLE
[10.0] [FIX] Remove part of the optimization of invoice creation

### DIFF
--- a/contract_payment_auto/tests/test_account_analytic_account.py
+++ b/contract_payment_auto/tests/test_account_analytic_account.py
@@ -198,10 +198,11 @@ class TestAccountAnalyticAccount(common.HttpCase):
                 [('contract_id', '=', self.contract.id)]).ensure_one()
             Transactions = self.contract.env['payment.transaction']
             Transactions.create.assert_called_once()
+            tx_vals = Transactions.create.call_args[0][0]
             if expected_token is not None:
-                tx_vals = Transactions.create.call_args[0][0]
                 self.assertEqual(tx_vals.get('payment_token_id'),
                                  expected_token.id)
+            self.assertEqual(tx_vals['amount'], invoice.amount_total)
 
     def test_pay_invoice_success(self):
         """ It should return True on success. """


### PR DESCRIPTION
The `norecompute` context manager was used around a call to method
`_create_invoice`, which is overriden by at least the
contract_payment_auto module (which is arguably a bug in itself as
the method name starts with an underscore). This breaks some
automations like the closing of invoices with no residual after
payment.

To fix this without changing the de facto API of this module, the
`norecompute context manager` was removed and the
`_onchange_invoice_line_ids` method of account.invoice model is now
explicitely called.

The invoice creation context is now set around the `_create_invoice`
method call so that it can be used in the module that override it too.