### PR TITLE
[IMP] product_contract: manage contracts at variant level, enforce contract field

### DIFF
--- a/product_contract/__manifest__.py
+++ b/product_contract/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Recurring - Product Contract',
-    'version': '12.0.5.1.1',
+    'version': '12.0.6.0.0',
     'category': 'Contract Management',
     'license': 'AGPL-3',
     'author': "LasLabs, "

--- a/product_contract/migrations/12.0.6.0.0/pre-migration.py
+++ b/product_contract/migrations/12.0.6.0.0/pre-migration.py
@@ -1,0 +1,18 @@
+# Copyright 2020 ACSONE SA/NV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Copy the product template contract on their variants."""
+    contract_key = "property_contract_template_id"  # TODO: check that mig (do in SQL?)
+
+    for company in env["res.company"].with_context(active_test=False).search([]):
+        company_env = env["product.template"].with_context(
+            force_company=company.id, active_test=False
+        )
+        templates = company_env.search([(contract_key, "!=", False)])
+        for template in templates:
+            template.variant_ids.write({contract_key: template[contract_key].id})

--- a/product_contract/models/__init__.py
+++ b/product_contract/models/__init__.py
@@ -5,6 +5,7 @@
 from . import contract
 from . import contract_line
 from . import product_template
+from . import product_product
 from . import sale_order
 from . import sale_order_line
 from . import res_company

--- a/product_contract/models/product_product.py
+++ b/product_contract/models/product_product.py
@@ -1,0 +1,56 @@
+# Copyright 2020 ACSONE SA/NV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ProductProduct(models.Model):
+    """Adds the possibility to override the template contract at variant level."""
+
+    _inherit = "product.product"
+
+    property_contract_template_id = fields.Many2one(
+        comodel_name="contract.template",
+        string="Contract Template",
+        company_dependent=True,
+    )
+
+    def _format_names_for_constraint_message(self, limit=None):
+        exceeds = limit and len(self) > limit
+        to_format = self[:limit] if exceeds else self
+        names = to_format.mapped("display_name")
+        if exceeds:
+            names.append(_("etc"))
+        return _("\n - ").join(names)
+
+    @api.constrains("property_contract_template_id", "is_contract")
+    def _contract_constraint(self):
+        if self.env.context.get("create_from_tmpl"):
+            return  # in that case, constraint is checked after
+
+        self._contract_constraint_template()
+        if self.env["res.company"]._company_default_get().constrain_contract_products:
+            self._contract_constraint_check()
+
+    def _contract_constraint_check(self):
+        contract_products = self.filtered("is_contract")
+        bad_products = contract_products.filtered(
+            lambda p: not p.property_contract_template_id
+        )
+        if bad_products:
+            message_error = _(
+                "Every contract product should have a contract template.\n"
+                "Please check the following products:\n{}"
+            ).format(bad_products._format_names_for_constraint_message(10))
+            raise ValidationError(message_error)
+
+    def _contract_constraint_template(self):
+        products_with_contracts = self.filtered("property_contract_template_id")
+        bad_products = products_with_contracts.filtered(lambda p: not p.is_contract)
+        if bad_products:
+            message_error = _(
+                "Every product with a contract template should be a contract.\n"
+                "Check the following products:\n{}"
+            ).format(bad_products._format_names_for_constraint_message(10))
+            raise ValidationError(message_error)

--- a/product_contract/models/res_company.py
+++ b/product_contract/models/res_company.py
@@ -12,3 +12,7 @@ class ResCompany(models.Model):
         string="Automatically Create Contracts At Sale Order Confirmation",
         default=True,
     )
+    constrain_contract_products = fields.Boolean(
+        string="Enforce that all contract products have a contract template",
+        default=False,
+    )

--- a/product_contract/models/res_config_settings.py
+++ b/product_contract/models/res_config_settings.py
@@ -12,3 +12,7 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.create_contract_at_sale_order_confirmation",
         readonly=False
     )
+
+    constrain_contract_products = fields.Boolean(
+        related="company_id.constrain_contract_products", readonly=False
+    )

--- a/product_contract/readme/CONTRIBUTORS.rst
+++ b/product_contract/readme/CONTRIBUTORS.rst
@@ -1,5 +1,6 @@
 * Ted Salmon <tsalmon@laslabs.com>
 * Souheil Bejaoui <souheil.bejaoui@acsone.eu>
+* Nans Lefebvre <nans.lefebvre@acsone.eu>
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * Ernesto Tejeda

--- a/product_contract/readme/USAGE.rst
+++ b/product_contract/readme/USAGE.rst
@@ -4,3 +4,13 @@ To use this module, you need to:
 #. Check "Is a contract" and select the contract template related to the
    product
 #. Define default recurrence rules
+
+For contract products, the contract template is set on the product template,
+and automatically set on its variants.
+It is then possible to modify the contract template independently on each variant.
+Afterwards, modifying the variant on the product template modifies it only on variants
+for which the default value was not modified.
+
+There is a setting to constrain any contract product to have a contract template.
+Note that this is verified at the variant level, so if all variants have a contract
+template, it is possible to unset it on their product template.

--- a/product_contract/tests/__init__.py
+++ b/product_contract/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_product
 from . import test_sale_order
+from . import test_variant

--- a/product_contract/tests/test_product.py
+++ b/product_contract/tests/test_product.py
@@ -32,3 +32,17 @@ class TestProductTemplate(TransactionCase):
         """
         with self.assertRaises(ValidationError):
             self.consu_product.is_contract = True
+
+    def test_check_contract_template_write(self):
+        """It should not be possible to write a contract on 'not a contract'."""
+        template_values = {"name": "Name", "is_contract": False}
+        not_a_contract = self.env["product.template"].create(template_values)
+        with self.assertRaises(ValidationError):
+            not_a_contract.property_contract_template_id = self.contract
+
+    def test_check_contract_template_create(self):
+        """It should not be possible to create a 'not a contract' with a contract."""
+        template_values = {"name": "Name", "is_contract": False}
+        template_values["property_contract_template_id"] = self.contract.id
+        with self.assertRaises(ValidationError):
+            self.env["product.template"].create(template_values)

--- a/product_contract/tests/test_variant.py
+++ b/product_contract/tests/test_variant.py
@@ -1,0 +1,105 @@
+# Copyright 2020 ACSONE SA/NV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+PCTI = "property_contract_template_id"
+
+
+class TestProductVariant(TransactionCase):
+    def setUp(self):
+        super(TestProductVariant, self).setUp()
+        self.contract = self.env["contract.template"].create({"name": "Test"})
+        self.attribute = self.env["product.attribute"].create({"name": "Brol"})
+        atid = self.attribute.id
+        pav = self.env["product.attribute.value"]
+        self.attr_value_plic = pav.create({"name": "Plic", "attribute_id": atid})
+        self.attr_value_ploc = pav.create({"name": "Ploc", "attribute_id": atid})
+        atvids = [self.attr_value_plic.id, self.attr_value_ploc.id]
+        self.product_template = self.env["product.template"].create(
+            {
+                "name": "Potiquet",
+                "type": "service",
+                "is_contract": True,
+                PCTI: self.contract.id,
+                "attribute_line_ids": [
+                    (0, 0, {"attribute_id": atid, "value_ids": [(6, 0, atvids)]})
+                ],
+            }
+        )
+
+    def test_change_contract_on_variants(self):
+        """The contract on variant should be the one on the template, unless
+           manually changed.
+        """
+        contract_plic = self.env["contract.template"].create({"name": "Plic"})
+        contract_ploc = self.env["contract.template"].create({"name": "Ploc"})
+        template = self.product_template
+        plic, ploc = self.product_template.product_variant_ids
+
+        for variant in self.product_template.product_variant_ids:
+            self.assertEqual(variant[PCTI], template[PCTI])
+
+        # editing a variant only edits the variant itself
+        plic[PCTI] = contract_plic
+        self.assertEqual(plic[PCTI], contract_plic)
+        self.assertEqual(template[PCTI], self.contract)
+        self.assertEqual(ploc[PCTI], self.contract)
+
+        # editing the template only edits the variants that have the default contract
+        template[PCTI] = contract_ploc
+        self.assertEqual(plic[PCTI], contract_plic)
+        self.assertEqual(template[PCTI], contract_ploc)
+        self.assertEqual(ploc[PCTI], contract_ploc)
+
+        # removing the template contract does not impact the variants
+        template[PCTI] = False
+        self.assertEqual(plic[PCTI], contract_plic)
+        self.assertTrue(not template[PCTI])
+        self.assertEqual(ploc[PCTI], contract_ploc)
+
+    def test_change_is_contract(self):
+        """If we remove the contract, it should be removed from the variants."""
+        self.product_template.is_contract = False
+        self.assertTrue(not self.product_template.product_variant_ids.mapped(PCTI))
+
+    def test_check_contract_template(self):
+        """It should not be possible to have products with a contract template
+           if they aren't contracts.
+        """
+        values = {"name": "Test", "is_contract": False}
+        not_a_contract = self.env["product.template"].create(values)
+
+        variant = not_a_contract.product_variant_ids
+        with self.assertRaises(ValidationError):
+            variant[PCTI] = self.contract
+
+        values["property_contract_template_id"] = self.contract.id
+        with self.assertRaises(ValidationError):
+            self.env["product.product"].create(values)
+
+    def test_check_is_contract(self):
+        """If we activate the constrain_contract_products settings, it is not possible
+           to create/write variants without setting a contract template.
+        """
+        company = self.env["res.company"]._company_default_get()
+        company.constrain_contract_products = False
+        values = {"type": "service", "is_contract": True}
+
+        product = self.env["product.product"].create(dict(**values, name="not"))
+        self.assertTrue(product.is_contract)
+
+        plic = self.product_template.product_variant_ids[0]
+        ploc = self.product_template.product_variant_ids[1]
+
+        plic.write({PCTI: False})
+        self.assertTrue(plic.is_contract)
+        self.assertTrue(not plic[PCTI])
+
+        company.constrain_contract_products = True
+        with self.assertRaises(ValidationError):
+            self.env["product.product"].create(dict(**values, name="new"))
+
+        with self.assertRaises(ValidationError):
+            ploc.write({PCTI: False})

--- a/product_contract/views/res_config_settings.xml
+++ b/product_contract/views/res_config_settings.xml
@@ -27,5 +27,23 @@
         </field>
     </record>
 
-
+    <record model="ir.ui.view" id="res_config_settings_contract_form_view">
+        <field name="name">res.config.settings.form.constraint</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="contract.res_config_settings_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='account']" position="inside">
+                <div class="row mt16 o_settings_container">
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="constrain_contract_products" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="constrain_contract_products" />
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
There are two improvements here:
(1) allow to manage contract template per variant. The one set on the template is the default for the variants.
(2) add a constraint to enforce a contract template for products that are contracts

The point (2) is managed through a (company) settings which defaults to False, as to not break existing installs.