### PR TITLE
[14.0][FIX][contract] Set uom as relevant parameter to calculate price unit in automatic price mode

### DIFF
--- a/contract/models/abstract_contract_line.py
+++ b/contract/models/abstract_contract_line.py
@@ -182,6 +182,7 @@ class ContractAbstractContractLine(models.AbstractModel):
         "quantity",
         "contract_id.pricelist_id",
         "contract_id.partner_id",
+        "uom_id",
     )
     def _compute_price_unit(self):
         """Get the specific price if no auto-price, and the price obtained
@@ -205,6 +206,7 @@ class ContractAbstractContractLine(models.AbstractModel):
                     date=line.env.context.get(
                         "old_date", fields.Date.context_today(line)
                     ),
+                    uom=line.uom_id.id,
                 )
                 line.price_unit = product.price
             else:

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -2401,3 +2401,17 @@ class TestContract(TestContractBase):
         action = self.contract.action_preview()
         self.assertIn("/my/contracts/", action["url"])
         self.assertIn("access_token=", action["url"])
+
+    def test_automatic_price_with_specific_uom(self):
+        uom_hour = self.env.ref("uom.product_uom_hour")
+        uom_day = self.env.ref("uom.product_uom_day")
+        # Set automatic price on contract line
+        self.acct_line.automatic_price = True
+        # Check UOM from contract line and product and product price to be the same
+        self.assertEqual(self.product_1.uom_id, uom_hour)
+        self.assertEqual(self.acct_line.uom_id, uom_hour)
+        self.assertEqual(self.acct_line.price_unit, 30.75)
+        # Check UOM update and price in contract line
+        self.acct_line.uom_id = uom_day.id
+        self.acct_line.refresh()
+        self.assertEqual(self.acct_line.price_unit, 30.75 * 8)


### PR DESCRIPTION
Actually UOM is not used in calculation of price unit neither in automatic price mode.
I think this field is relevant to be used. If you change unit of measure, you want to show the price modified consequently.