### PR TITLE
[14.0][IMP] contract: Set default name to '/' for newly created invoice from contract

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -429,7 +429,7 @@ class ContractContract(models.Model):
         move_form = Form(
             self.env["account.move"]
             .with_company(self.company_id)
-            .with_context(default_move_type=invoice_type)
+            .with_context(default_move_type=invoice_type, default_name="/")
         )
         move_form.partner_id = self.invoice_partner_id
         if self.payment_term_id:


### PR DESCRIPTION
No default name is defined on invoice values for creation from contract.
The result is invoice without name for the first of the month and all others with the same invoice number specific at the month "INV/2022/07/00001".

It's better to have default name '/' for all invoices, the name will be recompute at the invoice validation.