### PR TITLE
[14.0][FIX] contract: Put proper invoice accounting date

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -445,6 +445,7 @@ class ContractContract(models.Model):
                 "company_id": self.company_id.id,
                 "currency_id": self.currency_id.id,
                 "invoice_date": date_invoice,
+                "date": date_invoice,
                 "journal_id": journal.id,
                 "invoice_origin": self.name,
             }


### PR DESCRIPTION
**Steps to reproduce the problem**

- Create a new contract with starting date 2023-01-01.
- Run the advance invoicing wizard on 2022-12-27.

**Current behavior:**

The invoice has as invoice date (invoice_date) 2023-01-01, but accounting date (date) 2022-12-27.

**Expected behavior:**

To have the same accounting date than the invoice date. If not, things like the new fiscal year numbering won't work correctly.

@Tecnativa TT40964