### PR TITLE
[15.0][IMP] contract: add tree/form views for contract.modification

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -39,6 +39,7 @@
         "views/contract_tag.xml",
         "views/abstract_contract_line.xml",
         "views/contract.xml",
+        "views/contract_modification.xml",
         "views/contract_line.xml",
         "views/contract_template.xml",
         "views/contract_template_line.xml",

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -418,13 +418,7 @@
                             <field
                                 name="modification_ids"
                                 attrs="{'readonly': [('is_terminated','=',True)]}"
-                            >
-                                <tree editable="bottom">
-                                    <field name="date" />
-                                    <field name="description" />
-                                    <field name="sent" />
-                                </tree>
-                            </field>
+                                context="{'default_contract_id': active_id}"/>
                         </page>
                         <page name="info" string="Other Information">
                             <field name="create_invoice_visibility" invisible="1" />

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -418,7 +418,8 @@
                             <field
                                 name="modification_ids"
                                 attrs="{'readonly': [('is_terminated','=',True)]}"
-                                context="{'default_contract_id': active_id}"/>
+                                context="{'default_contract_id': active_id}"
+                            />
                         </page>
                         <page name="info" string="Other Information">
                             <field name="create_invoice_visibility" invisible="1" />

--- a/contract/views/contract_modification.xml
+++ b/contract/views/contract_modification.xml
@@ -8,10 +8,13 @@
             <form>
                 <sheet>
                     <group>
-                        <field name="contract_id" invisible="context.get('default_contract_id', False)"/>
-                        <field name="date"/>
-                        <field name="description"/>
-                        <field name="sent"/>
+                        <field
+                            name="contract_id"
+                            invisible="context.get('default_contract_id', False)"
+                        />
+                        <field name="date" />
+                        <field name="description" />
+                        <field name="sent" />
                     </group>
                 </sheet>
             </form>
@@ -21,10 +24,10 @@
         <field name="model">contract.modification</field>
         <field name="arch" type="xml">
             <tree>
-                <field name="contract_id" optional="hide"/>
-                <field name="date"/>
-                <field name="description"/>
-                <field name="sent"/>
+                <field name="contract_id" optional="hide" />
+                <field name="date" />
+                <field name="description" />
+                <field name="sent" />
             </tree>
         </field>
     </record>
@@ -35,8 +38,8 @@
     </record>
     <record model="ir.ui.menu" id="menu_contract_modification">
         <field name="name">contract.modification</field>
-        <field name="parent_id" ref="contract.menu_config_contract"/>
-        <field name="action" ref="action_contract_modification"/>
+        <field name="parent_id" ref="contract.menu_config_contract" />
+        <field name="action" ref="action_contract_modification" />
         <field name="sequence" eval="16" />
     </record>
 </odoo>

--- a/contract/views/contract_modification.xml
+++ b/contract/views/contract_modification.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 BDO Auditores S.L.P
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_contract_modification_form" model="ir.ui.view">
+        <field name="model">contract.modification</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="contract_id" invisible="context.get('default_contract_id', False)"/>
+                        <field name="date"/>
+                        <field name="description"/>
+                        <field name="sent"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="view_contract_modification_tree">
+        <field name="model">contract.modification</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="contract_id" optional="hide"/>
+                <field name="date"/>
+                <field name="description"/>
+                <field name="sent"/>
+            </tree>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="action_contract_modification">
+        <field name="name">Contract modification</field>
+        <field name="res_model">contract.modification</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <record model="ir.ui.menu" id="menu_contract_modification">
+        <field name="name">contract.modification</field>
+        <field name="parent_id" ref="contract.menu_config_contract"/>
+        <field name="action" ref="action_contract_modification"/>
+        <field name="sequence" eval="16" />
+    </record>
+</odoo>


### PR DESCRIPTION
Now the modifications page in contract form appears like that: ![Captura de pantalla de 2022-06-23 17-40-25](https://user-images.githubusercontent.com/6186623/175342328-b4328f39-e233-45a8-b69b-0ca0ec54383d.png)
Editable="bottom" Attribute is not working https://github.com/OCA/contract/blob/15.0/contract/views/contract.xml#L422
After this PR, the 'modifications' model fields appear in the form:
![Captura de pantalla de 2022-06-23 17-57-16](https://user-images.githubusercontent.com/6186623/175342848-4c1786b4-685d-45d5-b8fe-c378058785ff.png)

