### PR TITLE
[12.0][IMP] product_contract: Implements parameter to define the quantity (one or sale_order_line.product_uom_qty)

### DIFF
--- a/product_contract/models/res_company.py
+++ b/product_contract/models/res_company.py
@@ -12,3 +12,16 @@ class ResCompany(models.Model):
         string="Automatically Create Contracts At Sale Order Confirmation",
         default=True,
     )
+
+    standard_quantity_for_creation_contract_by_sale_order = fields.Selection(
+        string="Standard Quantity For Contract Creation By Sales Order",
+        selection=[
+            ('one', 'Create contracts with quantity equal to 1'),
+            ('sale_order_line', 'Create contracts with quantity from the sales '
+                                'order line.'),
+        ],
+        help='One: Create contracts with quantity equal to 1\n'
+             'Sale Order Line: Create contracts with quantity from the sales '
+             'order line.',
+        default="one",
+    )

--- a/product_contract/models/res_config_settings.py
+++ b/product_contract/models/res_config_settings.py
@@ -12,3 +12,8 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.create_contract_at_sale_order_confirmation",
         readonly=False
     )
+
+    standard_quantity_for_creation_contract_by_sale_order = fields.Selection(
+        related="company_id.standard_quantity_for_creation_contract_by_sale_order",
+        readonly=False
+    )

--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -148,8 +148,17 @@ class SaleOrderLine(models.Model):
         #   automatic invoicing of the actual hours through a variable
         #   quantity formula, in which case the quantity on the contract
         #   line is not used
+        # However, there are other cases in which the quantity must be equal
+        # to the quantity of the product in the sales order line:
+        # - quantity on the SO line = Number of contracted users.
         # Other use cases are easy to implement by overriding this method.
-        return 1.0
+        company_id = self.order_id.company_id
+        qty_standard = company_id.standard_quantity_for_creation_contract_by_sale_order
+        if qty_standard == 'sale_order_line':
+            quantity = self.product_uom_qty
+        else:
+            quantity = 1.0
+        return quantity
 
     @api.multi
     def _prepare_contract_line_values(

--- a/product_contract/readme/CONTRIBUTORS.rst
+++ b/product_contract/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
 
   * Ernesto Tejeda
   * Pedro M. Baeza
+* `Escodoo <https://www.escodoo.com.br>`__:
+
+  * Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+

--- a/product_contract/views/res_config_settings.xml
+++ b/product_contract/views/res_config_settings.xml
@@ -23,6 +23,19 @@
                         </div>
                     </div>
                 </div>
+                <div class="col-12 col-lg-6 o_setting_box" id="invoicing_policy_setting" title="The mode selected here applies when the contract is created by the sales order.">
+                    <div class="o_setting_right_pane">
+                        <span class="o_form_label">Standard Quantity For Contract Creation</span>
+                        <div class="text-muted">
+                            Standard quantity for contract creation by sales order
+                        </div>
+                        <div class="content-group">
+                            <div class="mt16">
+                                <field name="standard_quantity_for_creation_contract_by_sale_order" class="o_light_label" widget="radio"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Implements parameter to define the quantity that should be used in the creation of a recurring contract.

![image](https://user-images.githubusercontent.com/3595132/119278223-45ab3b80-bbfa-11eb-961d-6672058d34b8.png)
