### PR TITLE
[12.0][Fix] Recurring config missing on order line with product configurator

### DIFF
--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -91,6 +91,8 @@
                        attrs="{'column_invisible': [('parent.is_contract', '=', False)]}"/>
                 <field name="date_end"
                        attrs="{'column_invisible': [('parent.is_contract', '=', False)]}"/>
+                <field name="recurring_rule_type" invisible="1"/>
+                <field name="recurring_invoicing_type" invisible="1"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree"
                    position="attributes">


### PR DESCRIPTION
The fields recurring_rule_type and recurring_invoicing_type are not present in the sale order form in lines tree view, so they are not set when creating a sales order line from the product configurator.
Here in the fix they are only added as invisible but maybe they could be shown in the line tree view.