### PR TITLE
[FIX] contract unittest test_contract.py 

### DIFF
--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests import Form, common
+from odoo.tests import Form, common, tagged
 
 
 def to_date(date):
@@ -191,6 +191,7 @@ class TestContractBase(common.SavepointCase):
         return cls.uom_obj.create(vals)
 
 
+@tagged("post_install", "-at_install")
 class TestContract(TestContractBase):
     def _add_template_line(self, overrides=None):
         if overrides is None:

--- a/contract/tests/test_contract_manually_create_invoice.py
+++ b/contract/tests/test_contract_manually_create_invoice.py
@@ -5,10 +5,12 @@
 
 
 from odoo.exceptions import UserError
+from odoo.tests import tagged
 
 from .test_contract import TestContractBase
 
 
+@tagged("post_install", "-at_install")
 class TestContractManuallyCreateInvoice(TestContractBase):
     @classmethod
     def setUpClass(cls):

--- a/contract/tests/test_multicompany.py
+++ b/contract/tests/test_multicompany.py
@@ -1,9 +1,12 @@
 # Copyright 2021 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo.tests import tagged
+
 from .test_contract import TestContractBase
 
 
+@tagged("post_install", "-at_install")
 class ContractMulticompanyCase(TestContractBase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This unittest needs the installation of l10n_us and l10n_generic_coa
otherwise there are no account.journal 
the install of the two modules happens in the account module with a post_init_hook