### PR TITLE
[13.0][FIX] contract: Align contract line form view to inline behaviour

### DIFF
--- a/contract/views/abstract_contract_line.xml
+++ b/contract/views/abstract_contract_line.xml
@@ -16,11 +16,7 @@
                         col="4"
                         attrs="{'invisible': [('display_type', '!=', False)]}"
                     >
-                        <field
-                            colspan="4"
-                            name="product_id"
-                            attrs="{'required': [('display_type', '=', False)]}"
-                        />
+                        <field colspan="4" name="product_id" />
                         <label for="quantity" />
                         <div class="o_row">
                             <field name="quantity" class="oe_inline" />
@@ -28,7 +24,6 @@
                                 name="uom_id"
                                 class="oe_inline"
                                 groups="uom.group_uom"
-                                attrs="{'required': [('display_type', '=', False)]}"
                             />
                         </div>
                         <field colspan="2" name="automatic_price" />


### PR DESCRIPTION
When editing contract line in inline mode, product is not mandatory (and should stay as is). Adapt form view as in that one, product is mandatory (and should not)