### PR TITLE
[13.0][FIX] agreement_legal: Fix JS var declaration

### DIFF
--- a/agreement_legal/static/src/js/domain_widget_ext.js
+++ b/agreement_legal/static/src/js/domain_widget_ext.js
@@ -39,8 +39,10 @@ odoo.define("agreement_legal.domain_widget_ext", function(require) {
 
             // Create the domain selector or change the value of the current
             // one...
-            /* eslint-disable no-negated-condition */
-            if (!this.domainSelector) {
+            var def = null;
+            if (this.domainSelector) {
+                def = this.domainSelector.setDomain(value);
+            } else {
                 this.domainSelector = new DomainSelector(
                     this,
                     this._domainModel,
@@ -52,12 +54,9 @@ odoo.define("agreement_legal.domain_widget_ext", function(require) {
                         partialUse: this.partialUse || false,
                     }
                 );
-                const def = this.domainSelector.prependTo(this.$el);
-            } else {
-                const def = this.domainSelector.setDomain(value);
+                def = this.domainSelector.prependTo(this.$el);
             }
             // ... then replace the other content (matched records, etc)
-            // eslint-disable-next-line no-undef
             return def.then(this._replaceContent.bind(this));
         },
         /**


### PR DESCRIPTION
Was causing UI errors in several parts.

**To reproduce:**
1. Go to Agreements and create one.
2. You will see an UI error: 
```
Traceback:
Error: def is not defined
_render@http://odoo13.127.0.0.1.sslip.io:13069/web/content/572-10eb302/web.assets_backend.js:3236:1
start/<@http://odoo13.127.0.0.1.sslip.io:13069/web/content/572-10eb302/web.assets_backend.js:821:1408
```

@Tecnativa
TT32294

ping @pedrobaeza @Tardo 