### PR TITLE
[12.0] FIX contract: allow to view and modify last_date_invoiced

### DIFF
--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -23,8 +23,8 @@
                            attrs="{'required': [('is_auto_renew', '=', True)]}"/>
                     <field name="next_period_date_end"/>
                 </group>
-                <group groups="base.group_no_one">
-                    <field name="last_date_invoiced" readonly="True"/>
+                <group>
+                    <field name="last_date_invoiced" readonly="0"/>
                     <field name="termination_notice_date" readonly="True"/>
                 </group>
                 <group>


### PR DESCRIPTION
This is needed when invoice date is not coherent with contract line, so that user can adjust it manually