### PR TITLE
[IMP] agreement_legal: extend button

### DIFF
--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -390,6 +390,18 @@ class Agreement(models.Model):
             # Reset revision to 0 since it's a new version
         return super().write({"revision": 0})
 
+    # Create Extension Button: Copy
+    def create_extend_agreement(self):
+        self.ensure_one()
+        res = self.copy()
+        return {
+            "res_model": "agreement",
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "view_type": "form",
+            "res_id": res.id,
+        }
+
     def _get_new_agreement_default_vals(self):
         self.ensure_one()
         default_vals = {

--- a/agreement_legal/views/agreement.xml
+++ b/agreement_legal/views/agreement.xml
@@ -34,6 +34,12 @@
                         attrs="{'invisible': [('state', '=', 'active')]}"
                     />
                     <button
+                        string="Extend"
+                        type="object"
+                        name="create_extend_agreement"
+                        class="oe_highlight"
+                    />
+                    <button
                         string="New Agreement"
                         type="object"
                         name="create_new_agreement"


### PR DESCRIPTION
This button allows the user to create a copy.

This can be used in order to create an extension without losing the original one.