### PR TITLE
[12.0] [FIX] product_contract -> Expected singleton: sale.order(…, …)

### DIFF
--- a/product_contract/models/sale_order.py
+++ b/product_contract/models/sale_order.py
@@ -49,7 +49,8 @@ class SaleOrder(models.Model):
 
     @api.depends('order_line')
     def _compute_is_contract(self):
-        self.is_contract = any(self.order_line.mapped('is_contract'))
+        for rec in self:
+            rec.is_contract = any(rec.order_line.mapped('is_contract'))
 
     @api.multi
     def _prepare_contract_value(self, contract_template):


### PR DESCRIPTION
Hello,

we received a singleton error with the method _compute_is_contract.
Could it be that the code in the _compute_is_contract ("product_contract") method is wrong?