### PR TITLE
[FIX] contract: multi-company assignment notification

### DIFF
--- a/contract/README.rst
+++ b/contract/README.rst
@@ -74,6 +74,7 @@ Known issues / Roadmap
 ======================
 
 * Recover states and others functional fields in Contracts.
+* Remove ``models/ir_ui_view.py`` in v13, where the workaround it contains is supported upstream.
 
 Bug Tracker
 ===========

--- a/contract/models/__init__.py
+++ b/contract/models/__init__.py
@@ -13,3 +13,4 @@ from . import contract_tag
 from . import res_company
 from . import res_config_settings
 from . import contract_terminate_reason
+from . import ir_ui_view

--- a/contract/models/ir_ui_view.py
+++ b/contract/models/ir_ui_view.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class IrUiView(models.Model):
+    _inherit = "ir.ui.view"
+
+    @api.model
+    def _prepare_qcontext(self):
+        """Patch context to use fw-compatible v13 company."""
+        # TODO Delete this method in v13; it's upstream there
+        result = super()._prepare_qcontext()
+        if self.env.context.get("allowed_company_ids"):
+            result["res_company"] = self.env["res.company"].browse(
+                self.env.context["allowed_company_ids"][0]
+            ).sudo()

--- a/contract/readme/ROADMAP.rst
+++ b/contract/readme/ROADMAP.rst
@@ -1,1 +1,2 @@
 * Recover states and others functional fields in Contracts.
+* Remove ``models/ir_ui_view.py`` in v13, where the workaround it contains is supported upstream.

--- a/contract/static/description/index.html
+++ b/contract/static/description/index.html
@@ -425,6 +425,7 @@ To use it, just select the template on the contract and fields will be filled au
 <h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>Recover states and others functional fields in Contracts.</li>
+<li>Remove <tt class="docutils literal">models/ir_ui_view.py</tt> in v13, where the workaround it contains is supported upstream.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">


### PR DESCRIPTION
Steps to reproduce the problem:

1. Log in as Mitchell Admin.
2. Create contract CNT-A for company CMP-A, assigned to Marc Demo.
3. Create contract CNT-B for company CMP-B, assigned to Marc Demo.
4. Run cron to create recurring invoices.

Actual results:

- Odoo sends automated assignment emails to Marc Demo, which indicate the name of the company activated for `__system__` user whlie the cron was being executed.

Expected results after this patch:

- Odoo sends automated assignment emails to Marc Demo, which indicate the invoice company.

@Tecnativa TT24657