### PR TITLE
[FIX]contract: Avoid error in invoicing contracts crone

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -646,6 +646,8 @@ class ContractContract(models.Model):
         for row in companies_to_invoice:
             contracts_to_invoice = self.search(row["__domain"]).with_context(
                 allowed_company_ids=[row["company_id"][0]]
+            ).filtered(
+                lambda a: not a.date_end or a.recurring_next_date <= a.date_end
             )
             invoices |= contracts_to_invoice._recurring_create_invoice(date_ref)
         return invoices


### PR DESCRIPTION
When date_end < recurring_next_date in a contract and the "Generate Recurring Invoices from Contracts" tries to generate a new invoice, there is an error that can be avoided filtering the contracts to invoice.