### PR TITLE
[FIX]Add ref views on create_invoice action depending on invoices type

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -17,7 +17,7 @@
               "LasLabs, "
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/contract',
-    'depends': ['base', 'account', 'product', 'portal'],
+    'depends': ['base', 'account', 'auth_signup', 'product', 'portal'],
     "external_dependencies": {"python": ["dateutil"]},
     'data': [
         'security/groups.xml',

--- a/contract/wizards/contract_manually_create_invoice.py
+++ b/contract/wizards/contract_manually_create_invoice.py
@@ -56,10 +56,17 @@ class ContractManuallyCreateInvoice(models.TransientModel):
         invoices = self.env['account.invoice']
         for contract in self.contract_to_invoice_ids:
             invoices |= contract.recurring_create_invoice()
+        if self.contract_type == "sale":
+            tree_view_id = self.env.ref('account.invoice_tree').id
+            form_view_id = self.env.ref('account.invoice_form').id
+        else:
+            tree_view_id = self.env.ref('account.invoice_supplier_tree').id
+            form_view_id = self.env.ref('account.invoice_supplier_form').id
         return {
             "type": "ir.actions.act_window",
             "name": _("Invoices"),
             "res_model": "account.invoice",
+            "views": [[tree_view_id, "tree"], [form_view_id, "form"]],
             "domain": [('id', 'in', invoices.ids)],
             "view_mode": "tree,form",
             "context": self.env.context,


### PR DESCRIPTION
The functionnality Invoice sales contracts manually opens the supplier views instead of customer views. 
Add control on the type of invoice, then call ref views sale for customer invoices, and supplier views for the other fix the issue. 