### PR TITLE
14.0 fix contract manually single invoice

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -35,6 +35,7 @@
         "wizards/contract_line_wizard.xml",
         "wizards/contract_manually_create_invoice.xml",
         "wizards/contract_contract_terminate.xml",
+        "wizards/contract_manually_single_invoice.xml",
         "views/contract_tag.xml",
         "views/account_move_views.xml",
         "views/assets.xml",

--- a/contract/readme/CONTRIBUTORS.rst
+++ b/contract/readme/CONTRIBUTORS.rst
@@ -15,3 +15,6 @@
     * Víctor Martínez
 * Iván Antón <ozono@ozonomultimedia.com>
 * Eric Antones <eantones@nuobit.com>
+* `Dixmit <https://www.dixmit.com>`_:
+
+    * Enric Tobella

--- a/contract/security/ir.model.access.csv
+++ b/contract/security/ir.model.access.csv
@@ -14,3 +14,4 @@
 "contract_line_wizard","contract_line_wizard","model_contract_line_wizard","account.group_account_manager",1,1,1,1
 "contract_manually_create_invoice_wizard","contract_manually_create_invoice_wizard","model_contract_manually_create_invoice","account.group_account_invoice",1,1,1,1
 "contract_contract_terminate_wizard","contract_contract_terminate_wizard","model_contract_contract_terminate","contract.can_terminate_contract",1,1,1,1
+"contract_manually_single_invoice_wizard","contract_manually_single_process_wizard","model_contract_manually_single_invoice","account.group_account_invoice",1,1,1,1

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -279,7 +279,9 @@ class TestContract(TestContractBase):
         self.acct_line._onchange_product_id()
         self.acct_line.price_unit = 100.0
         self.contract.partner_id = self.partner.id
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.invoice_monthly = self.contract._get_related_invoices()
         self.assertTrue(self.invoice_monthly)
         self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-02-15"))
@@ -298,7 +300,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "daily"
         self.contract.pricelist_id = False
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoice_daily = self.contract._get_related_invoices()
         self.assertTrue(invoice_daily)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -317,7 +321,9 @@ class TestContract(TestContractBase):
         self.contract.message_subscribe(
             partner_ids=self.contract.partner_id.ids, subtype_ids=subtype_ids
         )
-        self.contract._recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoice_daily = self.contract._get_related_invoices()
         self.assertTrue(invoice_daily)
         self.assertTrue(self.contract.partner_id in invoice_daily.message_partner_ids)
@@ -329,7 +335,9 @@ class TestContract(TestContractBase):
             {"name": "Some Salesperson", "login": "salesperson_test"}
         )
         self.contract.user_id = new_salesperson
-        self.contract._recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoice_daily = self.contract._get_related_invoices()
         self.assertTrue(invoice_daily)
         self.assertEqual(self.contract.user_id, invoice_daily.user_id)
@@ -341,7 +349,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "weekly"
         self.acct_line.recurring_invoicing_type = "post-paid"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -353,7 +363,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "weekly"
         self.acct_line.recurring_invoicing_type = "pre-paid"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -365,7 +377,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "yearly"
         self.acct_line.recurring_invoicing_type = "post-paid"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -378,7 +392,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "yearly"
         self.acct_line.recurring_invoicing_type = "pre-paid"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -390,7 +406,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_invoicing_type = "post-paid"
         self.acct_line.recurring_rule_type = "monthlylastday"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoices_monthly_lastday = self.contract._get_related_invoices()
         self.assertTrue(invoices_monthly_lastday)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -403,7 +421,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "quarterly"
         self.acct_line.recurring_invoicing_type = "pre-paid"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -416,7 +436,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "quarterly"
         self.acct_line.recurring_invoicing_type = "post-paid"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -429,7 +451,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "semesterly"
         self.acct_line.recurring_invoicing_type = "pre-paid"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -442,7 +466,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_next_date = "2018-02-22"
         self.acct_line.recurring_rule_type = "semesterly"
         self.acct_line.recurring_invoicing_type = "post-paid"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         invoices_weekly = self.contract._get_related_invoices()
         self.assertTrue(invoices_weekly)
         self.assertEqual(self.acct_line.recurring_next_date, recurring_next_date)
@@ -481,13 +507,19 @@ class TestContract(TestContractBase):
         self.assertTrue(self.acct_line.create_invoice_visibility)
         self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-01-01"))
         self.assertFalse(self.acct_line.last_date_invoiced)
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-02-01"))
         self.assertEqual(self.acct_line.last_date_invoiced, to_date("2018-01-31"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.assertEqual(self.acct_line.last_date_invoiced, to_date("2018-02-28"))
         self.assertEqual(self.acct_line.last_date_invoiced, to_date("2018-02-28"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.assertEqual(self.acct_line.last_date_invoiced, to_date("2018-03-15"))
         self.assertFalse(self.acct_line.recurring_next_date)
         self.assertFalse(self.acct_line.create_invoice_visibility)
@@ -541,7 +573,12 @@ class TestContract(TestContractBase):
         journal = self.env["account.journal"].search([("type", "=", "sale")])
         journal.write({"type": "general"})
         with self.assertRaises(ValidationError):
-            self.contract.recurring_create_invoice()
+            self.env["contract.manually.single.invoice"].create(
+                {
+                    "date": self.contract.recurring_next_date,
+                    "contract_id": self.contract.id,
+                }
+            ).create_invoice()
 
     def test_check_date_end(self):
         with self.assertRaises(ValidationError):
@@ -1132,7 +1169,9 @@ class TestContract(TestContractBase):
 
     def test_recurring_next_date(self):
         """recurring next date for a contract is the min for all lines"""
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.assertEqual(
             self.contract.recurring_next_date,
             min(self.contract.contract_line_ids.mapped("recurring_next_date")),
@@ -1788,14 +1827,18 @@ class TestContract(TestContractBase):
         )
         self.assertEqual(first, to_date("2018-01-05"))
         self.assertEqual(last, to_date("2018-01-31"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
         )
         self.assertEqual(first, to_date("2018-02-01"))
         self.assertEqual(last, to_date("2018-02-28"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
@@ -1817,7 +1860,9 @@ class TestContract(TestContractBase):
         self.assertEqual(last, to_date("2018-01-31"))
         self.assertEqual(recurring_next_date, to_date("2018-01-05"))
         self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-01-05"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
@@ -1827,7 +1872,9 @@ class TestContract(TestContractBase):
         self.assertEqual(recurring_next_date, to_date("2018-02-01"))
         self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-02-01"))
         self.assertEqual(self.acct_line.last_date_invoiced, to_date("2018-01-31"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
@@ -1837,7 +1884,9 @@ class TestContract(TestContractBase):
         self.assertEqual(recurring_next_date, to_date("2018-03-01"))
         self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-03-01"))
         self.assertEqual(self.acct_line.last_date_invoiced, to_date("2018-02-28"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
@@ -1873,7 +1922,9 @@ class TestContract(TestContractBase):
         self.acct_line.recurring_invoicing_type = "post-paid"
         self.acct_line.recurring_rule_type = "monthly"
         self.acct_line.date_end = "2018-08-15"
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
@@ -1899,14 +1950,18 @@ class TestContract(TestContractBase):
         )
         self.assertEqual(first, to_date("2018-01-05"))
         self.assertEqual(last, to_date("2018-02-04"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
         )
         self.assertEqual(first, to_date("2018-02-05"))
         self.assertEqual(last, to_date("2018-03-04"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
@@ -1925,14 +1980,18 @@ class TestContract(TestContractBase):
         )
         self.assertEqual(first, to_date("2018-01-05"))
         self.assertEqual(last, to_date("2018-02-04"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
         )
         self.assertEqual(first, to_date("2018-02-05"))
         self.assertEqual(last, to_date("2018-03-04"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
@@ -1951,14 +2010,18 @@ class TestContract(TestContractBase):
         )
         self.assertEqual(first, to_date("2018-01-05"))
         self.assertEqual(last, to_date("2019-01-04"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
         )
         self.assertEqual(first, to_date("2019-01-05"))
         self.assertEqual(last, to_date("2020-01-04"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
@@ -1977,14 +2040,18 @@ class TestContract(TestContractBase):
         )
         self.assertEqual(first, to_date("2018-01-05"))
         self.assertEqual(last, to_date("2019-01-04"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
         )
         self.assertEqual(first, to_date("2019-01-05"))
         self.assertEqual(last, to_date("2020-01-04"))
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         first, last, recurring_next_date = self.acct_line._get_period_to_invoice(
             self.acct_line.last_date_invoiced,
             self.acct_line.recurring_next_date,
@@ -2239,9 +2306,15 @@ class TestContract(TestContractBase):
         self.assertEqual(view["view_id"], sale_form_view.id)
 
     def test_contract_count_invoice(self):
-        self.contract.recurring_create_invoice()
-        self.contract.recurring_create_invoice()
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.contract._compute_invoice_count()
         self.assertEqual(self.contract.invoice_count, 3)
 
@@ -2280,7 +2353,9 @@ class TestContract(TestContractBase):
         self.assertFalse(self.contract.recurring_create_invoice())
 
     def test_stop_at_last_date_invoiced(self):
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.assertTrue(self.acct_line.recurring_next_date)
         self.acct_line.stop(self.acct_line.last_date_invoiced)
         self.assertFalse(self.acct_line.recurring_next_date)
@@ -2373,7 +2448,9 @@ class TestContract(TestContractBase):
         self.assertFalse(self.contract3.recurring_next_date)
 
     def test_terminate_date_before_last_date_invoiced(self):
-        self.contract.recurring_create_invoice()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.assertEqual(self.acct_line.last_date_invoiced, to_date("2018-02-14"))
         group_can_terminate_contract = self.env.ref("contract.can_terminate_contract")
         group_can_terminate_contract.users |= self.env.user

--- a/contract/tests/test_contract_manually_create_invoice.py
+++ b/contract/tests/test_contract_manually_create_invoice.py
@@ -48,6 +48,31 @@ class TestContractManuallyCreateInvoice(TestContractBase):
         self.assertFalse(invoice_lines.mapped("move_id") - invoices)
         self.assertEqual(len(invoices), contract_to_invoice_count)
 
+    def test_contract_manually_single_contract(self):
+        contracts = self.env["contract.contract"]
+        for _i in range(10):
+            contracts |= self.contract.copy()
+        wizard = self.env["contract.manually.single.invoice"].create(
+            {"date": self.today, "contract_id": self.contract.id}
+        )
+        wizard.create_invoice()
+        invoice_lines = self.env["account.move.line"].search(
+            [("contract_line_id", "in", contracts.mapped("contract_line_ids").ids)]
+        )
+        self.assertEqual(
+            0,
+            len(invoice_lines),
+        )
+        invoice_lines = self.env["account.move.line"].search(
+            [("contract_line_id", "in", self.contract.mapped("contract_line_ids").ids)]
+        )
+        self.assertEqual(
+            2,
+            len(invoice_lines),
+        )
+        # Two invoices are available from to 2018-1-1 2018-3-15.
+        # We are invoicing at the end of the month
+
     def test_contract_manually_create_invoice_with_usererror(self):
 
         contracts = self.contract

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -38,11 +38,11 @@
                         groups="base.group_user"
                     />
                     <button
-                        name="recurring_create_invoice"
-                        type="object"
-                        attrs="{'invisible': ['|', ('create_invoice_visibility', '=', False),('generation_type','!=','invoice')]}"
-                        string="Create invoices"
-                        groups="base.group_no_one"
+                        name="%(contract.contract_manually_single_invoice_act_window)s"
+                        type="action"
+                        string="Process manually"
+                        context="{'default_contract_id': id, 'default_date': recurring_next_date}"
+                        attrs="{'invisible': [('id', '=', False)]}"
                     />
                     <button
                         name="action_terminate_contract"

--- a/contract/wizards/__init__.py
+++ b/contract/wizards/__init__.py
@@ -1,3 +1,4 @@
 from . import contract_line_wizard
 from . import contract_manually_create_invoice
 from . import contract_contract_terminate
+from . import contract_manually_single_invoice

--- a/contract/wizards/contract_manually_single_invoice.py
+++ b/contract/wizards/contract_manually_single_invoice.py
@@ -29,14 +29,15 @@ class ContractManuallySingleInvoice(models.TransientModel):
                     domain=[("id", "=", self.contract_id.id)],
                 )
             )
-            for record in result:
-                self.contract_id.message_post(
-                    body=_(
-                        "Contract manually generated: "
-                        '<a href="#" data-oe-model="%s" data-oe-id="%s">'
-                        "%s"
-                        "</a>"
+            for list in result:
+                for record in list:
+                    self.contract_id.message_post(
+                        body=_(
+                            "Contract manually generated: "
+                            '<a href="#" data-oe-model="%s" data-oe-id="%s">'
+                            "%s"
+                            "</a>"
+                        )
+                        % (record._name, record.id, record.display_name)
                     )
-                    % (record._name, record.id, record.display_name)
-                )
         return True

--- a/contract/wizards/contract_manually_single_invoice.py
+++ b/contract/wizards/contract_manually_single_invoice.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Dixmit
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, fields, models
+
+
+class ContractManuallySingleInvoice(models.TransientModel):
+    _name = "contract.manually.single.invoice"
+    _description = "Manually invoice a single contract"
+
+    contract_id = fields.Many2one("contract.contract", required=True)
+    date = fields.Date(required=True, default=lambda r: fields.Date.today())
+
+    def create_invoice(self):
+        while (
+            self.contract_id.recurring_next_date
+            and self.contract_id.recurring_next_date <= self.date
+            and (
+                not self.contract_id.date_end
+                or self.contract_id.recurring_next_date <= self.contract_id.date_end
+            )
+        ):
+            result = (
+                self.env["contract.contract"]
+                .with_company(self.contract_id.company_id.id)
+                ._cron_recurring_create(
+                    self.contract_id.recurring_next_date,
+                    create_type=self.contract_id.generation_type,
+                    domain=[("id", "=", self.contract_id.id)],
+                )
+            )
+            for record in result:
+                self.contract_id.message_post(
+                    body=_(
+                        "Contract manually generated: "
+                        '<a href="#" data-oe-model="%s" data-oe-id="%s">'
+                        "%s"
+                        "</a>"
+                    )
+                    % (record._name, record.id, record.display_name)
+                )
+        return True

--- a/contract/wizards/contract_manually_single_invoice.xml
+++ b/contract/wizards/contract_manually_single_invoice.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Dixmit
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="contract_manually_single_invoice_form_view">
+        <field name="name">contract.manually.single.invoice.form (in contract)</field>
+        <field name="model">contract.manually.single.invoice</field>
+        <field name="arch" type="xml">
+            <form string="Contract Manually Single Invoice">
+                <!-- TODO -->
+                <group>
+                    <field name="contract_id" invisible="1" />
+                    <field name="date" />
+                </group>
+                <footer>
+                    <button
+                        name="create_invoice"
+                        string="Generate invoices"
+                        class="btn-primary"
+                        type="object"
+                    />
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record
+        model="ir.actions.act_window"
+        id="contract_manually_single_invoice_act_window"
+    >
+        <field name="name">Process Contract Manually</field> <!-- TODO -->
+        <field name="res_model">contract.manually.single.invoice</field>
+        <field name="view_mode">form</field>
+        <field name="context">{}</field>
+        <field name="target">new</field>
+    </record>
+
+
+</odoo>

--- a/contract_sale_generation/models/contract.py
+++ b/contract_sale_generation/models/contract.py
@@ -8,7 +8,11 @@
 # Copyright 2018 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import logging
+
 from odoo import _, api, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class ContractContract(models.Model):
@@ -70,6 +74,9 @@ class ContractContract(models.Model):
         This method triggers the creation of the next sale order of the
         contracts even if their next sale order date is in the future.
         """
+        _logger.warning(
+            "recurring_create_invoice is no longer necessary. It should be removed on v17"
+        )
         sales = self._recurring_create_sale()
         for sale_rec in sales:
             self.message_post(

--- a/contract_sale_generation/tests/test_contract_sale_recurrency.py
+++ b/contract_sale_generation/tests/test_contract_sale_recurrency.py
@@ -67,12 +67,15 @@ class TestContractSale(ContractSaleCommon, SavepointCase):
         self.assertEqual(
             fields.Date.to_date("2020-01-15"), self.contract.recurring_next_date
         )
-
-        self.contract.recurring_create_sale()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.assertEqual(
             fields.Date.to_date("2020-01-22"), self.contract.recurring_next_date
         )
-        self.contract.recurring_create_sale()
+        self.env["contract.manually.single.invoice"].create(
+            {"date": self.contract.recurring_next_date, "contract_id": self.contract.id}
+        ).create_invoice()
         self.assertEqual(
             fields.Date.to_date("2020-01-29"), self.contract.recurring_next_date
         )

--- a/contract_sale_generation/views/contract.xml
+++ b/contract_sale_generation/views/contract.xml
@@ -10,16 +10,6 @@
                     name="sale_autoconfirm"
                 />
             </xpath>
-            <xpath expr="//button[@name='recurring_create_invoice']" position="before">
-                <button
-                    attrs="{'invisible': [('generation_type','!=','sale')]}"
-                    class="oe_link"
-                    groups="base.group_no_one"
-                    name="recurring_create_sale"
-                    string="CREATE SALES"
-                    type="object"
-                />
-            </xpath>
             <xpath expr="//button[@name='action_show_invoices']" position="after">
                 <button
                     attrs="{'invisible': [('generation_type','!=','sale')]}"


### PR DESCRIPTION
based on #1005 

review only last commit

if the method creating invoice generates more than one invoice, we have
`[account.move(ID1, ID2)]` for example and the `message_post()` fails w/ a `singleton error`.

Adding a loop level allows to properly post messages no matter of the number of invoices generated by the wizard