### PR TITLE
[16.0][FIX] contract: report translations & change structure

### DIFF
--- a/contract/README.rst
+++ b/contract/README.rst
@@ -127,6 +127,9 @@ Contributors
     * Rafael Blasco
     * Víctor Martínez
 * Iván Antón <ozono@ozonomultimedia.com>
+* `[APSL] <https://www.apsl.tech>`_:
+
+    * Antoni Marroig <amarroig@apsl.net>
 
 Maintainers
 ~~~~~~~~~~~

--- a/contract/readme/CONTRIBUTORS.rst
+++ b/contract/readme/CONTRIBUTORS.rst
@@ -14,3 +14,6 @@
     * Rafael Blasco
     * Víctor Martínez
 * Iván Antón <ozono@ozonomultimedia.com>
+* `[APSL] <https://www.apsl.tech>`_:
+
+    * Antoni Marroig <amarroig@apsl.net>

--- a/contract/report/contract_views.xml
+++ b/contract/report/contract_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Contract</field>
         <field name="model">contract.contract</field>
         <field name="report_type">qweb-pdf</field>
-        <field name="report_name">contract.report_contract_document</field>
+        <field name="report_name">contract.report_contract_template</field>
         <field name="report_file">contract.report_contract</field>
         <field name="binding_model_id" ref="model_contract_contract" />
         <field name="binding_type">report</field>

--- a/contract/report/report_contract.xml
+++ b/contract/report/report_contract.xml
@@ -1,209 +1,192 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="report_contract_document">
-        <t t-call="web.html_container">
-            <t t-foreach="docs" t-as="o">
-                <t t-call="web.external_layout">
-                    <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)" />
-                    <t t-set="address">
-                        <p id="partner_info">
-                            <strong>Partner:</strong>
+        <t t-call="web.external_layout">
+            <t t-set="o" t-value="o.with_context(lang=lang)" />
+            <t t-set="address">
+                <p id="partner_info">
+                    <strong>Partner:</strong>
+                </p>
+                <div
+                    t-field="o.partner_id"
+                    t-options='{"widget": "contact", "fields": ["address", "name", "phone", "mobile", "fax", "email"], "no_marker": true, "phone_icons": true}'
+                />
+                <p t-if="o.partner_id.vat">VAT: <span t-field="o.partner_id.vat" /></p>
+            </t>
+            <div class="page">
+                <div class="oe_structure" />
+                <div class="row" id="header_info">
+                    <div class="col-3">
+                        <strong>Responsible: </strong>
+                        <p t-field="o.user_id" />
+                        <strong>Contract: </strong>
+                        <p t-field="o.code" />
+                    </div>
+                </div>
+                <div class="row" id="invoice_info">
+                    <t t-set="total" t-value="0" />
+                    <div class="col-12">
+                        <p id="services_info">
+                            <strong>Recurring Items</strong>
                         </p>
-                        <div
-                            t-field="o.partner_id"
-                            t-options='{"widget": "contact", "fields": ["address", "name", "phone", "mobile", "fax", "email"], "no_marker": true, "phone_icons": true}'
-                        />
-                        <p t-if="o.partner_id.vat">VAT: <span
-                                t-field="o.partner_id.vat"
-                            /></p>
-                    </t>
-                    <div class="page">
-                        <div class="oe_structure" />
-                        <div class="row" id="header_info">
-                            <div class="col-3">
-                                <strong>Responsible: </strong>
-                                <p t-field="o.user_id" />
-                                <strong>Contract: </strong>
-                                <p t-field="o.code" />
-                            </div>
-                        </div>
-                        <div class="row" id="invoice_info">
-                            <t t-set="total" t-value="0" />
-                            <div class="col-12">
-                                <p id="services_info">
-                                    <strong>Recurring Items</strong>
-                                </p>
-                                <table class="table table-sm">
-                                    <thead>
-                                        <tr>
-                                            <th>
-                                                <strong>Description</strong>
-                                            </th>
-                                            <th class="text-right">
-                                                <strong>Quantity</strong>
-                                            </th>
-                                            <th class="text-right">
-                                                <strong>Unit Price</strong>
-                                            </th>
-                                            <th class="text-right">
-                                                <strong>Price</strong>
-                                            </th>
-                                            <th class="text-right">
-                                                <strong>Date Start</strong>
-                                            </th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <t t-set="current_subtotal" t-value="0" />
-                                        <t t-foreach="o.contract_line_ids" t-as="l">
+                        <table class="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>
+                                        <strong>Description</strong>
+                                    </th>
+                                    <th class="text-right">
+                                        <strong>Quantity</strong>
+                                    </th>
+                                    <th class="text-right">
+                                        <strong>Unit Price</strong>
+                                    </th>
+                                    <th class="text-right">
+                                        <strong>Price</strong>
+                                    </th>
+                                    <th class="text-right">
+                                        <strong>Date Start</strong>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <t t-set="current_subtotal" t-value="0" />
+                                <t t-foreach="o.contract_line_ids" t-as="l">
+                                    <t
+                                        t-set="current_subtotal"
+                                        t-value="current_subtotal + l.price_subtotal"
+                                    />
+                                    <tr
+                                        t-att-class="'bg-200 font-weight-bold o_line_section' if l.display_type == 'line_section' else 'font-italic o_line_note' if l.display_type == 'line_note' else ''"
+                                    >
+                                        <t t-if="not l.display_type">
+                                            <td>
+                                                <span t-field="l.name" />
+                                            </td>
+                                            <td class="text-right">
+                                                <span t-field="l.quantity" />
+                                            </td>
+                                            <td class="text-right">
+                                                <span
+                                                    t-field="l.price_unit"
+                                                    t-options='{"widget": "monetary", "display_currency": o.currency_id}'
+                                                />
+                                            </td>
+                                            <td class="text-right">
+                                                <span
+                                                    t-field="l.price_subtotal"
+                                                    t-options='{"widget": "monetary", "display_currency": o.currency_id}'
+                                                />
+                                            </td>
+                                            <td class="text-right">
+                                                <span t-field="l.date_start" />
+                                            </td>
                                             <t
-                                                t-set="current_subtotal"
-                                                t-value="current_subtotal + l.price_subtotal"
+                                                t-set="total"
+                                                t-value="total + l.price_subtotal"
                                             />
-                                            <tr
-                                                t-att-class="'bg-200 font-weight-bold o_line_section' if l.display_type == 'line_section' else 'font-italic o_line_note' if l.display_type == 'line_note' else ''"
-                                            >
-                                                <t t-if="not l.display_type">
-                                                    <td>
-                                                        <span t-field="l.name" />
-                                                    </td>
-                                                    <td class="text-right">
-                                                        <span t-field="l.quantity" />
-                                                    </td>
-                                                    <td class="text-right">
-                                                        <span
-                                                            t-field="l.price_unit"
-                                                            t-options='{"widget": "monetary", "display_currency": o.currency_id}'
-                                                        />
-                                                    </td>
-                                                    <td class="text-right">
-                                                        <span
-                                                            t-field="l.price_subtotal"
-                                                            t-options='{"widget": "monetary", "display_currency": o.currency_id}'
-                                                        />
-                                                    </td>
-                                                    <td class="text-right">
-                                                        <span t-field="l.date_start" />
-                                                    </td>
-                                                    <t
-                                                        t-set="total"
-                                                        t-value="total + l.price_subtotal"
-                                                    />
-                                                </t>
-                                                <t
-                                                    t-if="l.display_type == 'line_section'"
-                                                >
-                                                    <td colspan="99">
-                                                        <span t-field="l.name" />
-                                                    </td>
-                                                    <t
-                                                        t-set="current_section"
-                                                        t-value="l"
-                                                    />
-                                                    <t
-                                                        t-set="current_subtotal"
-                                                        t-value="0"
-                                                    />
-                                                </t>
-                                                <t t-if="l.display_type == 'line_note'">
-                                                    <td colspan="99">
-                                                        <span t-field="l.name" />
-                                                    </td>
-                                                </t>
-                                            </tr>
-                                            <t
-                                                t-if="current_section and (l_last or o.contract_line_ids[l_index+1].display_type == 'line_section')"
-                                            >
-                                                <tr class="is-subtotal text-right">
-                                                    <td colspan="99">
-                                                        <strong
-                                                            class="mr16"
-                                                        >Subtotal</strong>
-                                                        <span
-                                                            t-esc="current_subtotal"
-                                                            t-options='{"widget": "monetary", "display_currency": o.currency_id}'
-                                                        />
-                                                    </td>
-                                                </tr>
-                                            </t>
                                         </t>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                        <div
-                            class="row"
-                            id="modification_info"
-                            t-if="o.modification_ids"
-                        >
-                            <div class="col-12">
-                                <p id="modification_info_p">
-                                    <strong>Modifications</strong>
-                                </p>
-                                <table class="table table-sm">
-                                    <thead>
-                                        <tr>
-                                            <th name="th_date">Date</th>
-                                            <th
-                                                name="th_description"
-                                                class="text-right"
-                                            >Description</th>
+                                        <t t-if="l.display_type == 'line_section'">
+                                            <td colspan="99">
+                                                <span t-field="l.name" />
+                                            </td>
+                                            <t t-set="current_section" t-value="l" />
+                                            <t t-set="current_subtotal" t-value="0" />
+                                        </t>
+                                        <t t-if="l.display_type == 'line_note'">
+                                            <td colspan="99">
+                                                <span t-field="l.name" />
+                                            </td>
+                                        </t>
+                                    </tr>
+                                    <t
+                                        t-if="current_section and (l_last or o.contract_line_ids[l_index+1].display_type == 'line_section')"
+                                    >
+                                        <tr class="is-subtotal text-right">
+                                            <td colspan="99">
+                                                <strong class="mr16">Subtotal</strong>
+                                                <span
+                                                    t-esc="current_subtotal"
+                                                    t-options='{"widget": "monetary", "display_currency": o.currency_id}'
+                                                />
+                                            </td>
                                         </tr>
-                                    </thead>
-                                    <tbody>
-                                        <t
-                                            t-foreach="o.modification_ids"
-                                            t-as="notification_id"
-                                        >
-                                            <tr>
-                                                <td name="td_date">
-                                                    <span
-                                                        t-field="notification_id.date"
-                                                    />
-                                                </td>
-                                                <td
-                                                    name="td_description"
-                                                    class="text-right"
-                                                >
-                                                    <div
-                                                        t-field="notification_id.description"
-                                                    />
-                                                </td>
-                                            </tr>
-                                        </t>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                        <div id="total" class="row" name="total">
-                            <div class="col-4 ml-auto">
-                                <table class="table table-sm">
-                                    <tr class="border-black o_subtotal" style="">
-                                        <td>
-                                            <strong>Total</strong>
+                                    </t>
+                                </t>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="row" id="modification_info" t-if="o.modification_ids">
+                    <div class="col-12">
+                        <p id="modification_info_p">
+                            <strong>Modifications</strong>
+                        </p>
+                        <table class="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th name="th_date">Date</th>
+                                    <th
+                                        name="th_description"
+                                        class="text-right"
+                                    >Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <t
+                                    t-foreach="o.modification_ids"
+                                    t-as="notification_id"
+                                >
+                                    <tr>
+                                        <td name="td_date">
+                                            <span t-field="notification_id.date" />
                                         </td>
-                                        <td class="text-right">
-                                            <span
-                                                t-esc="total"
-                                                t-options='{"widget": "monetary", "display_currency": o.currency_id}'
+                                        <td name="td_description" class="text-right">
+                                            <div
+                                                t-field="notification_id.description"
                                             />
                                         </td>
                                     </tr>
-                                </table>
-                            </div>
-                        </div>
+                                </t>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div id="total" class="row" name="total">
+                    <div class="col-4 ml-auto">
+                        <table class="table table-sm">
+                            <tr class="border-black o_subtotal" style="">
+                                <td>
+                                    <strong>Total</strong>
+                                </td>
+                                <td class="text-right">
+                                    <span
+                                        t-esc="total"
+                                        t-options='{"widget": "monetary", "display_currency": o.currency_id}'
+                                    />
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+                <div>
+                    <div class="row mt-4" id="note">
                         <div>
-                            <div class="row mt-4" id="note">
-                                <div>
-                                    <strong>Notes: </strong>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <p t-field="o.note" />
-                            </div>
+                            <strong>Notes: </strong>
                         </div>
                     </div>
-                </t>
+                    <div class="row">
+                        <p t-field="o.note" />
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+    <template id="report_contract_template">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-set="lang" t-value="o.partner_id.lang" />
+                <t t-call="contract.report_contract_document" t-lang="lang" />
             </t>
         </t>
     </template>

--- a/contract/static/description/index.html
+++ b/contract/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -485,14 +484,19 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><p class="first">Iván Antón &lt;<a class="reference external" href="mailto:ozono&#64;ozonomultimedia.com">ozono&#64;ozonomultimedia.com</a>&gt;</p>
 </li>
+<li><p class="first"><a class="reference external" href="https://www.apsl.tech">[APSL]</a>:</p>
+<blockquote>
+<ul class="simple">
+<li>Antoni Marroig &lt;<a class="reference external" href="mailto:amarroig&#64;apsl.net">amarroig&#64;apsl.net</a>&gt;</li>
+</ul>
+</blockquote>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Description of the problem:
Go to Invoicing -> Customer Contracts and try to print a contract.
Normally when you print a contract the default language of that one bases on customer language but not works in that report.
Example:
Your default language is Spanish and your customer's default language is English
Try to print the report and you see that the report prints in Spanish and not in English.
I changed the structure because i'm base of the report of an invoice from the odoo's core structure(see more in the links below):

https://github.com/odoo/odoo/blob/16.0/addons/account/views/report_invoice.xml#L329
https://github.com/odoo/odoo/blob/16.0/addons/account/views/report_invoice.xml#L4

I test that structure first and works perfect and I try to reproduce in that case and works fine.

[contract_report_failed.webm](https://github.com/OCA/contract/assets/91435961/6e7eb612-595f-43b6-a2e6-bed64a8b60af)

[contract_report_works.webm](https://github.com/OCA/contract/assets/91435961/12ba0c84-f4bd-406a-8816-54b54ab239f9)

