### PR TITLE
[14.0][ADD] contract_comment_template

### DIFF
--- a/contract_comment_template/__init__.py
+++ b/contract_comment_template/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2023 elegosoft (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/contract_comment_template/__manifest__.py
+++ b/contract_comment_template/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2023 elegosoft (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Contract Comments",
+    "summary": "Comments texts templates on Contract documents",
+    "version": "14.0.1.0.0",
+    "category": "Contract Management",
+    "author": "elego Software Solutions GmbH, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/contract",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "contract",
+        "account_comment_template",
+    ],
+    "data": [
+        "views/contract_view.xml",
+        "views/base_comment_template_view.xml",
+        "views/report_contract.xml",
+    ],
+}

--- a/contract_comment_template/i18n/contract_comment_template.pot
+++ b/contract_comment_template/i18n/contract_comment_template.pot
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* contract_comment_template
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-11 14:31+0000\n"
+"PO-Revision-Date: 2023-01-11 14:31+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: contract_comment_template
+#: model:ir.model.fields,field_description:contract_comment_template.field_contract_contract__comment_template_ids
+msgid "Comment Template"
+msgstr ""
+
+#. module: contract_comment_template
+#: model_terms:ir.ui.view,arch_db:contract_comment_template.contract_contract_form_view_add_comment
+msgid "Comments"
+msgstr ""
+
+#. module: contract_comment_template
+#: model:ir.model,name:contract_comment_template.model_contract_contract
+msgid "Contract"
+msgstr ""
+
+#. module: contract_comment_template
+#: model:ir.actions.act_window,name:contract_comment_template.action_contract_comment_template
+#: model:ir.ui.menu,name:contract_comment_template.menu_base_comment_template_contract
+msgid "Contract Comments"
+msgstr ""
+
+#. module: contract_comment_template
+#: model:ir.model.fields,field_description:contract_comment_template.field_contract_contract__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: contract_comment_template
+#: model:ir.model.fields,field_description:contract_comment_template.field_contract_contract__id
+msgid "ID"
+msgstr ""
+
+#. module: contract_comment_template
+#: model:ir.model.fields,field_description:contract_comment_template.field_contract_contract____last_update
+msgid "Last Modified on"
+msgstr ""

--- a/contract_comment_template/i18n/de.po
+++ b/contract_comment_template/i18n/de.po
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* contract_comment_template
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-11 14:31+0000\n"
+"PO-Revision-Date: 2023-01-11 14:31+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: contract_comment_template
+#: model:ir.model.fields,field_description:contract_comment_template.field_contract_contract__comment_template_ids
+msgid "Comment Template"
+msgstr "Textbaustein-Vorlage"
+
+#. module: contract_comment_template
+#: model_terms:ir.ui.view,arch_db:contract_comment_template.contract_contract_form_view_add_comment
+msgid "Comments"
+msgstr "Textbausteine"
+
+#. module: contract_comment_template
+#: model:ir.model,name:contract_comment_template.model_contract_contract
+msgid "Contract"
+msgstr "Vertrag"
+
+#. module: contract_comment_template
+#: model:ir.actions.act_window,name:contract_comment_template.action_contract_comment_template
+#: model:ir.ui.menu,name:contract_comment_template.menu_base_comment_template_contract
+msgid "Contract Comments"
+msgstr "Vertrag Textbausteine"
+
+#. module: contract_comment_template
+#: model:ir.model.fields,field_description:contract_comment_template.field_contract_contract__display_name
+msgid "Display Name"
+msgstr "Anzeigename"
+
+#. module: contract_comment_template
+#: model:ir.model.fields,field_description:contract_comment_template.field_contract_contract__id
+msgid "ID"
+msgstr ""
+
+#. module: contract_comment_template
+#: model:ir.model.fields,field_description:contract_comment_template.field_contract_contract____last_update
+msgid "Last Modified on"
+msgstr "Zuletzt geändert am"

--- a/contract_comment_template/models/__init__.py
+++ b/contract_comment_template/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2023 elegosoft (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import contract

--- a/contract_comment_template/models/contract.py
+++ b/contract_comment_template/models/contract.py
@@ -1,0 +1,9 @@
+# Copyright 2023 elegosoft (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ContractContract(models.Model):
+    _name = "contract.contract"
+    _inherit = ["contract.contract", "comment.template"]

--- a/contract_comment_template/tests/__init__.py
+++ b/contract_comment_template/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2023 elegosoft (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_contract_comment

--- a/contract_comment_template/tests/test_contract_comment.py
+++ b/contract_comment_template/tests/test_contract_comment.py
@@ -1,0 +1,82 @@
+# Copyright 2023 elegosoft (https://www.elegosoft.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.contract.tests.test_contract import TestContractBase
+
+
+class TestContractInvoiceComment(TestContractBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+        cls.base_comment_model = cls.env["base.comment.template"]
+        # Create comment related to contract.contract model
+        cls.contract_obj = cls.env.ref("contract.model_contract_contract")
+        cls.contract_before_comment = cls._create_comment(
+            cls.contract_obj, "before_lines"
+        )
+        cls.contract_after_comment = cls._create_comment(
+            cls.contract_obj, "after_lines"
+        )
+        # Create comment related to move model
+        cls.move_obj = cls.env.ref("account.model_account_move")
+        cls.move_before_comment = cls._create_comment(cls.move_obj, "before_lines")
+        cls.move_after_comment = cls._create_comment(cls.move_obj, "after_lines")
+        # Create partner
+        cls.comment_partner = cls.env["res.partner"].create({"name": "Partner Test"})
+        cls.comment_partner.base_comment_template_ids = [
+            (4, cls.contract_before_comment.id),
+            (4, cls.contract_after_comment.id),
+            (4, cls.move_before_comment.id),
+            (4, cls.move_after_comment.id),
+        ]
+        cls.comment_contract = cls.contract2.copy(
+            {
+                "name": "Test Contract Comment",
+            }
+        )
+        cls.comment_contract.partner_id = cls.comment_partner.id
+        cls.comment_contract._onchange_partner_id()
+
+    @classmethod
+    def _create_comment(cls, model, position):
+        return cls.base_comment_model.create(
+            {
+                "name": "Comment " + position,
+                "company_id": cls.company.id,
+                "position": position,
+                "text": "Text " + position,
+                "model_ids": [(6, 0, model.ids)],
+            }
+        )
+
+    def test_comments_in_contract_report(self):
+        res = (
+            self.env["ir.actions.report"]
+            ._get_report_from_name("contract.report_contract_document")
+            ._render_qweb_html(self.comment_contract.ids)
+        )
+        self.assertRegex(str(res[0]), self.contract_before_comment.text)
+        self.assertRegex(str(res[0]), self.contract_after_comment.text)
+
+    def test_comments_in_generated_invoice_from_contract(self):
+        invoice = self.comment_contract.recurring_create_invoice()
+        self.assertTrue(self.move_before_comment in invoice.comment_template_ids)
+        self.assertTrue(self.move_after_comment in invoice.comment_template_ids)
+        self.assertFalse(self.contract_before_comment in invoice.comment_template_ids)
+        self.assertFalse(self.contract_after_comment in invoice.comment_template_ids)
+        res = (
+            self.env["ir.actions.report"]
+            ._get_report_from_name("account.report_invoice")
+            ._render_qweb_html(invoice.ids)
+        )
+        self.assertRegex(str(res[0]), self.move_before_comment.text)
+        self.assertRegex(str(res[0]), self.move_after_comment.text)
+
+    def test_comments_in_contract(self):
+        self.assertTrue(
+            self.contract_after_comment in self.comment_contract.comment_template_ids
+        )
+        self.assertTrue(
+            self.contract_before_comment in self.comment_contract.comment_template_ids
+        )

--- a/contract_comment_template/views/base_comment_template_view.xml
+++ b/contract_comment_template/views/base_comment_template_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2023 elegosoft (https://www.elegosoft.com)
+  License AGPL-3.0 or later
+(http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record model="ir.actions.act_window" id="action_contract_comment_template">
+        <field name="name">Contract Comments</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">base.comment.template</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('model_ids.model', '=', 'contract.contract')]</field>
+        <field
+            name="context"
+            eval="{'default_model_ids': [(4, ref('contract.model_contract_contract'))]}"
+        />
+        <field
+            name="view_id"
+            ref="base_comment_template.view_base_comment_template_tree"
+        />
+    </record>
+
+    <record model="ir.ui.menu" id="menu_base_comment_template_contract">
+        <field name="name">Contract Comments</field>
+        <field name="parent_id" ref="contract.menu_config_contract" />
+        <field name="action" ref="action_contract_comment_template" />
+        <field name="sequence" eval="17" />
+    </record>
+</odoo>

--- a/contract_comment_template/views/contract_view.xml
+++ b/contract_comment_template/views/contract_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2023 elegosoft (https://www.elegosoft.com)
+  License AGPL-3.0 or later
+(http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record model="ir.ui.view" id="contract_contract_form_view_add_comment">
+        <field name="name">contract.contract.form.comment</field>
+        <field name="model">contract.contract</field>
+        <field name="inherit_id" ref="contract.contract_contract_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Comments" name="comments">
+                    <field name="comment_template_ids" />
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/contract_comment_template/views/report_contract.xml
+++ b/contract_comment_template/views/report_contract.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2023 elegosoft (https://www.elegosoft.com)
+  License AGPL-3.0 or later
+(http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <template
+        id="report_contract_document_comments"
+        inherit_id="contract.report_contract_document"
+    >
+        <xpath expr="//table[hasclass('table-sm')]" position="before">
+            <t
+                t-foreach="o.comment_template_ids.filtered(lambda x: x.position == 'before_lines')"
+                t-as="comment_template_top"
+            >
+                <div t-raw="o.render_comment(comment_template_top)" />
+            </t>
+        </xpath>
+        <xpath expr="//div[hasclass('page')]" position="inside">
+            <t
+                t-foreach="o.comment_template_ids.filtered(lambda x: x.position == 'after_lines')"
+                t-as="comment_template_bottom"
+            >
+                <div t-raw="o.render_comment(comment_template_bottom)" />
+            </t>
+        </xpath>
+    </template>
+
+</odoo>

--- a/setup/contract_comment_template/odoo/addons/contract_comment_template
+++ b/setup/contract_comment_template/odoo/addons/contract_comment_template
@@ -1,0 +1,1 @@
+../../../../contract_comment_template

--- a/setup/contract_comment_template/setup.py
+++ b/setup/contract_comment_template/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Adds comments on the contract and the comments can be loaded from templates.
Reference from [sale_comment_template](https://github.com/OCA/sale-reporting/tree/14.0/sale_comment_template) or [account_comment_template](https://github.com/OCA/account-invoice-reporting/tree/14.0/account_comment_template) in `14.0`