### PR TITLE
[13.0][FIX] contract: Reset next invoicing date when terminating a line

### DIFF
--- a/contract/models/contract_recurrency_mixin.py
+++ b/contract/models/contract_recurrency_mixin.py
@@ -91,6 +91,7 @@ class ContractRecurrencyMixin(models.AbstractModel):
 
     @api.depends("next_period_date_start")
     def _compute_recurring_next_date(self):
+        self.recurring_next_date = False
         for rec in self.filtered("next_period_date_start"):
             rec.recurring_next_date = self.get_next_invoice_date(
                 rec.next_period_date_start,

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -2384,3 +2384,11 @@ class TestContract(TestContractBase):
         action = self.contract.action_preview()
         self.assertIn("/my/contracts/", action["url"])
         self.assertIn("access_token=", action["url"])
+
+    def test_contract_line_termination(self):
+        """Don't fail when the line receives an end date."""
+        self.contract.recurring_create_invoice()
+        self.acct_line.date_end = "2018-02-14"
+        self.assertFalse(self.acct_line.recurring_next_date)
+        # This doesn't give any error
+        self.contract.recurring_create_invoice()


### PR DESCRIPTION
**Steps to reproduce the problem:**

- Create a new contract
- Set "Recurrence at line level?"
- Add a new line, with following data:

  * Invoice Every: 1 Month(s)
  * Date Start: 2022-06-01
  * Invoicing type: Pre-paid
- Save and click on "Create invoices" button
- Now edit again and put "Date End": 2022-06-30

**Current behavior:**

The line is still invoiceable (appears in blue), and if you click on "Create invoices" button, you get the traceback:

```
  ...
  File "/mnt/data/odoo-addons-dir/contract/models/contract.py", line 534, in recurring_create_invoice
    invoice = self._recurring_create_invoice()
  File "/mnt/data/odoo-addons-dir/contract/models/contract.py", line 561, in _recurring_create_invoice
    invoices_values = self._prepare_recurring_invoices_values(date_ref)
  File "/mnt/data/odoo-addons-dir/contract/models/contract.py", line 516, in _prepare_recurring_invoices_values
    invoice_line_vals = line._prepare_invoice_line(move_form=move_form)
  File "/mnt/data/odoo-addons-dir/contract_layout_category_hide_detail/models/contract_line.py", line 12, in _prepare_invoice_line
    vals = super()._prepare_invoice_line(move_form)
  File "/mnt/data/odoo-addons-dir/product_contract/models/contract_line.py", line 22, in _prepare_invoice_line
    res = super(ContractLine, self)._prepare_invoice_line(move_form)
  File "/mnt/data/odoo-addons-dir/contract_variable_quantity/models/contract_line.py", line 44, in _prepare_invoice_line
    vals = super()._prepare_invoice_line(move_form)
  File "/mnt/data/odoo-addons-dir/contract/models/contract_line.py", line 545, in _prepare_invoice_line
    name = self._insert_markers(dates[0], dates[1])
  File "/mnt/data/odoo-addons-dir/contract/models/contract_line.py", line 595, in _insert_markers
    name = name.replace("#END#", last_date_invoiced.strftime(date_format))
AttributeError: 'bool' object has no attribute 'strftime'
```

**Expected behavior:**

Line is not invoiceable anymore, and "Create invoices" button disappears (as no invoiceable line - but anyways, calling the method the same doesn't trigger the invoice creation).

@Tecnativa TT37880