### PR TITLE
[FIX][12.0]product_contract: bad date_end regarding the contract renew strategy

### DIFF
--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -107,17 +107,16 @@ class SaleOrderLine(models.Model):
                     rec.product_id.recurring_invoicing_type
                 )
                 rec.date_start = rec.date_start or fields.Date.today()
-
-                rec.date_end = (
-                    rec.date_start
-                    + contract_line_model.get_relative_delta(
-                        rec._get_auto_renew_rule_type(),
-                        int(rec.product_uom_qty),
-                    )
-                    - relativedelta(days=1)
-                )
                 rec.is_auto_renew = rec.product_id.is_auto_renew
                 if rec.is_auto_renew:
+                    rec.date_end = (
+                        rec.date_start
+                        + contract_line_model.get_relative_delta(
+                            rec._get_auto_renew_rule_type(),
+                            int(rec.product_uom_qty),
+                        )
+                        - relativedelta(days=1)
+                    )
                     rec.auto_renew_interval = (
                         rec.product_id.auto_renew_interval
                     )
@@ -125,11 +124,11 @@ class SaleOrderLine(models.Model):
                         rec.product_id.auto_renew_rule_type
                     )
 
-    @api.onchange('date_start', 'product_uom_qty', 'recurring_rule_type')
+    @api.onchange('date_start', 'product_uom_qty', 'recurring_rule_type', 'is_auto_renew')
     def onchange_date_start(self):
         contract_line_model = self.env['contract.line']
         for rec in self.filtered('product_id.is_contract'):
-            if not rec.date_start:
+            if not rec.date_start or not rec.is_auto_renew:
                 rec.date_end = False
             else:
                 rec.date_end = (

--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -124,7 +124,8 @@ class SaleOrderLine(models.Model):
                         rec.product_id.auto_renew_rule_type
                     )
 
-    @api.onchange('date_start', 'product_uom_qty', 'recurring_rule_type', 'is_auto_renew')
+    @api.onchange('date_start', 'product_uom_qty', 
+                  'recurring_rule_type', 'is_auto_renew')
     def onchange_date_start(self):
         contract_line_model = self.env['contract.line']
         for rec in self.filtered('product_id.is_contract'):

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -66,7 +66,7 @@
                            attrs="{'required': [('is_contract', '=', True)]}"/>
                 </group>
                 <group attrs="{'invisible': [('is_contract', '=', False)]}">
-                    <field name="date_end" attrs="{'required': [('is_contract', '=', True)]}"/>
+                    <field name="date_end" attrs="{'required': [('is_contract', '=', True),('is_auto_renew', '=', True)]}"/>
                 </group>
                 <group
                     attrs="{'invisible': [('is_contract', '=', False)]}">


### PR DESCRIPTION
The product contract has options for setting the auto renw strategy.
The strategy was incoherent regarding the contract line strategy :
* Date_end is mandatory if auto renew is set on contract line
* date_end is always mandatory on sale.order.line whatever the reneww option is set

The purpose is to have the same behaviour in both modules