### PR TITLE
[FIX] contract: function _get_partner_contract_domain of res.partner

### DIFF
--- a/contract/models/res_partner.py
+++ b/contract/models/res_partner.py
@@ -22,7 +22,6 @@ class ResPartner(models.Model):
     )
 
     def _get_partner_contract_domain(self):
-        self.ensure_one()
         return [("partner_id", "child_of", self.ids)]
 
     def _compute_contract_count(self):


### PR DESCRIPTION
We will get singleton Error, if the function _compute_contract_count calculates the contract count for more partners.