### PR TITLE
[14.0][FIX] contract: add default_move_type in context

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -277,12 +277,20 @@ class ContractContract(models.Model):
         self.ensure_one()
         tree_view = self.env.ref("account.view_invoice_tree", raise_if_not_found=False)
         form_view = self.env.ref("account.view_move_form", raise_if_not_found=False)
+        ctx = dict(self.env.context)
+        if ctx.get("default_contract_type"):
+            ctx["default_move_type"] = (
+                "out_invoice"
+                if ctx.get("default_contract_type") == "sale"
+                else "in_invoice"
+            )
         action = {
             "type": "ir.actions.act_window",
             "name": "Invoices",
             "res_model": "account.move",
             "view_mode": "tree,kanban,form,calendar,pivot,graph,activity",
             "domain": [("id", "in", self._get_related_invoices().ids)],
+            "context": ctx,
         }
         if tree_view and form_view:
             action["views"] = [(tree_view.id, "tree"), (form_view.id, "form")]


### PR DESCRIPTION
If `default_move_type` isn't in the context some views lack some information or are not correct.

For example the field` invoice_date` is not shown in the tree view  when accessing to the contract invoices' from the Contact view or from Invoicing/Customers/Customer Contracts. 

Also, if a new invoice line wants to be added in one of these invoices, only products that "Can be Purchased" appear because the product_id domain is:
```
context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt')
and [('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]
or [('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]
```

