### PR TITLE
[15.0][FIX] action_view_partner_invoices value error fix

### DIFF
--- a/subscription_oca/views/res_partner_views.xml
+++ b/subscription_oca/views/res_partner_views.xml
@@ -5,6 +5,10 @@
         <field name="name">res.partner.form</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('account.group_account_invoice')), (4, ref('account.group_account_readonly'))]"
+        />
         <field name="arch" type="xml">
             <button name="action_view_partner_invoices" position="after">
                 <field name="subscription_ids" invisible="1" />


### PR DESCRIPTION
When navigating to contact in a helpdesk ticket by clicking it, a value error appears (full error below).

This happens because the module `subscription_oca` tries to modify a button that will not be loaded if the current user is not in the following groups: `account.group_account_invoice`, `account.group_account_readonly`

This is fixed by adding the same `group_id` field to the record in `subscription_oca/views/res_partner_views.xml`

The field looks as follows:
```xml
<field name="groups_id" eval="[(4, ref('account.group_account_invoice')), (4, ref('account.group_account_readonly'))]"/>
```

The error in question:
```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/srv/odoo/odoo/parts/odoo/odoo/addons/base/models/ir_ui_view.py", line 865, in apply_inheritance_specs
    source = apply_inheritance_specs(
  File "/srv/odoo/odoo/parts/odoo/odoo/tools/template_inheritance.py", line 254, in apply_inheritance_specs
    raise ValueError(
ValueError: Element '<button name="action_view_partner_invoices">' cannot be located in parent view

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/srv/odoo/odoo/parts/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 368, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/srv/odoo/odoo/parts/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 357, in checked_call
    result = self.endpoint(*a, **kw)
  File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 921, in __call__
    return self.method(*args, **kw)
  File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/tmp/addons/web/controllers/main.py", line 1324, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/tmp/addons/web/controllers/main.py", line 1316, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/srv/odoo/odoo/parts/odoo/odoo/api.py", line 467, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "/srv/odoo/odoo/parts/odoo/odoo/api.py", line 438, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/srv/odoo/odoo/parts/odoo/odoo/models.py", line 1640, in load_views
    result['fields_views'] = {
  File "/srv/odoo/odoo/parts/odoo/odoo/models.py", line 1641, in <dictcomp>
    v_type: self.fields_view_get(v_id, v_type if v_type != 'list' else 'tree',
  File "/tmp/addons/base_search_mail_content/models/mail_thread.py", line 48, in fields_view_get
    res = super(MailThread, self).fields_view_get(
  File "/tmp/addons/web/models/models.py", line 249, in fields_view_get
    r = super().fields_view_get(view_id, view_type, toolbar, submenu)
  File "/srv/odoo/odoo/parts/odoo/odoo/models.py", line 1724, in fields_view_get
    result = self._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
  File "/srv/odoo/odoo/parts/odoo/odoo/addons/base/models/res_partner.py", line 357, in _fields_view_get
    res = super(Partner, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
  File "/srv/odoo/odoo/parts/odoo/odoo/models.py", line 1686, in _fields_view_get
    result['arch'] = view.get_combined_arch()
  File "/srv/odoo/odoo/parts/odoo/odoo/addons/base/models/ir_ui_view.py", line 963, in get_combined_arch
    return etree.tostring(self._get_combined_arch(), encoding='unicode')
  File "/tmp/addons/website/models/ir_ui_view.py", line 537, in _get_combined_arch
    root = super()._get_combined_arch()
  File "/srv/odoo/odoo/parts/odoo/odoo/addons/base/models/ir_ui_view.py", line 993, in _get_combined_arch
    arch = root.with_prefetch(tree_views._prefetch_ids)._combine(hierarchy)
  File "/srv/odoo/odoo/parts/odoo/odoo/addons/base/models/ir_ui_view.py", line 934, in _combine
    combined_arch = view.apply_inheritance_specs(combined_arch, arch)
  File "/tmp/addons/base_view_inheritance_extension/models/ir_ui_view.py", line 63, in apply_inheritance_specs
    source = handled_by(source, specs)
  File "/srv/odoo/odoo/parts/odoo/odoo/addons/base/models/ir_ui_view.py", line 871, in apply_inheritance_specs
    self._raise_view_error(str(e), specs_tree)
  File "/srv/odoo/odoo/parts/odoo/odoo/addons/base/models/ir_ui_view.py", line 748, in _raise_view_error
    raise err from from_exception
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 654, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/srv/odoo/odoo/parts/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: Element '<button name="action_view_partner_invoices">' cannot be located in parent view

```
 
