### PR TITLE
[16.0][IMP] contract: add company_id on contract lines

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -32,6 +32,7 @@ class ContractLine(models.Model):
         auto_join=True,
         ondelete="cascade",
     )
+    company_id = fields.Many2one(related="contract_id.company_id")
     currency_id = fields.Many2one(related="contract_id.currency_id")
     date_start = fields.Date(required=True)
     date_end = fields.Date(compute="_compute_date_end", store=True, readonly=False)

--- a/contract/views/abstract_contract_line.xml
+++ b/contract/views/abstract_contract_line.xml
@@ -12,6 +12,7 @@
                 <header attrs="{'invisible': [('display_type', '!=', False)]}" />
                 <sheet>
                     <field name="specific_price" invisible="1" />
+                    <field name="company_id" invisible="1" />
                     <field name="currency_id" invisible="1" />
                     <field colspan="1" name="product_uom_category_id" invisible="1" />
                     <group>

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -211,6 +211,7 @@
                                             context="{'default_display_type': 'line_note'}"
                                         />
                                     </control>
+                                    <field name="company_id" invisible="1" />
                                     <field name="currency_id" invisible="1" />
                                     <field name="display_type" invisible="1" />
                                     <field name="sequence" widget="handle" />
@@ -289,6 +290,7 @@
                                             context="{'default_display_type': 'line_note'}"
                                         />
                                     </control>
+                                    <field name="company_id" invisible="1" />
                                     <field name="currency_id" invisible="1" />
                                     <field name="display_type" invisible="1" />
                                     <field name="sequence" widget="handle" />


### PR DESCRIPTION
This is useful to later add `check_company=True` on some contract line fields.