### PR TITLE
[13.0] Fixing multiple lines when creating invoices & Checking if values do exist before deletion

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -513,7 +513,7 @@ class ContractContract(models.Model):
             invoice_vals, move_form = contract._prepare_invoice(date_ref)
             invoice_vals["invoice_line_ids"] = []
             for line in contract_lines:
-                invoice_line_vals = line._prepare_invoice_line(move_form)
+                invoice_line_vals = line._prepare_invoice_line(move_form=move_form)
                 if invoice_line_vals:
                     # Allow extension modules to return an empty dictionary for
                     # nullifying line. We should then cleanup certain values.


### PR DESCRIPTION
The first change is checking if the values do exists or it will throw errors if they dont.
The second change is when creating from a contract with multiple lines they need to be treated as multiple values.