### PR TITLE
[13.0][FIX] contract: Cleanup values on line when invoicing

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -516,7 +516,9 @@ class ContractContract(models.Model):
                 invoice_line_vals = line._prepare_invoice_line(move_form=move_form)
                 if invoice_line_vals:
                     # Allow extension modules to return an empty dictionary for
-                    # nullifying line
+                    # nullifying line. We should then cleanup certain values.
+                    del invoice_line_vals["company_id"]
+                    del invoice_line_vals["company_currency_id"]
                     invoice_vals["invoice_line_ids"].append((0, 0, invoice_line_vals))
             invoices_values.append(invoice_vals)
             # Force the recomputation of journal items


### PR DESCRIPTION
It seems that having several fields returned by `Form` as `False` that are related to one2many inverse field, makes Odoo ORM mad, and get to an unbalanced move when generating the invoice.

Cleaning these values assures to work without problems.

Not able to provide a regression test, as I don't get to reproduce the conditions to happen in test environment, but the patch is safe and harmless anyways.

@Tecnativa TT30842