### PR TITLE
[16.0][FIX] contract: Fix modifications layout

### DIFF
--- a/contract/data/template_mail_notification.xml
+++ b/contract/data/template_mail_notification.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" ?>
 <odoo>
+    <template
+        id="mail_notification_contract"
+        inherit_id="mail.mail_notification_layout"
+        primary="True"
+    >
+        <xpath expr="//div[@t-out='message.body']" position="after">
+            <t t-raw="0" />
+        </xpath>
+    </template>
     <template id="template_contract_modification" name="Contract Modification">
         <t t-call="contract.mail_notification_contract">
             <table border="1" align="center">
@@ -12,10 +21,10 @@
                 <tbody>
                     <t t-foreach="record.modification_ids" t-as="modification">
                         <tr t-if="not modification.sent">
-                            <td name="td_date">
+                            <td name="td_date" style="padding: 10px">
                                 <span t-field="modification.date" />
                             </td>
-                            <td name="td_description">
+                            <td name="td_description" style="padding: 10px">
                                 <div t-field="modification.description" />
                             </td>
                         </tr>


### PR DESCRIPTION
On the migration to v16, the primary layout view was incorrectly removed. It's needed because of 2 reasons:

- It's referenced in the following template doing a t-call. Well, this one can be avoided calling the new layout upstream template, but...
- This layout is done for placing some extra content (the modifications table), as part of the layout that is not shown in the chatter for avoiding noise.

We recreate this template inheriting the new layout template, and adapting it properly.

Before:

![imagen](https://github.com/OCA/contract/assets/7165771/a0e1c7d8-abdb-4217-a8a7-de810c78375e)

After:

![imagen](https://github.com/OCA/contract/assets/7165771/8d7bc698-c327-4326-88cd-2054d551ef13)


@Tecnativa TT45646