### PR TITLE
[13.0][FIX] contract: security group_account_invoice

### DIFF
--- a/contract/security/contract_security.xml
+++ b/contract/security/contract_security.xml
@@ -40,4 +40,16 @@
             name="domain_force"
         >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
     </record>
+    <!-- For the sake of the OCA ecosystem, please do not remove this rule, as
+       it is used in other modules as contract_sale and maintenance_equipment_contract-->
+    <record id="contract_contract_see_all" model="ir.rule">
+        <field name="name">See All Contracts</field>
+        <field name="model_id" ref="contract.model_contract_contract" />
+        <field name="domain_force">[(1,'=',1)]</field>
+        <field
+            name="groups"
+            eval="[
+            (4,ref('account.group_account_invoice'))]"
+        />
+    </record>
 </odoo>

--- a/contract_sale/security/contract_security.xml
+++ b/contract_sale/security/contract_security.xml
@@ -15,8 +15,7 @@
         <field
             name="groups"
             eval="[
-            (4,ref('sales_team.group_sale_salesman_all_leads')),
-            (4,ref('account.group_account_invoice'))]"
+            (4,ref('sales_team.group_sale_salesman_all_leads'))]"
         />
     </record>
 </odoo>


### PR DESCRIPTION
In this PR, the permission given to the gruoup_account_invoice in security is changed from the "contract_sale" module to the "contract" module. If the two modules were installed, it worked perfectly. The problem came if you only had installed the contract module. In this case, the group_account_invoice could not view contracts. So I just changed the security to the more general "contract" module.