### PR TITLE
[FIX] contract: removed dateutil from dependencies

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -18,7 +18,6 @@
     "website": "https://github.com/OCA/contract",
     "depends": ["base", "account", "product", "portal"],
     "development_status": "Production/Stable",
-    "external_dependencies": {"python": ["dateutil"]},
     "data": [
         "security/groups.xml",
         "security/contract_tag.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# generated from manifests external_dependencies
-python-dateutil


### PR DESCRIPTION
**Context**
Since Odoo 16.0 has included dateutil on its dependencies, loading dateutil from here is generating Warning in Odoo.sh deployments

https://github.com/odoo/odoo/blob/16.0/requirements.txt#L46

**Before**
![Odoo-sh-Builds-1-](https://github.com/OCA/contract/assets/5335402/7c298b7e-7210-4cd0-94bc-b3847e59703c)

**After**
![Odoo-sh-Builds (2)](https://github.com/OCA/contract/assets/5335402/d55f98be-a08c-417c-bc62-1ef6952f61ea)
