### PR TITLE
[16.0][IMP] contract and contract_variable_quantity: improve visual of contract lines

### DIFF
--- a/contract/views/abstract_contract_line.xml
+++ b/contract/views/abstract_contract_line.xml
@@ -16,65 +16,30 @@
                     <field colspan="1" name="product_uom_category_id" invisible="1" />
                     <group>
                         <field
-                            colspan="1"
                             name="product_id"
                             attrs="{'required': [('display_type', '=', 'product')],'invisible': [('display_type', '!=', False)]}"
                         />
                     </group>
-                    <group
-                        col="2"
-                        attrs="{'invisible': [('display_type', '!=', False)]}"
-                    >
-                        <group colspan="1">
-                            <label for="automatic_price" colspan="2" />
-                            <field colspan="2" name="automatic_price" nolabel="1" />
-                        </group>
-                        <group colspan="1">
-                            <label for="price_unit" colspan="2" />
+                    <group attrs="{'invisible': [('display_type', '!=', False)]}">
+                        <group>
+                            <field name="automatic_price" />
                             <field
-                                colspan="2"
                                 name="price_unit"
                                 attrs="{'readonly': [('automatic_price', '=', True)]}"
-                                nolabel="1"
                             />
+                            <field name="quantity" />
                         </group>
-                        <group colspan="1">
-                            <label for="quantity" colspan="2" />
+                        <group>
                             <field
-                                colspan="2"
-                                name="quantity"
-                                class="oe_inline"
-                                nolabel="1"
-                            />
-                        </group>
-                        <group colspan="1">
-                            <label for="uom_id" colspan="2" />
-                            <field
-                                colspan="2"
                                 name="uom_id"
-                                class="oe_inline"
                                 groups="uom.group_uom"
                                 attrs="{'required': [('display_type', '=', False)]}"
-                                nolabel="1"
                             />
-                        </group>
-                        <group colspan="1">
-                            <label for="discount" colspan="2" />
                             <field
-                                colspan="2"
                                 name="discount"
                                 groups="product.group_discount_per_so_line"
-                                nolabel="1"
                             />
-                        </group>
-                        <group colspan="1">
-                            <label for="price_subtotal" colspan="2" />
-                            <field
-                                colspan="2"
-                                name="price_subtotal"
-                                readonly="1"
-                                nolabel="1"
-                            />
+                            <field name="price_subtotal" readonly="1" />
                         </group>
                     </group>
                     <label
@@ -99,46 +64,37 @@
                     >
                         <field name="note_invoicing_mode" widget="radio" />
                     </group>
-                    <group
-                        col="4"
-                        attrs="{'invisible': [('display_type', '!=', False)]}"
-                    >
-                        <field colspan="2" name="is_auto_renew" />
-                        <field colspan="2" name="is_canceled" invisible="1" />
+                    <group attrs="{'invisible': [('display_type', '!=', False)]}">
+                        <field name="is_auto_renew" />
+                        <field name="is_canceled" invisible="1" />
                     </group>
                     <group
                         attrs="{'invisible':['|', ('is_auto_renew', '=', False), ('display_type', '!=', False)]}"
                     >
                         <group>
                             <label for="auto_renew_interval" />
-                            <div>
+                            <div class="o_row">
                                 <field
                                     name="auto_renew_interval"
-                                    class="oe_inline"
-                                    nolabel="1"
                                     attrs="{'required':[('is_auto_renew', '=', True)]}"
                                 />
                                 <field
                                     name="auto_renew_rule_type"
-                                    class="oe_inline"
-                                    nolabel="1"
                                     attrs="{'required':[('is_auto_renew', '=', True)]}"
                                 />
                             </div>
                         </group>
                         <group>
                             <label for="termination_notice_interval" />
-                            <div>
+                            <div class="o_row">
                                 <field
                                     name="termination_notice_interval"
                                     class="oe_inline"
-                                    nolabel="1"
                                     attrs="{'required':[('is_auto_renew', '=', True)]}"
                                 />
                                 <field
                                     name="termination_notice_rule_type"
                                     class="oe_inline"
-                                    nolabel="1"
                                     attrs="{'required':[('is_auto_renew', '=', True)]}"
                                 />
                             </div>
@@ -151,19 +107,9 @@
                         <group>
                             <label for="recurring_interval" />
                             <div class="o_row">
-                                <field
-                                    name="recurring_interval"
-                                    class="oe_inline"
-                                    nolabel="1"
-                                />
-                                <field
-                                    name="recurring_rule_type"
-                                    class="oe_inline"
-                                    nolabel="1"
-                                />
+                                <field name="recurring_interval" />
+                                <field name="recurring_rule_type" />
                             </div>
-                        </group>
-                        <group>
                             <field name="recurring_invoicing_type" />
                             <field name="recurring_invoicing_offset" />
                         </group>

--- a/contract_variable_quantity/views/abstract_contract_line.xml
+++ b/contract_variable_quantity/views/abstract_contract_line.xml
@@ -8,7 +8,7 @@
             ref="contract.contract_abstract_contract_line_form_view"
         />
         <field name="arch" type="xml">
-            <xpath expr="//label[@for='quantity']" position="before">
+            <xpath expr="//field[@name='quantity']" position="before">
                 <field name="qty_type" />
             </xpath>
             <xpath expr="//field[@name='quantity']" position="after">


### PR DESCRIPTION
Working with the contracts you have found the following view for the contract lines:

![1](https://github.com/OCA/contract/assets/82393040/519badc7-2803-4b87-8973-d9773db8d12a)


Several changes have been made to improve the visual for the l contract lines, which is displayed as follows:

![2](https://github.com/OCA/contract/assets/82393040/9c385b67-3463-4a6c-9c76-35a2303cbc14)
