### PR TITLE
[13.0] [FIX] variable quantity view

### DIFF
--- a/contract_variable_quantity/views/contract.xml
+++ b/contract_variable_quantity/views/contract.xml
@@ -25,6 +25,24 @@
                     name="attrs"
                 >{'invisible': [('qty_type', '!=', 'fixed')]}</attribute>
             </xpath>
+            <xpath
+                expr="//field[@name='contract_line_fixed_ids']/tree/field[@name='quantity']"
+                position="before"
+            >
+                <field name="qty_type" />
+                <field
+                    name="qty_formula_id"
+                    attrs="{'invisible': [('qty_type', '!=', 'variable')]}"
+                />
+            </xpath>
+            <xpath
+                expr="//field[@name='contract_line_fixed_ids']/tree/field[@name='quantity']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': [('qty_type', '!=', 'fixed')]}</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
As in version 13.0 we have two fields to show recurring lines, we need to add variable quantity type in both views.

I checked in runbot, checking recurring by line works right

![image](https://user-images.githubusercontent.com/6750341/106392879-29d61c80-63f4-11eb-8504-93a32f2b8633.png)

But without this check, it does not work right

![image](https://user-images.githubusercontent.com/6750341/106392940-630e8c80-63f4-11eb-88de-874507cc1893.png)
