### PR TITLE
[FIX] dependency on 'dateutil' does not appear to be valid

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -18,7 +18,7 @@
     "website": "https://github.com/OCA/contract",
     "depends": ["base", "account", "product", "portal"],
     "development_status": "Production/Stable",
-    "external_dependencies": {"python": ["dateutil"]},
+    "external_dependencies": {"python": ["python-dateutil"]},
     "data": [
         "security/groups.xml",
         "security/contract_tag.xml",

--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -18,7 +18,6 @@
     "website": "https://github.com/OCA/contract",
     "depends": ["base", "account", "product", "portal"],
     "development_status": "Production/Stable",
-    "external_dependencies": {"python": ["python-dateutil"]},
     "data": [
         "security/groups.xml",
         "security/contract_tag.xml",

--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -18,6 +18,7 @@
     "website": "https://github.com/OCA/contract",
     "depends": ["base", "account", "product", "portal"],
     "development_status": "Production/Stable",
+    "external_dependencies": {"python": ["python-dateutil"]},
     "data": [
         "security/groups.xml",
         "security/contract_tag.xml",


### PR DESCRIPTION
Fixes:
`odoo odoo.addons.base.models.ir_module: python external dependency on 'dateutil' does not appear to be a valid PyPI package. Using a PyPI package name is recommended.`