### PR TITLE
[12.0][IMP] product_contract: termination_notice_interval on sale_order form

### DIFF
--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -68,6 +68,14 @@ class SaleOrderLine(models.Model):
         string='Renewal type',
         help="Specify Interval for automatic renewal.",
     )
+    termination_notice_interval = fields.Integer(
+        default=1, string='Termination Notice Before'
+    )
+    termination_notice_rule_type = fields.Selection(
+        [('daily', 'Day(s)'), ('weekly', 'Week(s)'), ('monthly', 'Month(s)')],
+        default='monthly',
+        string='Termination Notice type',
+    )
 
     @api.constrains('contract_id')
     def check_contact_is_not_terminated(self):
@@ -128,6 +136,12 @@ class SaleOrderLine(models.Model):
                     rec.auto_renew_rule_type = (
                         rec.product_id.auto_renew_rule_type
                     )
+                    rec.termination_notice_interval = (
+                        rec.product_id.termination_notice_interval
+                    )
+                    rec.termination_notice_rule_type = (
+                        rec.product_id.termination_notice_rule_type
+                    )
 
     @api.onchange('date_start', 'product_uom_qty', 'recurring_rule_type')
     def onchange_date_start(self):
@@ -169,12 +183,6 @@ class SaleOrderLine(models.Model):
             self.recurring_rule_type,
             1,
         )
-        termination_notice_interval = (
-            self.product_id.termination_notice_interval
-        )
-        termination_notice_rule_type = (
-            self.product_id.termination_notice_rule_type
-        )
         return {
             'sequence': self.sequence,
             'product_id': self.product_id.id,
@@ -192,8 +200,8 @@ class SaleOrderLine(models.Model):
             'is_auto_renew': self.is_auto_renew,
             'auto_renew_interval': self.auto_renew_interval,
             'auto_renew_rule_type': self.auto_renew_rule_type,
-            'termination_notice_interval': termination_notice_interval,
-            'termination_notice_rule_type': termination_notice_rule_type,
+            'termination_notice_interval': self.termination_notice_interval,
+            'termination_notice_rule_type': self.termination_notice_rule_type,
             'contract_id': contract.id,
             'sale_order_line_id': self.id,
             'predecessor_contract_line_id': predecessor_contract_line_id,

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -84,6 +84,18 @@
                                attrs="{'required':[('is_auto_renew', '=', True)]}"/>
                     </div>
                 </group>
+                <group
+                    attrs="{'invisible':[('is_auto_renew', '=', False)]}">
+                    <label for="termination_notice_interval"/>
+                    <div>
+                        <field name="termination_notice_interval"
+                               class="oe_inline" nolabel="1"
+                               attrs="{'required':[('is_auto_renew', '=', True)]}"/>
+                        <field name="termination_notice_rule_type"
+                               class="oe_inline" nolabel="1"
+                               attrs="{'required':[('is_auto_renew', '=', True)]}"/>
+                    </div>
+                </group>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree//field[@name='price_total']"
                    position="after">


### PR DESCRIPTION
This PR changes the module's behavior to allow that via sales order it is possible to change the default value of the termination_notice_interval and termination_notice_rule_type fields that come from the product.

Makes sense ?