### PR TITLE
[FIX] product-contract: non-existent external dependency in manifest

### DIFF
--- a/product_contract/__manifest__.py
+++ b/product_contract/__manifest__.py
@@ -18,6 +18,6 @@
     ],
     "installable": True,
     "application": False,
-    "external_dependencies": {"python": ["dateutil"]},
+    "external_dependencies": {"python": ["python-dateutil"]},
     "maintainers": ["sbejaoui"],
 }


### PR DESCRIPTION
The `dateutil` is a non-existent dependency. This modification replaces it by `python-dateutil`.
- https://pypi.org/project/python-dateutil/