### PR TITLE
[14.0][IMP] agreement_legal: Replace the created_by + date_created fields

### DIFF
--- a/agreement_legal/views/agreement.xml
+++ b/agreement_legal/views/agreement.xml
@@ -364,8 +364,27 @@
                             name="revision"
                             readonly="True"
                         />
-                        |  Created By: <field name="created_by" readonly="True" />
-                        |  Created On: <field name="date_created" readonly="True" />
+                        |  Created By:
+                        <field
+                            name="create_uid"
+                            readonly="True"
+                            attrs="{'invisible': [('parent_agreement_id', '!=', False)]}"
+                        />
+                        <field
+                            name="create_uid_parent"
+                            attrs="{'invisible': [('parent_agreement_id', '=', False)]}"
+                        />
+                        |  Created On:
+                        <field
+                            name="create_date"
+                            readonly="True"
+                            attrs="{'invisible': [('parent_agreement_id', '!=', False)]}"
+                        />
+                        <field
+                            name="create_date_parent"
+                            readonly="True"
+                            attrs="{'invisible': [('parent_agreement_id', '=', False)]}"
+                        />
                     </p>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/contract/pull/733

The created_by + date_created fields are removed and will be displayed in the view create_uid + create_date or related fields (create_uid_parent + create_date_parent). https://github.com/OCA/contract/pull/726

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT32469