### PR TITLE
feat(contract): add multi-company constraint

### DIFF
--- a/contract/readme/CONTRIBUTORS.rst
+++ b/contract/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@
     * Rafael Blasco
     * Víctor Martínez
 * Iván Antón <ozono@ozonomultimedia.com>
+* Yves Goldberg <yves@ygol.com>


### PR DESCRIPTION
In multi-company environment when a user has access to several companies; the user has the ability to assign record from a different company to the contract. This will cause a silent error when running the cron task that generate the invoices.

To avoid the above problem, a new constraint is added that will test any one2many field and raise an error if it is not set to the same company as the contract.