### PR TITLE
[15.0][IMP] contract: Set invoice_user_id field with Form() to apply the correct values of other fields.

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -442,6 +442,8 @@ class ContractContract(models.Model):
             move_form.invoice_payment_term_id = self.payment_term_id
         if self.fiscal_position_id:
             move_form.fiscal_position_id = self.fiscal_position_id
+        if invoice_type == "out_invoice" and self.user_id:
+            move_form.invoice_user_id = self.user_id
         invoice_vals = move_form._values_to_save(all_fields=True)
         invoice_vals.update(
             {
@@ -451,7 +453,6 @@ class ContractContract(models.Model):
                 "invoice_date": date_invoice,
                 "journal_id": journal.id,
                 "invoice_origin": self.name,
-                "invoice_user_id": self.user_id.id,
             }
         )
         return invoice_vals, move_form

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -309,6 +309,7 @@ class TestContract(TestContractBase):
         invoice_daily = self.contract._get_related_invoices()
         self.assertTrue(invoice_daily)
         self.assertEqual(self.contract.user_id, invoice_daily.user_id)
+        self.assertEqual(self.contract.user_id, invoice_daily.invoice_user_id)
 
     def test_contract_weekly_post_paid(self):
         recurring_next_date = to_date("2018-03-01")


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/contract/pull/883

Set `invoice_user_id` field with `Form()` to apply the correct values of other fields (`team_id` for example).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT39934