### PR TITLE
[13.0][IMP] contract: Add fields to contract page in portal

### DIFF
--- a/contract/i18n/contract.pot
+++ b/contract/i18n/contract.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-12-31 14:54+0000\n"
+"PO-Revision-Date: 2020-12-31 14:54+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1233,11 +1235,6 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: contract
-#: model_terms:ir.ui.view,arch_db:contract.portal_contract_page
-msgid "Last date invoice"
-msgstr ""
-
-#. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 #: model_terms:ir.ui.view,arch_db:contract.contract_template_form_view
 msgid "Legend (for the markers inside invoice lines description)"
@@ -1523,6 +1520,11 @@ msgid "Preview"
 msgstr ""
 
 #. module: contract
+#: model_terms:ir.ui.view,arch_db:contract.portal_contract_page
+msgid "Price unit"
+msgstr ""
+
+#. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract__pricelist_id
 #: model:ir.model.fields,field_description:contract.field_contract_contract__pricelist_id
 #: model:ir.model.fields,field_description:contract.field_contract_template__pricelist_id
@@ -1548,6 +1550,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract_line__quantity
 #: model:ir.model.fields,field_description:contract.field_contract_line__quantity
 #: model:ir.model.fields,field_description:contract.field_contract_template_line__quantity
+#: model_terms:ir.ui.view,arch_db:contract.portal_contract_page
 msgid "Quantity"
 msgstr ""
 

--- a/contract/i18n/es.po
+++ b/contract/i18n/es.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-29 07:26+0000\n"
-"PO-Revision-Date: 2020-12-29 08:27+0100\n"
+"POT-Creation-Date: 2020-12-31 14:54+0000\n"
+"PO-Revision-Date: 2020-12-31 15:55+0100\n"
 "Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -1383,11 +1383,6 @@ msgid "Last Updated on"
 msgstr "Última Actualización en"
 
 #. module: contract
-#: model_terms:ir.ui.view,arch_db:contract.portal_contract_page
-msgid "Last date invoice"
-msgstr "Última fecha de factura"
-
-#. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 #: model_terms:ir.ui.view,arch_db:contract.contract_template_form_view
 msgid "Legend (for the markers inside invoice lines description)"
@@ -1678,6 +1673,13 @@ msgid "Preview"
 msgstr "Previsualizar"
 
 #. module: contract
+#: model_terms:ir.ui.view,arch_db:contract.portal_contract_page
+#, fuzzy
+#| msgid "Pricelist"
+msgid "Price unit"
+msgstr "Precio unitario"
+
+#. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract__pricelist_id
 #: model:ir.model.fields,field_description:contract.field_contract_contract__pricelist_id
 #: model:ir.model.fields,field_description:contract.field_contract_template__pricelist_id
@@ -1703,6 +1705,7 @@ msgstr "Contratos de compras"
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract_line__quantity
 #: model:ir.model.fields,field_description:contract.field_contract_line__quantity
 #: model:ir.model.fields,field_description:contract.field_contract_template_line__quantity
+#: model_terms:ir.ui.view,arch_db:contract.portal_contract_page
 msgid "Quantity"
 msgstr "Cantidad"
 
@@ -2310,6 +2313,9 @@ msgstr "ejemplo Contrato XYZ"
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 msgid "on"
 msgstr "en"
+
+#~ msgid "Last date invoice"
+#~ msgstr "Última fecha de factura"
 
 #~ msgid "Contract Order -"
 #~ msgstr "Pedido de contrato -"

--- a/contract/views/contract_portal_templates.xml
+++ b/contract/views/contract_portal_templates.xml
@@ -200,10 +200,26 @@
                             <table class="table table-sm" id="sales_order_table">
                                 <thead class="bg-100">
                                     <tr>
-                                        <th class="text-left">Description</th>
-                                        <th class="text-right">Recurrence</th>
-                                        <th class="text-right">Date of next invoice</th>
-                                        <th class="text-right">Last date invoice</th>
+                                        <th
+                                            name="th_name"
+                                            class="text-left"
+                                        >Description</th>
+                                        <th
+                                            name="th_quantity"
+                                            class="text-right"
+                                        >Quantity</th>
+                                        <th
+                                            name="th_price_unit"
+                                            class="text-right"
+                                        >Price unit</th>
+                                        <th
+                                            name="th_recurring_interval"
+                                            class="text-right"
+                                        >Recurrence</th>
+                                        <th
+                                            name="th_recurring_next_date"
+                                            class="text-right"
+                                        >Date of next invoice</th>
                                     </tr>
                                 </thead>
                                 <tbody class="contract_tbody">
@@ -212,10 +228,22 @@
                                         t-as="line"
                                     >
                                         <tr>
-                                            <td id="line_name">
+                                            <td name="td_name">
                                                 <span t-field="line.name" />
                                             </td>
-                                            <td class="text-right">
+                                            <td name="td_quantity" class="text-right">
+                                                <span t-field="line.quantity" />
+                                            </td>
+                                            <td name="td_price_unit" class="text-right">
+                                                <span
+                                                    t-field="line.price_unit"
+                                                    t-options='{"widget": "monetary", "display_currency": contract.currency_id}'
+                                                />
+                                            </td>
+                                            <td
+                                                name="td_recurring_interval"
+                                                class="text-right"
+                                            >
                                                 <span
                                                     t-field="line.recurring_interval"
                                                 />
@@ -241,14 +269,12 @@
                                                     t-if="line.recurring_rule_type=='yearly'"
                                                 >Year(s)</t>
                                             </td>
-                                            <td class="text-right">
+                                            <td
+                                                name="td_recurring_next_date"
+                                                class="text-right"
+                                            >
                                                 <span
                                                     t-field="line.recurring_next_date"
-                                                />
-                                            </td>
-                                            <td class="text-right">
-                                                <span
-                                                    t-field="line.last_date_invoiced"
                                                 />
                                             </td>
                                         </tr>


### PR DESCRIPTION
Related to 12.0: https://github.com/OCA/contract/pull/596

Changes in contract page (portal).
- Add quantity (line)
- Add price unit (line)
- Remove Last date invoice (line) It's not necessary in portal.

Please @pedrobaeza and @carlosdauden review it.
@Tecnativa TT27579