### PR TITLE
[16.0][IMP] contract: Big changes in recurrency fields 

### DIFF
--- a/contract/models/abstract_contract.py
+++ b/contract/models/abstract_contract.py
@@ -80,3 +80,20 @@ class ContractAbstractContract(models.AbstractModel):
                 contract.journal_id = journal.id
             else:
                 contract.journal_id = None
+
+    @api.onchange(
+        "date_start",
+        "date_end",
+        "recurring_interval",
+        "recurring_rule_type",
+        "recurring_invoicing_type",
+    )
+    def _onchange_recurrency_fields(self):
+        if self.contract_line_fixed_ids:
+            self.contract_line_fixed_ids.date_start = self.date_start
+            self.contract_line_fixed_ids.date_end = self.date_end
+            self.contract_line_fixed_ids.recurring_interval = self.recurring_interval
+            self.contract_line_fixed_ids.recurring_rule_type = self.recurring_rule_type
+            self.contract_line_fixed_ids.recurring_invoicing_type = (
+                self.recurring_invoicing_type
+            )

--- a/contract/models/abstract_contract_line.py
+++ b/contract/models/abstract_contract_line.py
@@ -85,6 +85,12 @@ class ContractAbstractContractLine(models.AbstractModel):
         readonly=False,
         copy=True,
     )
+    date_end = fields.Date(
+        compute="_compute_date_end",
+        store=True,
+        readonly=False,
+        copy=True,
+    )
     last_date_invoiced = fields.Date()
     is_canceled = fields.Boolean(string="Canceled", default=False)
     is_auto_renew = fields.Boolean(string="Auto Renew", default=False)
@@ -166,11 +172,9 @@ class ContractAbstractContractLine(models.AbstractModel):
     def _compute_date_start(self):
         self._set_recurrence_field("date_start")
 
-    # pylint: disable=missing-return
-    @api.depends("contract_id.recurring_next_date", "contract_id.line_recurrence")
-    def _compute_recurring_next_date(self):
-        super()._compute_recurring_next_date()
-        self._set_recurrence_field("recurring_next_date")
+    @api.depends("contract_id.date_end", "contract_id.line_recurrence")
+    def _compute_date_end(self):
+        self._set_recurrence_field("date_end")
 
     @api.depends("display_type", "note_invoicing_mode")
     def _compute_is_recurring_note(self):

--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -80,7 +80,6 @@ class ContractContract(models.Model):
     create_invoice_visibility = fields.Boolean(
         compute="_compute_create_invoice_visibility"
     )
-    date_end = fields.Date(compute="_compute_date_end", store=True, readonly=False)
     payment_term_id = fields.Many2one(
         comodel_name="account.payment.term", string="Payment Terms", index=True
     )
@@ -301,14 +300,6 @@ class ContractContract(models.Model):
         if tree_view and form_view:
             action["views"] = [(tree_view.id, "tree"), (form_view.id, "form")]
         return action
-
-    @api.depends("contract_line_ids.date_end")
-    def _compute_date_end(self):
-        for contract in self:
-            contract.date_end = False
-            date_end = contract.contract_line_ids.mapped("date_end")
-            if date_end and all(date_end):
-                contract.date_end = max(date_end)
 
     @api.depends(
         "contract_line_ids.recurring_next_date",

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -34,7 +34,6 @@ class ContractLine(models.Model):
     )
     currency_id = fields.Many2one(related="contract_id.currency_id")
     date_start = fields.Date(required=True)
-    date_end = fields.Date(compute="_compute_date_end", store=True, readonly=False)
     termination_notice_date = fields.Date(
         compute="_compute_termination_notice_date",
         store=True,
@@ -99,36 +98,6 @@ class ContractLine(models.Model):
         store=True,
         readonly=True,
     )
-
-    @api.depends(
-        "last_date_invoiced",
-        "date_start",
-        "date_end",
-        "contract_id.last_date_invoiced",
-        "contract_id.contract_line_ids.last_date_invoiced",
-    )
-    # pylint: disable=missing-return
-    def _compute_next_period_date_start(self):
-        """Rectify next period date start if another line in the contract has been
-        already invoiced previously when the recurrence is by contract.
-        """
-        rest = self.filtered(lambda x: x.contract_id.line_recurrence)
-        for rec in self - rest:
-            lines = rec.contract_id.contract_line_ids
-            if not rec.last_date_invoiced and any(lines.mapped("last_date_invoiced")):
-                next_period_date_start = max(
-                    lines.filtered("last_date_invoiced").mapped("last_date_invoiced")
-                ) + relativedelta(days=1)
-                if rec.date_end and next_period_date_start > rec.date_end:
-                    next_period_date_start = False
-                rec.next_period_date_start = next_period_date_start
-            else:
-                rest |= rec
-        super(ContractLine, rest)._compute_next_period_date_start()
-
-    @api.depends("contract_id.date_end", "contract_id.line_recurrence")
-    def _compute_date_end(self):
-        self._set_recurrence_field("date_end")
 
     @api.depends(
         "date_end",

--- a/contract/models/contract_recurrency_mixin.py
+++ b/contract/models/contract_recurrency_mixin.py
@@ -48,6 +48,7 @@ class ContractRecurrencyBasicMixin(models.AbstractModel):
         help="Invoice every (Days/Week/Month/Year)",
     )
     date_start = fields.Date()
+    date_end = fields.Date()
     recurring_next_date = fields.Date(string="Date of Next Invoice")
 
     @api.depends("recurring_invoicing_type", "recurring_rule_type")
@@ -78,7 +79,10 @@ class ContractRecurrencyMixin(models.AbstractModel):
 
     date_start = fields.Date(default=lambda self: fields.Date.context_today(self))
     recurring_next_date = fields.Date(
-        compute="_compute_recurring_next_date", store=True, readonly=False, copy=True
+        compute="_compute_recurring_next_date",
+        store=True,
+        readonly=False,
+        copy=True,
     )
     date_end = fields.Date(index=True)
     next_period_date_start = fields.Date(

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -251,6 +251,7 @@ class TestContract(TestContractBase):
         self.assertEqual(self.acct_line.price_unit, 10)
 
     def test_contract(self):
+        self.assertEqual(self.acct_line.recurring_next_date, to_date("2018-01-15"))
         self.assertEqual(self.contract.recurring_next_date, to_date("2018-01-15"))
         self.assertAlmostEqual(self.acct_line.price_subtotal, 50.0)
         self.acct_line.price_unit = 100.0

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -255,6 +255,11 @@
                                         groups="base.group_no_one"
                                     />
                                     <field
+                                        name="next_period_date_start"
+                                        invisible="1"
+                                    />
+                                    <field name="next_period_date_end" invisible="1" />
+                                    <field
                                         name="create_invoice_visibility"
                                         invisible="1"
                                     />


### PR DESCRIPTION
Modules instaled:
* contract
* contract_sale
* contract_sale_generation

Description of the problem(s):
TO report this problem, I changed to invisible fields to visible in the view in order to see ther error better.
We have made all the screenshots generating invoices, but it also occurs when generating sales.

### Problem 1
If you add the products and then you change the recurrency (for exemple Every 1 week), the recurrency fields are not updated correctly.

1. We add a product.
![image](https://github.com/factorlibre/contract/assets/126599115/0a8aaeee-ae59-493b-baf7-7e6fda91c038)

2. We change the recurrency
![image](https://github.com/factorlibre/contract/assets/126599115/eadfedd2-07b1-4ca1-895f-03cd70cb92a3)

3. We save and we create 3 invoices
![image](https://github.com/factorlibre/contract/assets/126599115/bb6b09e4-492f-499d-a31a-2193f358a161)

As we can see, the recurrence is every 1 Month and not every 1 Week.


### Problem 2

The contract never ends.

1. We create this contract with a Date End.
![image](https://github.com/factorlibre/contract/assets/126599115/aea8c990-0769-479a-b7b1-5c86d2aaebbd)


2. We add some products (in order to avoid the problem above).
![image](https://github.com/factorlibre/contract/assets/126599115/0a3c3b7e-6afe-4399-8e14-fc5c29bfdfaa)

As we can see, the Date End is not set on the lines. (origin of the error).

3. We generate infinite invoices.

![image](https://github.com/factorlibre/contract/assets/126599115/0f553ed4-db92-43ae-a1d1-9dc0f734c512)

We are able to generate infinite invoices. Maybe the scheduled action controls this, but this should be controlled manually also.

### Problem 3

Date end dissapear when changing the recurrency.

1. We create a contract. It must has a Date End. We save it.
![image](https://github.com/factorlibre/contract/assets/126599115/018743f7-c191-4cc9-a5ea-10f7024991b5)

2. We want to change de recurrency (it can happens). We notice the date end dissapears when we save the changes.
![image](https://github.com/factorlibre/contract/assets/126599115/a808a686-2bc0-4ea2-bcce-3abc89c2b2d5)


### Problem 4

When having 2 or more lines, the last date invoice field doesn't compute correctly.

1. We create a contract. To see more clear the error, we set the recurrency every 1 week.
![image](https://github.com/factorlibre/contract/assets/126599115/6211eb5a-0f4a-4b16-9d61-ea1b15903786)

2. We create 1 invoice.

![image](https://github.com/factorlibre/contract/assets/126599115/e901dbc8-2d73-451a-91d4-5ac7fe65c2db)

As we can see, the field last_date_invoice is mismatching between the 2 lines, when it should be the same because we aren't in a recurrency line level. If we had set a date end, we would be see an error at the last invoices, where only one product would be invoiced due to this error.


After exposing this, I made some several changes in the structure of the module contract.


### Problem 5
If we put a Date End and we change the Date Of Next Invoice manually, the date end dissapears

1. We create a contract with Date End
![image](https://github.com/factorlibre/contract/assets/126599115/93134199-6dd2-4d8e-9270-b9ec19997cd5)


2. We manually change the Date Of Next Invoice and we save it.

![image](https://github.com/factorlibre/contract/assets/126599115/b8c6169b-dcfc-41ba-aaec-99d851a4c34a)


As you can see, the Date End dissapears.



### Problem 6
We can't change the Date of Next Invoice in recurrence at line level

1. We create a contrat with recurrence at line level
![image](https://github.com/factorlibre/contract/assets/126599115/4e1c8747-4f40-4cc9-8f39-a5a4d928e6e6)

2. We create a line. We only establish a product and we save.
![image](https://github.com/factorlibre/contract/assets/126599115/78c65cc1-420d-4eb0-a5b6-e2022722d53b)

3. We edit the line and we stablish the 'Date of Next Invoice' on day later. We save and close. The Next Period End is correctly changed.
![image](https://github.com/factorlibre/contract/assets/126599115/66f21daa-0156-4141-9a1e-784a3b64a1fb)

4. We open the line again.
![image](https://github.com/factorlibre/contract/assets/126599115/ff760667-b040-4340-9dc0-093c259ef121)

As we can see, the Date of Next Invoice is not changed making the next period end beig bad calculated.
