### PR TITLE
[16.0][IMP] contract: solve error for last_date_invoiced field

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -514,6 +514,7 @@ class ContractContract(models.Model):
                 not contract_line.is_canceled
                 and contract_line.recurring_next_date
                 and contract_line.recurring_next_date <= date_ref
+                and contract_line.next_period_date_start
             )
 
         lines2invoice = previous = self.env["contract.line"]

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -1744,6 +1744,29 @@ class TestContract(TestContractBase):
             len(invoice_lines),
         )
 
+    def test_recurring_create_invoice(self):
+        self.acct_line.date_start = "2024-01-01"
+        self.acct_line.recurring_invoicing_type = "pre-paid"
+        self.acct_line.date_end = "2024-04-01"
+        self.contract.recurring_create_invoice()
+        self.assertEqual(self.acct_line.last_date_invoiced, to_date("2024-01-31"))
+        self.assertEqual(self.acct_line.recurring_next_date, to_date("2024-02-01"))
+        self.assertEqual(len(self.contract._get_related_invoices()), 1)
+        self.contract.recurring_create_invoice()
+        self.assertEqual(self.acct_line.last_date_invoiced, to_date("2024-02-29"))
+        self.assertEqual(self.acct_line.recurring_next_date, to_date("2024-03-01"))
+        self.assertEqual(len(self.contract._get_related_invoices()), 2)
+        self.contract.recurring_create_invoice()
+        self.assertEqual(self.acct_line.last_date_invoiced, to_date("2024-03-31"))
+        self.assertEqual(self.acct_line.recurring_next_date, to_date("2024-04-01"))
+        self.assertEqual(len(self.contract._get_related_invoices()), 3)
+        self.contract.recurring_create_invoice()
+        self.assertEqual(self.acct_line.last_date_invoiced, to_date("2024-04-01"))
+        self.assertFalse(self.acct_line.recurring_next_date)
+        self.assertEqual(len(self.contract._get_related_invoices()), 4)
+        self.contract.recurring_create_invoice()
+        self.assertEqual(len(self.contract._get_related_invoices()), 4)
+
     def test_get_period_to_invoice_monthlylastday_postpaid(self):
         self.acct_line.date_start = "2018-01-05"
         self.acct_line.recurring_invoicing_type = "post-paid"


### PR DESCRIPTION
When working with contracts, an error has been found in the creation of sales/invoice when the end date on the lines is exceeded.

## To Reproduce

1. Create a contract and add start date

![1](https://github.com/OCA/contract/assets/82393040/5d301f76-9cf8-4dc9-8db1-2dac0f3ace48)


2. Add an end date (check that the value is passed to the lines)

![2](https://github.com/OCA/contract/assets/82393040/f83c5955-9190-4e96-af05-2e62c5dc996b)


3. Create contracts until we reach the end date and the error occurs

![3](https://github.com/OCA/contract/assets/82393040/26dcc64d-cfff-4132-9b2c-461f83ee1be2)


![4](https://github.com/OCA/contract/assets/82393040/e7b52d7b-8c5e-486c-bcc8-778904f807a6)



A small change has been made to the code to create order/invoice when lines exceed the end date, which is what causes the error.