### PR TITLE
Fix #INVOICEMONTHNAME# for all languages

### DIFF
--- a/contract/i18n/es.po
+++ b/contract/i18n/es.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-12-31 14:54+0000\n"
-"PO-Revision-Date: 2022-11-09 10:45+0000\n"
+"PO-Revision-Date: 2023-05-17 14:00-0400\n"
 "Last-Translator: JHernandezConinpe <jhernandez@coninpe.es>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #. module: contract
 #: model:mail.template,body_html:contract.mail_template_contract_modification
@@ -233,6 +233,10 @@ msgid ""
 "                                    the\n"
 "                                    invoiced period"
 msgstr ""
+"<strong>#INVOICEMONTHNAME#</strong>\n"
+"                                    : Nombre del mes\n"
+"                                    del\n"
+"                                    periodo facturado"
 
 #. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_template_form_view
@@ -240,6 +244,7 @@ msgid ""
 "<strong>#INVOICEMONTHNAME#</strong>: Invoice month name of the invoiced "
 "period"
 msgstr ""
+"<strong>#INVOICEMONTHNAME#</strong>: Nombre del mes del periodo facturado"
 
 #. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
@@ -448,7 +453,7 @@ msgstr "Cuenta analítica"
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "April"
-msgstr ""
+msgstr "Abril"
 
 #. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_search_view
@@ -485,7 +490,7 @@ msgstr "Nº de archivos adjuntos"
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "August"
-msgstr ""
+msgstr "Agosto"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract_line__is_auto_renew
@@ -1093,7 +1098,7 @@ msgstr "Día(s)"
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "December"
-msgstr ""
+msgstr "Diciembre"
 
 #. module: contract
 #: model:ir.model.fields,help:contract.field_contract_abstract_contract_line__note_invoicing_mode
@@ -1189,7 +1194,7 @@ msgstr ""
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "February"
-msgstr ""
+msgstr "Febrero"
 
 #. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_search_view
@@ -1431,7 +1436,7 @@ msgstr "Es suspensión sin fecha de finalización"
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "January"
-msgstr ""
+msgstr "Enero"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract__journal_id
@@ -1455,13 +1460,13 @@ msgstr "Apunte contable"
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "July"
-msgstr ""
+msgstr "Julio"
 
 #. module: contract
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "June"
-msgstr ""
+msgstr "Junio"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract_line__last_date_invoiced
@@ -1562,7 +1567,7 @@ msgstr "Facturar manualmente contratos de venta"
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "March"
-msgstr ""
+msgstr "Marzo"
 
 #. module: contract
 #: model:ir.model.fields,help:contract.field_contract_abstract_contract__line_recurrence
@@ -1579,7 +1584,7 @@ msgstr ""
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "May"
-msgstr ""
+msgstr "Mayo"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_contract__message_has_error
@@ -1707,7 +1712,7 @@ msgstr "Notas"
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "November"
-msgstr ""
+msgstr "Noviembre"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_contract__message_needaction_counter
@@ -1754,7 +1759,7 @@ msgstr "Número de mensajes no leídos"
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "October"
-msgstr ""
+msgstr "Octubre"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_account_bank_statement_line__old_contract_id
@@ -2037,7 +2042,7 @@ msgstr "Enviado"
 #: code:addons/contract/models/contract_line.py:0
 #, python-format
 msgid "September"
-msgstr ""
+msgstr "Septiembre"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract_line__sequence

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -618,18 +618,18 @@ class ContractLine(models.Model):
 
     def _translate_marker_month_name(self, month_name):
         months = {
-            "January": _("January"),
-            "February": _("February"),
-            "March": _("March"),
-            "April": _("April"),
-            "May": _("May"),
-            "June": _("June"),
-            "July": _("July"),
-            "August": _("August"),
-            "September": _("September"),
-            "October": _("October"),
-            "November": _("November"),
-            "December": _("December"),
+            "01": _("January"),
+            "02": _("February"),
+            "03": _("March"),
+            "04": _("April"),
+            "05": _("May"),
+            "06": _("June"),
+            "07": _("July"),
+            "08": _("August"),
+            "09": _("September"),
+            "10": _("October"),
+            "11": _("November"),
+            "12": _("December"),
         }
         return months[month_name]
 
@@ -641,10 +641,12 @@ class ContractLine(models.Model):
         name = self.name
         name = name.replace("#START#", first_date_invoiced.strftime(date_format))
         name = name.replace("#END#", last_date_invoiced.strftime(date_format))
+        name = name.replace("#INVOICEMONTHNUMBER#", first_date_invoiced.strftime("%m"))
+        name = name.replace("#INVOICEYEAR#", first_date_invoiced.strftime("%Y"))
         name = name.replace(
             "#INVOICEMONTHNAME#",
             self.with_context(lang=lang.code)._translate_marker_month_name(
-                first_date_invoiced.strftime("%B")
+                first_date_invoiced.strftime("%m")
             ),
         )
         return name


### PR DESCRIPTION
It was working only in English

- Changed %B to %m to work on all languages
- Update month translations in es.po
