### PR TITLE
[14.0][FIX] contract_mode: fix payment_mode_id domain on supplier form

### DIFF
--- a/contract_payment_mode/views/contract_view.xml
+++ b/contract_payment_mode/views/contract_view.xml
@@ -48,11 +48,8 @@
         <field name="priority">18</field>
         <field name="inherit_id" ref="contract.contract_contract_supplier_form_view" />
         <field name="arch" type="xml">
-            <field name="partner_id" position="after">
-                <field
-                    name="payment_mode_id"
-                    domain="[('payment_type', '=', 'outbound')]"
-                />
+            <field name="payment_mode_id" position="attributes">
+                <attribute name="domain">[('payment_type', '=', 'outbound')]</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
The payment_mode_id field is inserted in the contract_contract_form_view form and also in the contract_contract_supplier_form_view form. As the form contract_contract_supplier_form_view inherits the form contract_contract_form_view the payment_mode_id field appears twice in the form and with the default domain (inbound) instead of the expected domain (outbound).

![image](https://user-images.githubusercontent.com/3595132/210279807-fe0e8c23-066d-4a94-bac1-b3dcba3a3f96.png)

Now

![image](https://user-images.githubusercontent.com/3595132/210280005-0d5b8543-159f-4e51-b399-7ed8eab6f643.png)
