### PR TITLE
[IMP] agreement_legal: Improve management of end dates

### DIFF
--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -96,6 +96,7 @@ class Agreement(models.Model):
         tracking=True,
         help="Date that the contract was terminated.",
     )
+    no_end_date = fields.Boolean(related="agreement_type_id.no_end_date")
     reviewed_date = fields.Date(string="Reviewed Date", tracking=True)
     reviewed_user_id = fields.Many2one("res.users", string="Reviewed By", tracking=True)
     approved_date = fields.Date(string="Approved Date", tracking=True)

--- a/agreement_legal/models/agreement_type.py
+++ b/agreement_legal/models/agreement_type.py
@@ -8,6 +8,7 @@ class AgreementType(models.Model):
     _inherit = "agreement.type"
     _description = "Agreement Types"
 
+    no_end_date = fields.Boolean(default=False)
     agreement_subtypes_ids = fields.One2many(
         "agreement.subtype", "agreement_type_id", string="Sub-Types"
     )

--- a/agreement_legal/views/agreement.xml
+++ b/agreement_legal/views/agreement.xml
@@ -225,7 +225,7 @@
                             />
                             <field
                                 name="end_date"
-                                attrs="{'required': [('is_template', '=', False)], 'invisible': [('is_template', '=', True)]}"
+                                attrs="{'required': [('is_template', '=', False), ('no_end_date', '=', False)], 'invisible': [('is_template', '=', True)]}"
                             />
                             <field name="expiration_notice" />
                             <field name="change_notice" />
@@ -235,6 +235,7 @@
                             />
                             <field name="termination_requested" />
                             <field name="termination_date" />
+                            <field name="no_end_date" invisible="1" />
                         </group>
                     </group>
                     <group string="Special Terms">

--- a/agreement_legal/views/agreement_type.xml
+++ b/agreement_legal/views/agreement_type.xml
@@ -7,6 +7,7 @@
         <field name="inherit_id" ref="agreement.agreement_type_list_view" />
         <field name="arch" type="xml">
             <field name="name" position="after">
+                <field name="no_end_date" />
                 <field name="agreement_subtypes_ids" widget="many2many_tags" />
             </field>
         </field>
@@ -17,6 +18,9 @@
         <field name="model">agreement.type</field>
         <field name="inherit_id" ref="agreement.agreement_type_form_view" />
         <field name="arch" type="xml">
+            <xpath expr="//group[@name='main']" position="inside">
+                <field name="no_end_date" />
+            </xpath>
             <xpath expr="//sheet" position="inside">
                 <field name="agreement_subtypes_ids" nolabel="1">
                     <tree editable="bottom">


### PR DESCRIPTION
Working with the module we found we can have agreements without end date. For example, when we make an agreement for a designation, no end date is defined.

With this change, we can specify if the field is required on the agreement type