### PR TITLE
[12.0][IMP] - Different payment mode for contracts generated from sale orders

### DIFF
--- a/contract_sale_payment_mode/__manifest__.py
+++ b/contract_sale_payment_mode/__manifest__.py
@@ -16,7 +16,7 @@
         'product_contract',
     ],
     'data': [
-    ],
-    'demo': [
+        'views/res_config_settings.xml',
+        'views/sale_order.xml'
     ],
 }

--- a/contract_sale_payment_mode/models/__init__.py
+++ b/contract_sale_payment_mode/models/__init__.py
@@ -1,1 +1,3 @@
 from . import sale_order
+from . import res_company
+from . import res_config_settings

--- a/contract_sale_payment_mode/models/res_company.py
+++ b/contract_sale_payment_mode/models/res_company.py
@@ -1,0 +1,13 @@
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+
+    _inherit = 'res.company'
+
+    specific_contract_payment_mode = fields.Boolean(
+        string="Specific payment mode for contracts created from sale orders"
+    )

--- a/contract_sale_payment_mode/models/res_config_settings.py
+++ b/contract_sale_payment_mode/models/res_config_settings.py
@@ -1,0 +1,15 @@
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+
+    _inherit = 'res.config.settings'
+
+    specific_contract_payment_mode = fields.Boolean(
+        related="company_id.specific_contract_payment_mode",
+        string="Specific payment mode for contracts created from sale orders",
+        readonly=False
+    )

--- a/contract_sale_payment_mode/models/sale_order.py
+++ b/contract_sale_payment_mode/models/sale_order.py
@@ -1,16 +1,43 @@
 # Copyright 2019 ACSONE SA/NV
+# Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
+
+    contract_payment_mode_id = fields.Many2one(
+        comodel_name='account.payment.mode',
+        string='Contract Payment Mode',
+        domain=[('payment_type', '=', 'inbound')],
+        index=True,
+    )
+    specific_contract_payment_mode = fields.Boolean(
+        related="company_id.specific_contract_payment_mode",
+        string="Different payment mode for contracts generated from sale "
+               "orders",
+    )
+
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        res = super().onchange_partner_id()
+        if self.partner_id:
+            self.contract_payment_mode_id = self.partner_id.with_context(
+                force_company=self.company_id.id
+            ).customer_payment_mode_id
+        else:
+            self.payment_mode_id = False
+        return res
 
     @api.multi
     def _prepare_contract_value(self, contract_template):
         self.ensure_one()
         vals = super(SaleOrder, self)._prepare_contract_value(
             contract_template)
-        vals['payment_mode_id'] = self.payment_mode_id.id
+        if self.specific_contract_payment_mode:
+            vals['payment_mode_id'] = self.contract_payment_mode_id.id
+        else:
+            vals['payment_mode_id'] = self.payment_mode_id.id
         return vals

--- a/contract_sale_payment_mode/tests/test_sale_order.py
+++ b/contract_sale_payment_mode/tests/test_sale_order.py
@@ -19,3 +19,22 @@ class TestSaleOrderPaymentMode(TestSaleOrder):
             self.sale.order_line.mapped('contract_id.payment_mode_id'),
             self.payment_mode,
         )
+
+    def test_action_confirm_with_contract_payment_mode_1(self):
+        self.contract_payment_mode_id = self.payment_mode.copy()
+        self.sale.contract_payment_mode_id = self.contract_payment_mode_id
+        self.test_action_confirm()
+        self.assertEqual(
+            self.sale.order_line.mapped('contract_id.payment_mode_id'),
+            self.payment_mode,
+        )
+
+    def test_action_confirm_with_contract_payment_mode_2(self):
+        self.contract_payment_mode_id = self.payment_mode.copy()
+        self.sale.contract_payment_mode_id = self.contract_payment_mode_id
+        self.sale.company_id.specific_contract_payment_mode = True
+        self.test_action_confirm()
+        self.assertEqual(
+            self.sale.order_line.mapped('contract_id.payment_mode_id'),
+            self.contract_payment_mode_id,
+        )

--- a/contract_sale_payment_mode/views/res_config_settings.xml
+++ b/contract_sale_payment_mode/views/res_config_settings.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="res_config_settings_form_view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='sale_config_online_confirmation_sign']"
+                   position="before">
+                <div class="col-12 col-lg-6 o_setting_box"
+                     id="specific_contract_payment_mode">
+                    <div class="o_setting_left_pane">
+                        <field name="specific_contract_payment_mode"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="specific_contract_payment_mode"/>
+                        <span class="fa fa-lg fa-building-o"
+                              title="Values set here are company-specific."
+                              groups="base.group_multi_company"/>
+                        <div class="text-muted">
+                            This option allow allow to set different payment mode for the contracts generated from the sale order than the one will be used for invoices.
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+
+
+</odoo>

--- a/contract_sale_payment_mode/views/sale_order.xml
+++ b/contract_sale_payment_mode/views/sale_order.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2020 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+
+    <record model="ir.ui.view" id="sale_order_form_view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="account_payment_sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_mode_id']" position="after">
+                <field name="specific_contract_payment_mode" invisible="1"/>
+                <field name="contract_payment_mode_id" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('specific_contract_payment_mode', '=', False)]}"/>
+            </xpath>
+        </field>
+    </record>
+
+
+</odoo>


### PR DESCRIPTION
New option allow to set different payment mode for the contracts generated from the sale order than the one will be used for invoices.