### PR TITLE
[IMP] contract: Simplify management of recurring_next_date

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -62,6 +62,9 @@ class ContractContract(models.Model):
         inverse_name="contract_id",
         copy=True,
     )
+    recurring_next_date = fields.Date(
+        compute="_compute_recurring_next_date", store=True, readonly=True
+    )
     # Trick for being able to have 2 different views for the same o2m
     # We need this as one2many widget doesn't allow to define in the view
     # the same field 2 times with different views. 2 views are needed because

--- a/contract/models/contract_recurrency_mixin.py
+++ b/contract/models/contract_recurrency_mixin.py
@@ -78,7 +78,7 @@ class ContractRecurrencyMixin(models.AbstractModel):
 
     date_start = fields.Date(default=lambda self: fields.Date.context_today(self))
     recurring_next_date = fields.Date(
-        compute="_compute_recurring_next_date", store=True, readonly=False, copy=True
+        compute="_compute_recurring_next_date", store=True, readonly=True
     )
     date_end = fields.Date(string="Date End", index=True)
     next_period_date_start = fields.Date(


### PR DESCRIPTION
The usage of this field was confusing. It was set as editable, but I found several issues:

On creation, the change was not applied on contract recurring_next_date
On edition of lines, the change was showed, but got back to the computed value when saving.

IMO, it has much more sense to disable the edition. WDYT? May I be missing something?