### PR TITLE
[16.0][FIX] contract_sale: Menu sequence and remove auto install

### DIFF
--- a/contract_sale/__manifest__.py
+++ b/contract_sale/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Contract from Sale",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "category": "Sales",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/contract",
@@ -20,5 +20,5 @@
     ],
     "license": "AGPL-3",
     "installable": True,
-    "auto_install": True,
+    "auto_install": False,
 }

--- a/contract_sale/views/contract.xml
+++ b/contract_sale/views/contract.xml
@@ -5,7 +5,7 @@
         name="Contracts"
         parent="sale.sale_order_menu"
         action="contract.action_customer_contract"
-        sequence="2"
+        sequence="21"
         groups="sales_team.group_sale_salesman"
     />
     <record id="contract_contract_form_view" model="ir.ui.view">


### PR DESCRIPTION
[FIX] Update sale menu sequence and remove auto install

In version v15, the menu order was:
![image](https://github.com/OCA/contract/assets/1799080/05bd8a64-bfc5-41ee-b27b-5b1358020804)

With the change to v16 it is changed to this:
![image](https://github.com/OCA/contract/assets/1799080/dbfac7d6-28c1-49d8-bd60-b6930a352704)

This patch restores the order as in v15.

I also see no reason why sale_contract needs to be installed when installing contract. Therefore removed auto_install.