### PR TITLE
[15.0][FIX] contract: invoice message create

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -575,8 +575,8 @@ class ContractContract(models.Model):
         This method triggers the creation of the next invoices of the contracts
         even if their next invoicing date is in the future.
         """
-        invoice = self._recurring_create_invoice()
-        if invoice:
+        invoices = self._recurring_create_invoice()
+        for invoice in invoices:
             self.message_post(
                 body=_(
                     "Contract manually invoiced: "
@@ -591,7 +591,7 @@ class ContractContract(models.Model):
                     "rec_id": invoice.id,
                 }
             )
-        return invoice
+        return invoices
 
     @api.model
     def _invoice_followers(self, invoices):


### PR DESCRIPTION
- Avoid singleton assertion.
- This PR was not added on migration module version 15.0 https://github.com/OCA/contract/pull/881
- This fix is needed for module contract_sale_invoicing. If you have multiple sale orders pending to invoice and create recurring invoices, raises singleton error.

@Tecnativa

TT45293

@pedrobaeza 

