### PR TITLE
[14.0][FIX] contract: fix compute_recurring_next_date for recurring_r…

### DIFF
--- a/contract/models/contract_recurrency_mixin.py
+++ b/contract/models/contract_recurrency_mixin.py
@@ -93,9 +93,16 @@ class ContractRecurrencyMixin(models.AbstractModel):
         string="Last Date Invoiced", readonly=True, copy=False
     )
 
-    @api.depends("next_period_date_start")
+    @api.depends(
+        "next_period_date_start",
+        "recurring_invoicing_type",
+        "recurring_rule_type",
+        "recurring_interval",
+    )
     def _compute_recurring_next_date(self):
         for rec in self:
+            if rec.recurring_rule_type == "monthlylastday":
+                rec.recurring_invoicing_type = "post-paid"
             rec.recurring_next_date = self.get_next_invoice_date(
                 rec.next_period_date_start,
                 rec.recurring_invoicing_type,

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -1814,7 +1814,7 @@ class TestContract(TestContractBase):
         self.assertEqual(last, to_date("2018-01-31"))
         self.assertEqual(recurring_next_date, to_date("2018-01-31"))
         self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-01-31"))
-        # monthlylastday with match with post-paid
+        # monthlylastday must match with post-paid
         # because in pre-paid the invoice date must be de fist of month
         self.assertEqual(self.acct_line.recurring_invoicing_type, "post-paid")
         self.contract.recurring_create_invoice()

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -293,8 +293,8 @@ class TestContract(TestContractBase):
     def test_contract_daily(self):
         recurring_next_date = to_date("2018-02-23")
         last_date_invoiced = to_date("2018-02-22")
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "daily"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.pricelist_id = False
         self.contract.recurring_create_invoice()
         invoice_daily = self.contract._get_related_invoices()
@@ -303,8 +303,8 @@ class TestContract(TestContractBase):
         self.assertEqual(self.acct_line.last_date_invoiced, last_date_invoiced)
 
     def test_contract_invoice_followers(self):
-        self.acct_line.recurring_next_date = "2018-02-23"
         self.acct_line.recurring_rule_type = "daily"
+        self.acct_line.recurring_next_date = "2018-02-23"
         self.contract.pricelist_id = False
         subtype_ids = self.contract.message_follower_ids.filtered(
             lambda x: self.contract.partner_id.id == x.partner_id.id
@@ -321,8 +321,8 @@ class TestContract(TestContractBase):
         self.assertTrue(self.contract.partner_id in invoice_daily.message_partner_ids)
 
     def test_contract_invoice_salesperson(self):
-        self.acct_line.recurring_next_date = "2018-02-23"
         self.acct_line.recurring_rule_type = "daily"
+        self.acct_line.recurring_next_date = "2018-02-23"
         new_salesperson = self.env["res.users"].create(
             {"name": "Some Salesperson", "login": "salesperson_test"}
         )
@@ -335,9 +335,9 @@ class TestContract(TestContractBase):
     def test_contract_weekly_post_paid(self):
         recurring_next_date = to_date("2018-03-01")
         last_date_invoiced = to_date("2018-02-21")
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "weekly"
         self.acct_line.recurring_invoicing_type = "post-paid"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.recurring_create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
@@ -347,9 +347,9 @@ class TestContract(TestContractBase):
     def test_contract_weekly_pre_paid(self):
         recurring_next_date = to_date("2018-03-01")
         last_date_invoiced = to_date("2018-02-28")
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "weekly"
         self.acct_line.recurring_invoicing_type = "pre-paid"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.recurring_create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
@@ -359,9 +359,9 @@ class TestContract(TestContractBase):
     def test_contract_yearly_post_paid(self):
         recurring_next_date = to_date("2019-02-22")
         last_date_invoiced = to_date("2018-02-21")
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "yearly"
         self.acct_line.recurring_invoicing_type = "post-paid"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.recurring_create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
@@ -372,9 +372,9 @@ class TestContract(TestContractBase):
         recurring_next_date = to_date("2019-02-22")
         last_date_invoiced = to_date("2019-02-21")
         self.acct_line.date_end = "2020-02-22"
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "yearly"
         self.acct_line.recurring_invoicing_type = "pre-paid"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.recurring_create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
@@ -384,9 +384,9 @@ class TestContract(TestContractBase):
     def test_contract_monthly_lastday(self):
         recurring_next_date = to_date("2018-02-28")
         last_date_invoiced = to_date("2018-02-22")
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_invoicing_type = "post-paid"
         self.acct_line.recurring_rule_type = "monthlylastday"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.recurring_create_invoice()
         invoices_monthly_lastday = self.contract._get_related_invoices()
         self.assertTrue(invoices_monthly_lastday)
@@ -397,9 +397,9 @@ class TestContract(TestContractBase):
         recurring_next_date = to_date("2018-05-22")
         last_date_invoiced = to_date("2018-05-21")
         self.acct_line.date_end = "2020-02-22"
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "quarterly"
         self.acct_line.recurring_invoicing_type = "pre-paid"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.recurring_create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
@@ -410,9 +410,9 @@ class TestContract(TestContractBase):
         recurring_next_date = to_date("2018-05-22")
         last_date_invoiced = to_date("2018-02-21")
         self.acct_line.date_end = "2020-02-22"
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "quarterly"
         self.acct_line.recurring_invoicing_type = "post-paid"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.recurring_create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
@@ -423,9 +423,9 @@ class TestContract(TestContractBase):
         recurring_next_date = to_date("2018-08-22")
         last_date_invoiced = to_date("2018-08-21")
         self.acct_line.date_end = "2020-02-22"
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "semesterly"
         self.acct_line.recurring_invoicing_type = "pre-paid"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.recurring_create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
@@ -436,9 +436,9 @@ class TestContract(TestContractBase):
         recurring_next_date = to_date("2018-08-22")
         last_date_invoiced = to_date("2018-02-21")
         self.acct_line.date_end = "2020-02-22"
-        self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "semesterly"
         self.acct_line.recurring_invoicing_type = "post-paid"
+        self.acct_line.recurring_next_date = "2018-02-22"
         self.contract.recurring_create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
@@ -1812,8 +1812,11 @@ class TestContract(TestContractBase):
         )
         self.assertEqual(first, to_date("2018-01-05"))
         self.assertEqual(last, to_date("2018-01-31"))
-        self.assertEqual(recurring_next_date, to_date("2018-01-05"))
-        self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-01-05"))
+        self.assertEqual(recurring_next_date, to_date("2018-01-31"))
+        self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-01-31"))
+        # monthlylastday with match with post-paid
+        # because in pre-paid the invoice date must be de fist of month
+        self.assertEqual(self.acct_line.recurring_invoicing_type, "post-paid")
         self.contract.recurring_create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
@@ -1821,8 +1824,8 @@ class TestContract(TestContractBase):
         )
         self.assertEqual(first, to_date("2018-02-01"))
         self.assertEqual(last, to_date("2018-02-28"))
-        self.assertEqual(recurring_next_date, to_date("2018-02-01"))
-        self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-02-01"))
+        self.assertEqual(recurring_next_date, to_date("2018-02-28"))
+        self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-02-28"))
         self.assertEqual(self.acct_line.last_date_invoiced, to_date("2018-01-31"))
         self.contract.recurring_create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
@@ -1831,8 +1834,8 @@ class TestContract(TestContractBase):
         )
         self.assertEqual(first, to_date("2018-03-01"))
         self.assertEqual(last, to_date("2018-03-15"))
-        self.assertEqual(recurring_next_date, to_date("2018-03-01"))
-        self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-03-01"))
+        self.assertEqual(recurring_next_date, to_date("2018-03-15"))
+        self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-03-15"))
         self.assertEqual(self.acct_line.last_date_invoiced, to_date("2018-02-28"))
         self.contract.recurring_create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(


### PR DESCRIPTION
contract: fix compute_recurring_next_date for recurring_rule_type = "monthlylastday"
before fix  : 
When you change value of recurring_rule_type (ex you pass from "monthly" to  "monthlylastday" or "weekly") or you change recurring_invoicing_type (ex: from "post-paid" to "pre-paid") or recurring_interval (every 1 to every 2 "month") ==> the recurring_next_date remain unchanged.
ex:
recurring_next_date = 2022-07-01 and recurring_rule_type (from "monthly" to  "monthlylastday" ) ==> recurring_next_date = 2022-07-01
 After fix:
When you change value of recurring_rule_type (ex pass from "monthly" to  "monthlylastday" or "weekly") or you change recurring_invoicing_type (ex: from "post-paid" to "pre-paid") or recurring_interval (from every 1 to every 2 "month") ==> the recurring_next_date is updated based on this new parameters.
ex:
recurring_next_date = 2022-07-01 and recurring_rule_type (from "monthly" to  "monthlylastday" ) ==> recurring_next_date = 2022-06-30