### PR TITLE
[12.0][FIX] contract: Incorrect product UOM qty dict key for the sale…

### DIFF
--- a/contract_sale_generation/models/contract_line.py
+++ b/contract_sale_generation/models/contract_line.py
@@ -15,7 +15,7 @@ class ContractLine(models.Model):
         )
         sale_line_vals = {
             'product_id': self.product_id.id,
-            'quantity': self._get_quantity_to_invoice(*dates),
+            'product_uom_qty': self._get_quantity_to_invoice(*dates),
             'uom_id': self.uom_id.id,
             'discount': self.discount,
             'contract_line_id': self.id,


### PR DESCRIPTION
….order.line

The product UOM qty was not correctly set on the Sale Order Line
During the creation of a recurring Order from a Contract, the given quantity on the Contract Line was not correctly set on the created Sale Order Line.