### PR TITLE
[16.0][IMP] contract: improve visual

### DIFF
--- a/contract/views/abstract_contract_line.xml
+++ b/contract/views/abstract_contract_line.xml
@@ -22,7 +22,7 @@
                         />
                     </group>
                     <group
-                        col="6"
+                        col="2"
                         attrs="{'invisible': [('display_type', '!=', False)]}"
                     >
                         <group colspan="1">


### PR DESCRIPTION
Working with the contracts you have found the following view for the contract lines:

![1](https://github.com/OCA/contract/assets/82393040/cbf06544-910c-4310-8f3f-898438c596c0)


A small change has been made to improve the visual as follows:

![2](https://github.com/OCA/contract/assets/82393040/e8eee711-0d8f-4099-a768-cddd8ce190bd)
