### PR TITLE
[14.0][FIX] contract: fix domain of payment_term_id field

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -88,7 +88,7 @@ class ContractContract(models.Model):
         string="Payment Terms",
         index=True,
         check_company=True,
-        domain="[('company_id', '=', company_id)]",
+        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
     )
     invoice_count = fields.Integer(compute="_compute_invoice_count")
     fiscal_position_id = fields.Many2one(


### PR DESCRIPTION
The way the domain is defined requires the creation of payment terms and the definition of the company to be able to select in the contract. I understand that in the case of this field it should also allow you to select payment terms that the company does not define.

Speaking of which, I could be wrong but I believe that check_company would already do the verification without the need for this domain.

domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",


cc @alexis-via @douglascstd