### PR TITLE
[IMP] agreement_serviceprofile (Copy True)

### DIFF
--- a/agreement_serviceprofile/models/agreement.py
+++ b/agreement_serviceprofile/models/agreement.py
@@ -9,4 +9,5 @@ class Agreement(models.Model):
 
     serviceprofile_ids = fields.One2many('agreement.serviceprofile',
                                          'agreement_id',
-                                         string="Service Profiles")
+                                         string="Service Profiles",
+                                         copy=True)


### PR DESCRIPTION
Service profiles should be copied when an agreement is created from a template or when duplicating from another agreement. This adds copy=True to the field.