### PR TITLE
[14.0][FIX] contract: subtotal miscalculated when price_unit displayed with fewer digits than actual value

### DIFF
--- a/contract/models/abstract_contract_line.py
+++ b/contract/models/abstract_contract_line.py
@@ -39,6 +39,7 @@ class ContractAbstractContractLine(models.AbstractModel):
         string="Unit Price",
         compute="_compute_price_unit",
         inverse="_inverse_price_unit",
+        digits="Product Price",
     )
     price_subtotal = fields.Float(
         compute="_compute_price_subtotal",

--- a/contract/readme/CONTRIBUTORS.rst
+++ b/contract/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@
     * Rafael Blasco
     * Víctor Martínez
 * Iván Antón <ozono@ozonomultimedia.com>
+* Eric Antones <eantones@nuobit.com>


### PR DESCRIPTION
This commit addresses an issue in the "contract" module where the subtotal was incorrectly calculated when the `price_unit` field was displayed with fewer digits than its actual value, resulting in discrepancies of a few cents.

The change made in this commit is: Adding the `digits` attribute with the value "Product Price" to the `price_unit` field, ensuring the proper display of decimal places, leading to accurate subtotal calculations and eliminating cent discrepancies.

Before:
![image](https://user-images.githubusercontent.com/10927087/226754874-fbb0f886-a351-481f-a84f-4ea3a7c06e5c.png)

After:
![image](https://user-images.githubusercontent.com/10927087/226754892-774a1d98-b43e-4dcc-88ec-551b545e3801.png)
