### PR TITLE
[FIX] dependency on 'dateutil' does not appear to be valid

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -18,7 +18,6 @@
     "website": "https://github.com/OCA/contract",
     "depends": ["base", "account", "product", "portal"],
     "development_status": "Production/Stable",
-    "external_dependencies": {"python": ["dateutil"]},
     "data": [
         "security/groups.xml",
         "security/contract_tag.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 # generated from manifests external_dependencies
-python-dateutil


### PR DESCRIPTION
Contract module lists `dateutil` as a python dependency which causes the error :
`python external dependency on 'dateutil' does not appear to be a valid PyPI package.`

To fix it remove the Dependency `dateutils`  in `contract/__manifest__.py` since it is already required by Odoo and does not have to be added here