### PR TITLE
[14.0][FIX] contract: Use same context signature as Odoo one

### DIFF
--- a/contract/models/abstract_contract_line.py
+++ b/contract/models/abstract_contract_line.py
@@ -201,7 +201,7 @@ class ContractAbstractContractLine(models.AbstractModel):
                         line.quantity,
                     ),
                     pricelist=pricelist.id,
-                    partner=line.contract_id.partner_id.id,
+                    partner=line.contract_id.partner_id,
                     date=line.env.context.get(
                         "old_date", fields.Date.context_today(line)
                     ),


### PR DESCRIPTION
In very particular conditions, if two 'with_context' calls are triggered in the same transaction, warnings are logged 'comparing apples and...'

I never succeeded reproduce it in tests but in interface.

The example is in sale generation:
 - A call to product_id_change that build a context there (partner is a recordset) : https://github.com/odoo/odoo/blob/14.0/addons/sale/models/sale.py#L1707
 - Then a call to (partner is an id): https://github.com/OCA/contract/blob/14.0/contract/models/abstract_contract_line.py#L204
 - Then a call to a third with_context

At the third one, Odoo look in existing environments  and compare each context field : https://github.com/odoo/odoo/blob/14.0/odoo/api.py#L451

So when comparing the two first contexts `<recordset> == <id>`