### PR TITLE
[14.0][FIX] contract: Defensive patch when next date is in the past

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -606,8 +606,10 @@ class ContractLine(models.Model):
         lang = lang_obj.search([("code", "=", self.contract_id.partner_id.lang)])
         date_format = lang.date_format or "%m/%d/%Y"
         name = self.name
-        name = name.replace("#START#", first_date_invoiced.strftime(date_format))
-        name = name.replace("#END#", last_date_invoiced.strftime(date_format))
+        if first_date_invoiced:
+            name = name.replace("#START#", first_date_invoiced.strftime(date_format))
+        if last_date_invoiced:
+            name = name.replace("#END#", last_date_invoiced.strftime(date_format))
         return name
 
     def _update_recurring_next_date(self):


### PR DESCRIPTION
if the recurring next date is in the past then the last_date_invoiced is returned as False there :+1: https://github.com/OCA/contract/blob/14.0/contract/models/contract_recurrency_mixin.py#L185 so the strftime failed.

If in any way the cron couldn't vee executed the nx date could be in the past.

This trivial  patch prevent this kind of issue.