### PR TITLE
[12.0][IMP] contract_forecast: imp subtotal price in company currency and others

### DIFF
--- a/contract_forecast/__manifest__.py
+++ b/contract_forecast/__manifest__.py
@@ -15,6 +15,7 @@
         "views/res_config_settings.xml",
         "views/contract_line_forecast_period.xml",
         "views/contract.xml",
+        "data/contract_forecast_cron.xml"
     ],
     "external_dependencies": {"python": ["dateutil"]},
     "post_init_hook": "post_init_hook",

--- a/contract_forecast/data/contract_forecast_cron.xml
+++ b/contract_forecast/data/contract_forecast_cron.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<odoo noupdate="1">
+
+    <record model="ir.cron" id="contract_forecast_cron_generate_all_forecast_periods">
+        <field name="name">Generate Contract Forecast Periods</field>
+        <field name="model_id" ref="model_contract_line"/>
+        <field name="state">code</field>
+        <field name="code">model.cron_generate_all_forecast_periods()</field>
+        <field name="user_id" ref="base.user_root" />
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall" />
+    </record>
+
+</odoo>

--- a/contract_forecast/models/contract_line.py
+++ b/contract_forecast/models/contract_line.py
@@ -147,3 +147,15 @@ class ContractLine(models.Model):
                 if rec.contract_id.company_id.enable_contract_forecast:
                     rec.with_delay()._generate_forecast_periods()
         return res
+
+    @api.model
+    def cron_generate_all_forecast_periods(self):
+        offset = 0
+        while True:
+            contract_lines = self.search(
+                [('is_canceled', '=', False)], limit=100, offset=offset
+            )
+            contract_lines.with_delay()._generate_forecast_periods()
+            if len(contract_lines) < 100:
+                break
+            offset += 100

--- a/contract_forecast/models/contract_line_forecast_period.py
+++ b/contract_forecast/models/contract_line_forecast_period.py
@@ -55,6 +55,13 @@ class ContractLineForecastPeriod(models.Model):
         compute='_compute_price_subtotal',
         store=True
     )
+    price_subtotal_signed = fields.Float(
+        digits=dp.get_precision("Account"),
+        string='Amount Untaxed Signed',
+        compute='_compute_price_subtotal',
+        store=True,
+        help="Amount Untaxed, negative for purchase."
+    )
     discount = fields.Float(
         string='Discount (%)',
         digits=dp.get_precision('Discount'),
@@ -62,16 +69,76 @@ class ContractLineForecastPeriod(models.Model):
         ' It should be less or equal to 100',
     )
     company_id = fields.Many2one(comodel_name="res.company", string="Company")
+    contract_type = fields.Selection(
+        string='Contract Type',
+        readonly=True,
+        related="contract_id.contract_type",
+        store=True,
+        index=True,
+    )
+    currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        string="Currency",
+        readonly=True,
+        related="contract_line_id.contract_id.currency_id",
+        store=True,
+        index=True,
+    )
+    company_currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        string="Company Currency",
+        related='company_id.currency_id',
+        readonly=True
+    )
+    currency_rate = fields.Float(
+        string='Currency Rate',
+        readonly=True,
+        group_operator="avg",
+        compute='_compute_price_subtotal',
+        groups="base.group_multi_currency",
+        store=True
+    )
+    price_subtotal_company = fields.Monetary(
+        string='Amount Untaxed in Company Currency',
+        currency_field='company_currency_id',
+        store=True,
+        readonly=True,
+        compute='_compute_price_subtotal',
+        help="Amount Untaxed in the currency of the company."
+    )
+    price_subtotal_company_signed = fields.Monetary(
+        string='Amount Untaxed Signed in Company Currency',
+        currency_field='company_currency_id',
+        store=True,
+        readonly=True,
+        compute='_compute_price_subtotal',
+        help="Amount Untaxed Signed in the currency of the company, "
+             "negative for purchase."
+    )
 
     @api.multi
     @api.depends('quantity', 'price_unit', 'discount')
     def _compute_price_subtotal(self):
         for line in self:
+            sign = line.contract_type in ['purchase'] and -1 or 1
             subtotal = line.quantity * line.price_unit
             discount = line.discount / 100
             subtotal *= 1 - discount
-            if line.contract_id.pricelist_id:
-                cur = line.contract_id.pricelist_id.currency_id
+            line.price_subtotal_signed = subtotal * sign
+            line.price_subtotal_company_signed = line.price_subtotal_signed
+            if (line.currency_id and line.company_id and
+                    line.currency_id != line.company_id.currency_id):
+                cur = line.currency_id
                 line.price_subtotal = cur.round(subtotal)
+                line.price_subtotal_signed = cur.round(line.price_subtotal_signed)
+                rate_date = line.date_invoice or fields.Date.today()
+                line.price_subtotal_company = cur._convert(
+                    line.price_subtotal,
+                    line.company_id.currency_id,
+                    line.company_id, rate_date)
+                line.price_subtotal_company_signed = line.price_subtotal_company * sign
+                line.currency_rate = (line.price_subtotal_signed
+                                      / line.price_subtotal_company_signed) or False
             else:
                 line.price_subtotal = subtotal
+                line.currency_rate = 1

--- a/contract_forecast/views/contract_line_forecast_period.xml
+++ b/contract_forecast/views/contract_line_forecast_period.xml
@@ -14,6 +14,12 @@
             <search>
                 <field name="contract_id" string="Contract"/>
                 <field name="company_id" groups="base.group_multi_company"/>
+                <filter string="Customer"
+                        domain="[('contract_type', '=', 'sale')]"
+                        name="customer"/>
+                <filter string="Supplier"
+                        domain="[('contract_type', '=', 'purchase')]"
+                        name="customer"/>
                 <group expand="0" string="Group By">
                     <filter string="Date Start" name="groupby_date_start"
                             context="{'group_by':'date_start'}"/>
@@ -21,6 +27,8 @@
                             context="{'group_by':'date_end'}"/>
                     <filter string="Date Invoice" name="groupby_date_invoice"
                             context="{'group_by':'date_invoice:day'}"/>
+                    <filter string="Type" name="groupby_type"
+                            context="{'group_by':'contract_type'}"/>
                 </group>
             </search>
         </field>
@@ -38,6 +46,9 @@
                 <field name="date_start"/>
                 <field name="date_end"/>
                 <field name="date_invoice"/>
+                <field name="price_subtotal_signed"/>
+                <field name="price_subtotal_company_signed" groups="base.group_multi_currency"/>
+                <field name="currency_rate" groups="base.group_multi_currency"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
@@ -50,9 +61,9 @@
         <field name="model">contract.line.forecast.period</field>
         <field name="arch" type="xml">
             <pivot string="Contract Forecast">
-                <field name="product_id" type="col"/>
+                <field name="contract_type" type="col"/>
                 <field name="date_invoice" type="row"/>
-                <field name="price_subtotal" type="measure"/>
+                <field name="price_subtotal_company_signed" type="measure"/>
             </pivot>
         </field>
     </record>
@@ -63,10 +74,10 @@
         </field>
         <field name="model">contract.line.forecast.period</field>
         <field name="arch" type="xml">
-            <graph string="Contract Forecast">
-                <field name="product_id" type="col"/>
+            <graph string="Contract Forecast" type="bar" stacked="1">
                 <field name="date_invoice" type="row"/>
-                <field name="price_subtotal" type="measure"/>
+                <field name="contract_type" type="col"/>
+                <field name="price_subtotal_company_signed" type="measure"/>
             </graph>
         </field>
     </record>


### PR DESCRIPTION
I'm working on the contract_forecast module and felt some difficulties when it comes to contracts in different currencies. So, I made some implementations and I would like the review of the other members.

These are some proposed changes:
- [X] field price_subtotal_company
- [X] field price_subtotal_signed
- [X] field price_subtotal_company_signed
- [X] field contract_type
- [X] field currency_id
- [X] field company_currency_id
- [X] field currency_rate
- [X] Refactoring _compute_price_subtotal method
- [X] Refactoring Contract Forecast Views
- [X] Include a disabled Cron Job to update contract forecast periods (Useful when there is a change in the exchange rate)
- [ ] Tests

cc @mileo @rvalyi 