### PR TITLE
[FIX] Do preserve the uom from the contract line 

### DIFF
--- a/contract_sale_generation/models/contract_line.py
+++ b/contract_sale_generation/models/contract_line.py
@@ -40,7 +40,10 @@ class ContractLine(models.Model):
             )
             order_line.order_id = sale
         # Get other order line values from product onchange
+        uom = order_line['product_uom']
         order_line.product_id_change()
+        # Do set again the product_uom - the product_id_change function does reset it before
+        order_line['product_uom'] = uom
         sale_line_vals = order_line._convert_to_write(order_line._cache)
         # Insert markers
         name = self._insert_markers(dates[0], dates[1])


### PR DESCRIPTION
contract.line is configured with a qty and a product uom. Will get set in the _prepare_sale_line_vals function. Then there is a call to the onchange function - there product_uom will get set from the product. So we have to set it here again.
