### PR TITLE
Update sale_order.py

### DIFF
--- a/agreement_legal_sale/models/sale_order.py
+++ b/agreement_legal_sale/models/sale_order.py
@@ -33,7 +33,7 @@ class SaleOrder(models.Model):
                         self._get_agreement_line_vals(line)
                     )
                     # Create SP's based on product_id config
-                    if line.product_id.is_serviceprofile:
+                    if line.product_id.product_tmpl_id.is_serviceprofile:
                         self.create_sp_qty(line, order)
         return res
 


### PR DESCRIPTION
I have detected that when a sale order is confirmed, an agreement is created that contains all the products of the order but it does not create the service profiles of the product templates marked as such.
This happens because the property is_serviceprofile of the product is not copied from the value indicated in the product template in the module agreement_serviceprofile
[Here the product code](https://github.com/OCA/contract/blob/14.0/agreement_serviceprofile/models/product.py)
```
    class ProductProduct(models.Model):
        _inherit = "product.product"

        is_serviceprofile = fields.Boolean(
            string="Create Service Profiles",
            help="""If True, this product will create a service profile on the
            agreement when the sales order is confirmed.""",
        )

        @api.onchange("is_serviceprofile")
        def onchange_type(self):
            if self.is_serviceprofile:
                self.type = "service"
```

In other odoo modules in which I have seen that this model is extended, I have seen that normally the added attributes have as default value a function that sets it to the value of its product template. 
I think this is the correct way to do it but in this case I don't see much point in replicating this attribute so I think the best way to solve this error is by using the product template property instead of the product one to check if the product is a serviceprofile

