### PR TITLE
[14.0][FIX] contract: fix an obvious crash when self is a multi-recordset

### DIFF
--- a/contract/models/res_partner.py
+++ b/contract/models/res_partner.py
@@ -24,7 +24,6 @@ class ResPartner(models.Model):
     )
 
     def _get_partner_contract_domain(self):
-        self.ensure_one()
         return [("partner_id", "child_of", self.ids)]
 
     def _compute_contract_count(self):


### PR DESCRIPTION
_compute_contract_count() is an api.multi
It calls self._get_partner_contract_domain(), so you can't have self.ensure_one() in there !!!
Quite an obvious bug.