### PR TITLE
[14.0][FIX] contract: Force add access_token in **View contract** button from contract modification mail

### DIFF
--- a/contract/data/mail_template.xml
+++ b/contract/data/mail_template.xml
@@ -91,6 +91,16 @@
     >
         <xpath expr="//t[@t-raw='message.body']" position="after">
             <t t-raw="0" />
+            <t t-if="record._name == 'contract.contract'">
+                <t
+                    t-set="share_url"
+                    t-value="record._get_share_url(redirect=True, signup_partner=True, share_token=True)"
+                />
+                <t
+                    t-set="access_url"
+                    t-value="is_online and share_url and base_url + share_url or ''"
+                />
+            </t>
         </xpath>
     </template>
     <template id="template_contract_modification" name="Contract Modification">


### PR DESCRIPTION
Force add `access_token` in **View contract** button from contract modification mail.

FWP from 13.0: https://github.com/OCA/contract/pull/680

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT29820
