### PR TITLE
[13.0][IMP+OU-ADD] agreement_legal: Replace the created_by + date_created fields + Openupgrade convert_binary_field_to_attachment 

### DIFF
--- a/agreement_legal/migrations/13.0.1.0.0/post-migration.py
+++ b/agreement_legal/migrations/13.0.1.0.0/post-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from openupgradelib import openupgrade, openupgrade_90
+
+attachment_fields = {
+    "agreement": [("signed_contract", None)],
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade_90.convert_binary_field_to_attachment(env, attachment_fields)

--- a/agreement_legal/migrations/13.0.1.0.0/pre-migration.py
+++ b/agreement_legal/migrations/13.0.1.0.0/pre-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+column_renames = {
+    "agreement": [("signed_contract", None)],
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, column_renames)

--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -208,6 +208,12 @@ class Agreement(models.Model):
         "agreement is an amendment to another agreement. This list will "
         "only show other agreements related to the same account.",
     )
+    create_uid_parent = fields.Many2one(
+        related="parent_agreement_id.create_uid", string="Created by (parent)"
+    )
+    create_date_parent = fields.Datetime(
+        related="parent_agreement_id.create_date", string="Created on (parent)"
+    )
     recital_ids = fields.One2many(
         "agreement.recital", "agreement_id", string="Recitals", copy=True
     )
@@ -276,19 +282,6 @@ class Agreement(models.Model):
         string="Placeholder Expression",
         help="""Final placeholder expression, to be copy-pasted in the desired
          template field.""",
-    )
-    created_by = fields.Many2one(
-        "res.users",
-        string="Created By",
-        copy=False,
-        default=lambda self: self.env.user,
-        help="User which create the agreement.",
-    )
-    date_created = fields.Datetime(
-        string="Created On",
-        copy=False,
-        default=lambda self: fields.Datetime.now(),
-        help="Date which create the agreement.",
     )
     template_id = fields.Many2one(
         "agreement", string="Template", domain=[("is_template", "=", True)],
@@ -378,8 +371,6 @@ class Agreement(models.Model):
             "parent_agreement_id": self.id,
             "version": self.version,
             "revision": self.revision,
-            "created_by": self.created_by.id,
-            "date_created": self.date_created,
             "code": "{}-V{}".format(self.code, str(self.version)),
             "stage_id": self.stage_id.id,
         }
@@ -394,13 +385,7 @@ class Agreement(models.Model):
             # Make a current copy and mark it as old
             rec.copy(default=rec._get_old_version_default_vals())
             # Update version, created by and created on
-            rec.update(
-                {
-                    "version": rec.version + 1,
-                    "created_by": self.env.user.id,
-                    "date_created": fields.Datetime.now(),
-                }
-            )
+            rec.update({"version": rec.version + 1})
             # Reset revision to 0 since it's a new version
         return super().write({"revision": 0})
 

--- a/agreement_legal/views/agreement.xml
+++ b/agreement_legal/views/agreement.xml
@@ -365,8 +365,27 @@
                             name="revision"
                             readonly="True"
                         />
-                        |  Created By: <field name="created_by" readonly="True" />
-                        |  Created On: <field name="date_created" readonly="True" />
+                        |  Created By:
+                        <field
+                            name="create_uid"
+                            readonly="True"
+                            attrs="{'invisible': [('parent_agreement_id', '!=', False)]}"
+                        />
+                        <field
+                            name="create_uid_parent"
+                            attrs="{'invisible': [('parent_agreement_id', '=', False)]}"
+                        />
+                        |  Created On:
+                        <field
+                            name="create_date"
+                            readonly="True"
+                            attrs="{'invisible': [('parent_agreement_id', '!=', False)]}"
+                        />
+                        <field
+                            name="create_date_parent"
+                            readonly="True"
+                            attrs="{'invisible': [('parent_agreement_id', '=', False)]}"
+                        />
                     </p>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
Changes done:
- [IMP] The created_by + date_created fields are removed and will be displayed in the view create_uid + create_date or related fields (create_uid_parent + create_date_parent). https://github.com/OCA/contract/pull/726
- [OU-ADD] Openupgrade convert_binary_field_to_attachment 

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT32469