### PR TITLE
[15.0][FIX] incorrect inherit res_partner_views

### DIFF
--- a/subscription_oca/views/res_partner_views.xml
+++ b/subscription_oca/views/res_partner_views.xml
@@ -6,7 +6,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <button name="action_view_partner_invoices" position="after">
+            <div name="button_box" position="inside">
                 <field name="subscription_ids" invisible="1" />
                 <button
                     type="object"
@@ -22,7 +22,7 @@
                         <span class="o_stat_text">Subscriptions</span>
                     </div>
                 </button>
-            </button>
+            </div>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
this fix corrects a bug that prevents people without billing permissions from opening contacts.