### PR TITLE
[FIX] Set last date invoiced not readonly

### DIFF
--- a/contract/models/contract_recurrency_mixin.py
+++ b/contract/models/contract_recurrency_mixin.py
@@ -90,7 +90,7 @@ class ContractRecurrencyMixin(models.AbstractModel):
         compute="_compute_next_period_date_end",
     )
     last_date_invoiced = fields.Date(
-        string="Last Date Invoiced", readonly=True, copy=False
+        string="Last Date Invoiced", readonly=False, copy=False
     )
 
     @api.depends("next_period_date_start")


### PR DESCRIPTION
If you do wrong invoice on contract, you can not re invoice with right data...

For example, set recurring invoice type as post-paid, create first invoice, set next invoice to previous date to re invoice and then data is not right.

Any problem to unset readonly? Finally this field is visible only to technical user so I think no problem