### PR TITLE
[FIX] Hide create contract button as other buttons

### DIFF
--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -17,7 +17,7 @@
                 <button name="action_create_contract"
                         string="Create Contracts"
                         type="object"
-                        class="oe_highlight" attrs="{'invisible': [('need_contract_creation', '=', False)]}"/>
+                        class="oe_highlight" attrs="{'invisible': ['|',('need_contract_creation', '=', False), ('state', '=', 'done')]}"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button name="action_show_contracts"


### PR DESCRIPTION
Just a bit of coherence with the rest of the buttons