### PR TITLE
[15.0][IMP] contract: Add discount + price_subtotal fields to the contract lines in the portal view.

### DIFF
--- a/contract/views/contract_portal_templates.xml
+++ b/contract/views/contract_portal_templates.xml
@@ -213,6 +213,14 @@
                                             class="text-right"
                                         >Price unit</th>
                                         <th
+                                            name="th_discount"
+                                            class="text-right"
+                                        >Discount (%)</th>
+                                        <th
+                                            name="th_price_subtotal"
+                                            class="text-right"
+                                        >Sub Total</th>
+                                        <th
                                             name="th_recurring_interval"
                                             class="text-right"
                                         >Recurrence</th>
@@ -246,6 +254,21 @@
                                                 >
                                                     <span
                                                         t-field="line.price_unit"
+                                                        t-options='{"widget": "monetary", "display_currency": contract.currency_id}'
+                                                    />
+                                                </td>
+                                                <td
+                                                    name="td_discount"
+                                                    class="text-right"
+                                                >
+                                                    <span t-field="line.discount" />
+                                                </td>
+                                                <td
+                                                    name="td_price_subtotal"
+                                                    class="text-right"
+                                                >
+                                                    <span
+                                                        t-field="line.price_subtotal"
                                                         t-options='{"widget": "monetary", "display_currency": contract.currency_id}'
                                                     />
                                                 </td>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/contract/pull/778

Add discount + price_subtotal fields to the contract lines in the portal view.
![contract-info](https://user-images.githubusercontent.com/4117568/150986565-d1b7c336-fb24-44b0-9b5a-c063dce9bc41.png)

Please @CarlosRoca13 and @pedrobaeza can you review it?

@Tecnativa TT34117