### PR TITLE
[13.0][FIX] contract: Fix invoice creation and salesperson assignment

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -411,7 +411,7 @@ class ContractContract(models.Model):
                 "invoice_date": date_invoice,
                 "journal_id": journal.id,
                 "invoice_origin": self.name,
-                "user_id": self.user_id.id,
+                "invoice_user_id": self.user_id.id,
             }
         )
         return invoice_vals, move_form

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -300,6 +300,18 @@ class TestContract(TestContractBase):
         self.assertTrue(invoice_daily)
         self.assertTrue(self.contract.partner_id in invoice_daily.message_partner_ids)
 
+    def test_contract_invoice_salesperson(self):
+        self.acct_line.recurring_next_date = "2018-02-23"
+        self.acct_line.recurring_rule_type = "daily"
+        new_salesperson = self.env["res.users"].create(
+            {"name": "Some Salesperson", "login": "salesperson_test"}
+        )
+        self.contract.user_id = new_salesperson
+        self.contract._recurring_create_invoice()
+        invoice_daily = self.contract._get_related_invoices()
+        self.assertTrue(invoice_daily)
+        self.assertEquals(self.contract.user_id, invoice_daily.user_id)
+
     def test_contract_weekly_post_paid(self):
         recurring_next_date = to_date("2018-03-01")
         last_date_invoiced = to_date("2018-02-21")


### PR DESCRIPTION
In v13, the `user_id` field is a related field to `invoice_user_id` (https://github.com/odoo/odoo/blob/13.0/addons/account/models/account_move.py#L191), that defaults to the environment user (`self.env.user`).
Therefore, if we try to create an invoice just by passing `user_id`, it is overwritten by the default computation of `invoice_user_id`.
This fixes it by passing the correct field and data.

@Tecnativa
TT31715

ping @pedrobaeza @victoralmau 