### PR TITLE
[13.0][FIX] contract: Only include 'section_and_note_one2many' js widget in view fields that contain it

### DIFF
--- a/contract/static/src/js/section_and_note_fields_backend.js
+++ b/contract/static/src/js/section_and_note_fields_backend.js
@@ -11,6 +11,7 @@ this can be applied directly to Odoo*/
 odoo.define("contract.section_and_note_backend", function(require) {
     "use strict";
 
+    require("account.section_and_note_backend");
     var fieldRegistry = require("web.field_registry");
     var section_and_note_one2many = fieldRegistry.get("section_and_note_one2many");
 


### PR DESCRIPTION
Now in contract list in runbot appear an error like this

![contract-js-error](https://user-images.githubusercontent.com/4117568/98081877-2c1dee80-1e78-11eb-9d88-7f8eca7eb8d5.png)

This error is related to include .js related to widget `section_and_note_one2many` in any places BUT it's only need to load when some fields that contain it show.

This error **NOT** appear in V12.

Please @pedrobaeza and @Tardo  review it

@Tecnativa TT26617