### PR TITLE
[13.0][IMP] agreement_legal: Define warning days cron and filter

### DIFF
--- a/agreement_legal/__manifest__.py
+++ b/agreement_legal/__manifest__.py
@@ -14,6 +14,7 @@
     "version": "13.0.2.4.1",
     "depends": ["contacts", "agreement", "product"],
     "data": [
+        "data/cron.xml",
         "data/ir_sequence.xml",
         "data/agreement_stage.xml",
         "data/agreement_type.xml",

--- a/agreement_legal/data/cron.xml
+++ b/agreement_legal/data/cron.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+    <!-- Add warning days -->
+    <record id="mail_activity_review_agreement" model="mail.activity.type">
+        <field name="name">Agreement needs a review</field>
+        <field name="summary">note</field>
+        <field name="category">default</field>
+        <field name="res_model_id" ref="model_agreement" />
+        <field name="icon">fa-tasks</field>
+        <field name="delay_count">0</field>
+    </record>
+    <!--Test warning days -->
+    <record model="ir.cron" forcecreate="True" id="ir_cron_test_acc_move_except">
+        <field name="name">Agreement: Check to Review Days</field>
+        <field name="model_id" ref="agreement_legal.model_agreement" />
+        <field name="state">code</field>
+        <field name="code">model._alert_to_review_date()</field>
+        <field name="user_id" ref="base.user_root" />
+        <field name="interval_number">20</field>
+        <field name="interval_type">minutes</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False" />
+        <field name="active" eval="True" />
+    </record>
+</odoo>

--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -3,6 +3,7 @@
 
 import ast
 import json as simplejson
+from datetime import timedelta
 
 from lxml import etree
 
@@ -288,6 +289,41 @@ class Agreement(models.Model):
         "agreement", string="Template", domain=[("is_template", "=", True)],
     )
     readonly = fields.Boolean(related="stage_id.readonly",)
+    to_review_date = fields.Date(
+        compute="_compute_to_review_date",
+        store=True,
+        readonly=False,
+        help="Date used to warn us some days before agreement expires",
+    )
+
+    @api.depends("agreement_type_id", "end_date")
+    def _compute_to_review_date(self):
+        for record in self:
+            if record.end_date:
+                record.to_review_date = record.end_date + timedelta(
+                    days=-record.agreement_type_id.review_days
+                )
+
+    @api.model
+    def _alert_to_review_date(self):
+        activities = self.search(
+            [
+                ("to_review_date", "=", fields.datetime.today()),
+                ("agreement_type_id.review_user_id", "!=", False),
+            ]
+        )
+        for activity in activities:
+            if (
+                self.env["mail.activity"].search_count(
+                    [("res_id", "=", activity.id), ("res_model", "=", "agreement")]
+                )
+                == 0
+            ):
+                activity.activity_schedule(
+                    "agreement_legal.mail_activity_review_agreement",
+                    user_id=activity.type_id.review_user_id.id,
+                    note=_("Your activity is going to end soon"),
+                )
 
     # compute the dynamic content for jinja expression
     def _compute_dynamic_description(self):

--- a/agreement_legal/models/agreement_type.py
+++ b/agreement_legal/models/agreement_type.py
@@ -12,3 +12,7 @@ class AgreementType(models.Model):
     agreement_subtypes_ids = fields.One2many(
         "agreement.subtype", "agreement_type_id", string="Sub-Types"
     )
+    review_user_id = fields.Many2one(
+        "res.users", help="User assigned automatically the activity on review date"
+    )
+    review_days = fields.Integer()

--- a/agreement_legal/views/agreement.xml
+++ b/agreement_legal/views/agreement.xml
@@ -227,6 +227,10 @@
                                 name="end_date"
                                 attrs="{'required': [('is_template', '=', False), ('no_end_date', '=', False)], 'invisible': [('is_template', '=', True)]}"
                             />
+                            <field
+                                name="to_review_date"
+                                attrs="{'required': [('is_template', '=', False), ('end_date', '!=', False)], 'invisible': [('is_template', '=', True)]}"
+                            />
                             <field name="expiration_notice" />
                             <field name="change_notice" />
                             <field
@@ -548,6 +552,11 @@
                     string="Active Activities"
                     domain="[('activity_ids.date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"
                     help="Show all activities which deadline is after today"
+                />
+                <filter
+                    name="filter_to_review"
+                    string="Agreements to review"
+                    domain="[('to_review_date', '&lt;=', context_today().strftime('%Y-%m-%d')), ('end_date', '&gt;=', context_today().strftime('%Y-%m-%d'))]"
                 />
                 <filter
                     name="group_partner_id"

--- a/agreement_legal/views/agreement_type.xml
+++ b/agreement_legal/views/agreement_type.xml
@@ -7,7 +7,6 @@
         <field name="inherit_id" ref="agreement.agreement_type_list_view" />
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="no_end_date" />
                 <field name="agreement_subtypes_ids" widget="many2many_tags" />
             </field>
         </field>
@@ -20,6 +19,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='main']" position="inside">
                 <field name="no_end_date" />
+                <field name="review_user_id" />
             </xpath>
             <xpath expr="//sheet" position="inside">
                 <field name="agreement_subtypes_ids" nolabel="1">


### PR DESCRIPTION
This change allows to define an activity automatically on a review date from the agreement. This date is computed automatically using the type, but we can edit to fulfill our specific needs.