### PR TITLE
[14.0][FIX] contract: Switch string > title in buttons

### DIFF
--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -135,28 +135,28 @@
                 <field name="is_canceled" invisible="1" />
                 <button
                     name="action_plan_successor"
-                    string="Plan Start"
+                    title="Plan Start"
                     type="object"
                     icon="fa-calendar text-success"
                     attrs="{'invisible': [('is_plan_successor_allowed', '=', False)]}"
                 />
                 <button
                     name="action_stop_plan_successor"
-                    string="Stop Plan Successor"
+                    title="Stop Plan Successor"
                     type="object"
                     icon="fa-pause text-muted"
                     attrs="{'invisible': [('is_stop_plan_successor_allowed', '=', False)]}"
                 />
                 <button
                     name="action_stop"
-                    string="Stop"
+                    title="Stop"
                     type="object"
                     icon="fa-stop text-danger"
                     attrs="{'invisible': [('is_stop_allowed', '=', False)]}"
                 />
                 <button
                     name="cancel"
-                    string="Cancel"
+                    title="Cancel"
                     type="object"
                     icon="fa-ban text-danger"
                     confirm="Are you sure you want to cancel this line"
@@ -164,14 +164,14 @@
                 />
                 <button
                     name="action_uncancel"
-                    string="Un-cancel"
+                    title="Un-cancel"
                     type="object"
                     icon="fa-ban text-success"
                     attrs="{'invisible': [('is_un_cancel_allowed', '=', False)]}"
                 />
                 <button
                     name="renew"
-                    string="Renew"
+                    title="Renew"
                     type="object"
                     icon="fa-fast-forward text-success"
                     groups="base.group_no_one"


### PR DESCRIPTION
In v14, the `string` attribute of the buttons is shown directly in UI. The tooltips are now put through `title` attribute. As that was the original intention, let's switch `string` to `title`.

@Tecnativa