### PR TITLE
[15.0][IMP] contract: Remove buttons from contract lines if recurrence is not per line

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -266,35 +266,6 @@
                                     <field name="is_cancel_allowed" invisible="1" />
                                     <field name="is_un_cancel_allowed" invisible="1" />
                                     <field name="is_canceled" invisible="1" />
-                                    <button
-                                        name="action_plan_successor"
-                                        string="Plan Start"
-                                        type="object"
-                                        icon="fa-calendar text-success"
-                                        attrs="{'invisible': [('is_plan_successor_allowed', '=', False)]}"
-                                    />
-                                    <button
-                                        name="action_stop"
-                                        string="Stop"
-                                        type="object"
-                                        icon="fa-stop text-danger"
-                                        attrs="{'invisible': [('is_stop_allowed', '=', False)]}"
-                                    />
-                                    <button
-                                        name="cancel"
-                                        string="Cancel"
-                                        type="object"
-                                        icon="fa-ban text-danger"
-                                        confirm="Are you sure you want to cancel this line"
-                                        attrs="{'invisible': [('is_cancel_allowed', '=', False)]}"
-                                    />
-                                    <button
-                                        name="action_uncancel"
-                                        string="Un-cancel"
-                                        type="object"
-                                        icon="fa-ban text-success"
-                                        attrs="{'invisible': [('is_un_cancel_allowed', '=', False)]}"
-                                    />
                                 </tree>
                             </field>
                             <field


### PR DESCRIPTION
Remove buttons from contract lines if recurrence is not per line

If we manage the contract at header level, we must set the end date and last invoice date there, otherwise data will be inconsistent.

Please @pedrobaeza can you review it?

@Tecnativa TT48273