### PR TITLE
[16.0][IMP] contract: Protect line recurrrency change

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -148,7 +148,11 @@
                         </group>
                     </group>
                     <group name="recurring_invoices">
-                        <field name="line_recurrence" class="oe_inline" />
+                        <field
+                            name="line_recurrence"
+                            class="oe_inline"
+                            attrs="{'readonly': [('line_recurrence', '=', True), ('invoice_count', '!=', 0)]}"
+                        />
                         <label for="line_recurrence" />
                         <group attrs="{'invisible': [('line_recurrence', '=', True)]}">
                             <label for="recurring_interval" />


### PR DESCRIPTION
Forward-port of #1033 

If you have defined several contract lines, each one with their recurrency information, unmarking the check "Line recurrency" by mistake and saving will make you lose the configuration in one shot, and also modify the invoceability conditions.

Thus, it's reasonable to avoid to uncheck the mark once you have at least one invoice issued for a contract with this mark checked.

@Tecnativa 