### PR TITLE
[IMP] contract: Add contract date

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Recurring - Contracts Management",
-    "version": "13.0.2.9.0",
+    "version": "13.0.2.10.0",
     "category": "Contract Management",
     "license": "AGPL-3",
     "author": "Tecnativa, ACSONE SA/NV, Odoo Community Association (OCA)",

--- a/contract/migrations/13.0.2.10.0/pre-migrate.py
+++ b/contract/migrations/13.0.2.10.0/pre-migrate.py
@@ -1,0 +1,18 @@
+# Copyright 2022 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    fields_list = [
+        ("date", "contract.contract", "contract_contract", "date", "date", "contract")
+    ]
+    openupgrade.add_fields(env, fields_list)
+    query = """
+        UPDATE contract_contract
+            SET date = date_start
+            WHERE date IS NULL
+    """
+    openupgrade.logged_query(env.cr, query)

--- a/contract/models/abstract_contract.py
+++ b/contract/models/abstract_contract.py
@@ -18,6 +18,11 @@ class ContractAbstractContract(models.AbstractModel):
     NO_SYNC = ["name", "partner_id", "company_id"]
 
     name = fields.Char(required=True)
+    date = fields.Date(
+        required=True,
+        default=lambda self: fields.Date.today(),
+        help="This is the date the contract is taken into account (e.g.: signature date)",
+    )
     # Needed for avoiding errors on several inherited behaviors
     partner_id = fields.Many2one(
         comodel_name="res.partner", string="Partner", index=True

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -103,6 +103,10 @@
                     </div>
                     <group name="main">
                         <group>
+                            <field
+                                name="date"
+                                attrs="{'readonly': [('is_terminated','=',True)]}"
+                            />
                             <field name="commercial_partner_id" invisible="1" />
                             <field
                                 name="partner_id"


### PR DESCRIPTION
In some cases, the contract date (e.g.: signature date) can be different from the
start date (e.g.: signature on 05/15/2022 and start date on 06/01/2022).

It can have importance in case of prices revisions from a legal point of view as
this is the contract date that has to be taken into account.