### PR TITLE
[14.0][FIX] contract: show uom only when multi uom is activated

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -222,7 +222,7 @@
                                     />
                                     <field name="quantity" />
                                     <field name="allowed_uom_categ_id" invisible="1" />
-                                    <field name="uom_id" />
+                                    <field name="uom_id" groups="uom.group_uom" />
                                     <field
                                         name="automatic_price"
                                         attrs="{'column_invisible': [('parent.contract_type', '=', 'purchase')]}"
@@ -322,7 +322,7 @@
                                         groups="analytic.group_analytic_tags"
                                     />
                                     <field name="quantity" />
-                                    <field name="uom_id" />
+                                    <field name="uom_id" groups="uom.group_uom" />
                                     <field
                                         name="automatic_price"
                                         attrs="{'column_invisible': [('parent.contract_type', '=', 'purchase')]}"

--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -109,7 +109,7 @@
                     groups="analytic.group_analytic_tags"
                 />
                 <field name="quantity" />
-                <field name="uom_id" />
+                <field name="uom_id" groups="uom.group_uom" />
                 <field name="automatic_price" />
                 <field
                     name="price_unit"
@@ -213,7 +213,7 @@
                     groups="analytic.group_analytic_tags"
                 />
                 <field name="quantity" />
-                <field name="uom_id" />
+                <field name="uom_id" groups="uom.group_uom" />
                 <field name="price_unit" />
                 <field name="discount" groups="base.group_no_one" />
                 <field name="price_subtotal" />

--- a/contract/views/contract_template.xml
+++ b/contract/views/contract_template.xml
@@ -44,7 +44,7 @@
                             <field name="product_id" />
                             <field name="name" widget="section_and_note_text" />
                             <field name="quantity" />
-                            <field name="uom_id" />
+                            <field name="uom_id" groups="uom.group_uom" />
                             <field
                                 name="automatic_price"
                                 attrs="{'column_invisible': [('parent.contract_type','=','purchase')]}"


### PR DESCRIPTION
before this commit, the unit of measure field is
always visible in different views, irrespective
of the unit of measure option in the settings.

after this commit, the unit of measure field will
be shown only if the multi uom feature is activated in the settings.