### PR TITLE
[15.0][FIX] contract: Apply some values directly in Form + default name

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -37,6 +37,7 @@
         "wizards/contract_contract_terminate.xml",
         "views/contract_tag.xml",
         "views/abstract_contract_line.xml",
+        "views/account_move_views.xml",
         "views/contract.xml",
         "views/contract_line.xml",
         "views/contract_template.xml",

--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -438,7 +438,7 @@ class ContractContract(models.Model):
         move_form = Form(
             self.env["account.move"]
             .with_company(self.company_id)
-            .with_context(default_move_type=invoice_type),
+            .with_context(default_move_type=invoice_type, default_name="/"),
             view="contract.view_account_move_contract_helper_form",
         )
         move_form.partner_id = self.invoice_partner_id

--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -438,9 +438,13 @@ class ContractContract(models.Model):
         move_form = Form(
             self.env["account.move"]
             .with_company(self.company_id)
-            .with_context(default_move_type=invoice_type)
+            .with_context(default_move_type=invoice_type),
+            view="contract.view_account_move_contract_helper_form",
         )
         move_form.partner_id = self.invoice_partner_id
+        move_form.journal_id = journal
+        move_form.currency_id = self.currency_id
+        move_form.invoice_date = date_invoice
         if self.payment_term_id:
             move_form.invoice_payment_term_id = self.payment_term_id
         if self.fiscal_position_id:
@@ -451,10 +455,6 @@ class ContractContract(models.Model):
         invoice_vals.update(
             {
                 "ref": self.code,
-                "company_id": self.company_id.id,
-                "currency_id": self.currency_id.id,
-                "invoice_date": date_invoice,
-                "journal_id": journal.id,
                 "invoice_origin": self.name,
             }
         )

--- a/contract/views/account_move_views.xml
+++ b/contract/views/account_move_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Auxiliary view for correct Form operation -->
+    <record id="view_account_move_contract_helper_form" model="ir.ui.view">
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="model">account.move</field>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <form position="inside">
+                <field name="journal_id" invisible="1" />
+                <field name="currency_id" invisible="1" />
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Forward-port of #995 and #857

----

[FIX] contract: Apply some values directly in Form

If not applied, they will not be taken into account in the lines operations.

We have needed to add an auxiliary form that adds the fields without groups.

----

[IMP] contract: Set default name to '/' for newly created invoice from contract

No default name is defined on invoice values for creation from contract.
The result is invoice without name for the first of the month and all others with the same invoice number specific at the month "INV/2022/07/00001".

It's better to have default name '/' for all invoices, the name will be recompute at the invoice validation.

----

@Tecnativa Tecnativa-Task #45329