### PR TITLE
[13.0][FIX] Safe Deletion from dict

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -517,8 +517,8 @@ class ContractContract(models.Model):
                 if invoice_line_vals:
                     # Allow extension modules to return an empty dictionary for
                     # nullifying line. We should then cleanup certain values.
-                    del invoice_line_vals["company_id"]
-                    del invoice_line_vals["company_currency_id"]
+                    invoice_line_vals.pop("company_id", None)
+                    invoice_line_vals.pop("company_currency_id", None)
                     invoice_vals["invoice_line_ids"].append((0, 0, invoice_line_vals))
             invoices_values.append(invoice_vals)
             # Force the recomputation of journal items


### PR DESCRIPTION
using del dict[key] crashes if key isn't in dict. Since none of the previous code ensures that company_id or company_currency_id are with certainty in invoice_line_vals, it's a crashing risk. dict.pop(key, None) fixes that.