### PR TITLE
[14.0][FIX] contract: product is also required in contract line tree view

### DIFF
--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -97,7 +97,11 @@
                 decoration-info="create_invoice_visibility and not is_canceled"
             >
                 <field name="sequence" widget="handle" />
-                <field name="product_id" />
+                <field name="display_type" invisible="1" />
+                <field
+                    name="product_id"
+                    attrs="{'required': [('display_type', '=', False)]}"
+                />
                 <field name="name" />
                 <field
                     name="analytic_account_id"


### PR DESCRIPTION
The Product is a mandatory field in the contract line form view

https://github.com/OCA/contract/blob/14.0/contract/views/abstract_contract_line.xml#L23

but it's not set as mandatory in the embedded tree view of the contract line. This commit fixes this inconsistency.

This causes problems in particular with module contract_sale_generation, since, unlike invoices, it's mandatory to have a product on a Sales Order line.