### PR TITLE
[14.0] [IMP] Free invoice date

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -135,6 +135,9 @@ class ContractContract(models.Model):
         inverse_name="contract_id",
         string="Modifications",
     )
+    free_invoice_date = fields.Boolean(
+        string="Free Invoice Date",
+    )
 
     def get_formview_id(self, access_uid=None):
         if self.contract_type == "sale":
@@ -437,6 +440,7 @@ class ContractContract(models.Model):
         if self.fiscal_position_id:
             move_form.fiscal_position_id = self.fiscal_position_id
         invoice_vals = move_form._values_to_save(all_fields=True)
+        date_invoice = not self.free_invoice_date and date_invoice
         invoice_vals.update(
             {
                 "ref": self.code,

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -430,6 +430,7 @@
                                     name="code"
                                     attrs="{'readonly': [('is_terminated','=',True)]}"
                                 />
+                                <field name="free_invoice_date" />
                                 <field
                                     name="group_id"
                                     attrs="{'readonly': [('is_terminated','=',True)]}"


### PR DESCRIPTION
Adds "Free Invoice Date" (boolean field) on contract.

If you set "Free Invoice Date" on contract, generated invoices will create without invoice date.

As invoice date is not required on invoice until you confirm the invoice you can set null, and it will autocomplete when you confirm invoice.

This way yo can, for example, generate invoice on contract monthly (from 1 to last day of the month), and validate few days later, after check it or complete with other date.

Other example, I invoice timesheets monthly (from 1 to last day of the month) with contract, but I need to check timesheet before invoice, so I disable cron, and launch manualy after check all timesheets. Before this modification, invoice was created with day 1. 