### PR TITLE
[15.0][FIX] No contract line and invoices when contract is archived

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -58,6 +58,7 @@ class ContractContract(models.Model):
         comodel_name="contract.line",
         inverse_name="contract_id",
         copy=True,
+        context={"active_test": False},
     )
     # Trick for being able to have 2 different views for the same o2m
     # We need this as one2many widget doesn't allow to define in the view
@@ -68,6 +69,7 @@ class ContractContract(models.Model):
         string="Contract lines (fixed)",
         comodel_name="contract.line",
         inverse_name="contract_id",
+        context={"active_test": False},
     )
 
     user_id = fields.Many2one(


### PR DESCRIPTION
If you have an archived contract the form view doesn't show any contract lines and the Invoices button is also not showing the connected invoices.

This happens because the contract lines have a related active field and without the additional context a normal read would result in no line at all.

The invoices aren't shown because they are also based on the contract lines.