### PR TITLE
[17.0][IMP] product_contract: Add contract configurator instead of making tree not editable

### DIFF
--- a/product_contract/README.rst
+++ b/product_contract/README.rst
@@ -52,6 +52,12 @@ To use this module, you need to:
    product
 3. Define default recurrence rules
 
+Known issues / Roadmap
+======================
+
+-  There's no support right now for computing the start date for the
+   following recurrent types: daily, weekly and monthlylastday.
+
 Bug Tracker
 ===========
 
@@ -80,6 +86,7 @@ Contributors
 
    -  Ernesto Tejeda
    -  Pedro M. Baeza
+   -  Carlos Roca
 
 -  David Jaen <david.jaen.revert@gmail.com>
 

--- a/product_contract/__init__.py
+++ b/product_contract/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from . import wizards

--- a/product_contract/__manifest__.py
+++ b/product_contract/__manifest__.py
@@ -11,13 +11,16 @@
     "website": "https://github.com/OCA/contract",
     "depends": ["product", "contract", "sale"],
     "data": [
+        "security/ir.model.access.csv",
         "wizards/res_config_settings.xml",
         "views/contract.xml",
         "views/product_template.xml",
         "views/sale_order.xml",
+        "wizards/product_contract_configurator_views.xml",
     ],
     "installable": True,
     "application": False,
     "external_dependencies": {"python": ["dateutil"]},
     "maintainers": ["sbejaoui"],
+    "assets": {"web.assets_backend": ["product_contract/static/src/js/*"]},
 }

--- a/product_contract/i18n/es.po
+++ b/product_contract/i18n/es.po
@@ -9,16 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-10 03:15+0000\n"
-"PO-Revision-Date: 2020-06-17 11:28+0000\n"
+"POT-Creation-Date: 2024-08-30 12:54+0000\n"
+"PO-Revision-Date: 2024-08-30 15:06+0200\n"
 "Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.10\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: product_contract
 #: model_terms:ir.ui.view,arch_db:product_contract.contract_contract_customer_form_view
@@ -26,6 +26,17 @@ msgid "<span class=\"o_stat_text\">Sale Orders</span>"
 msgstr "<span class=\"o_stat_text\">Pedidos de Venta</span>"
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__4
+msgid "April"
+msgstr "Abril"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__8
+msgid "August"
+msgstr "Agosto"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__is_auto_renew
 #: model:ir.model.fields,field_description:product_contract.field_product_product__is_auto_renew
 #: model:ir.model.fields,field_description:product_contract.field_product_template__is_auto_renew
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__is_auto_renew
@@ -40,9 +51,19 @@ msgid "Automatically Create Contracts At Sale Order Confirmation"
 msgstr "Crear Contratos Automáticamente en la Confirmación del Pedido de Venta"
 
 #. module: product_contract
+#: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: product_contract
 #: model:ir.model,name:product_contract.model_res_company
 msgid "Companies"
 msgstr "Compañías"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__company_id
+msgid "Company"
+msgstr "Compañía"
 
 #. module: product_contract
 #: model:ir.model,name:product_contract.model_res_config_settings
@@ -50,8 +71,15 @@ msgid "Config Settings"
 msgstr "Configuraciones"
 
 #. module: product_contract
+#: model:ir.actions.act_window,name:product_contract.product_contract_configurator_action
+msgid "Configure a contract"
+msgstr "Configurar un contrato"
+
+#. module: product_contract
 #: model:ir.model,name:product_contract.model_contract_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__contract_id
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__contract_id
+#: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
 #: model_terms:ir.ui.view,arch_db:product_contract.product_template_form_contract_view
 msgid "Contract"
 msgstr "Contrato"
@@ -67,11 +95,13 @@ msgid "Contract Line"
 msgstr "Línea de Contrato"
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__contract_line_id
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__contract_line_id
 msgid "Contract Line to replace"
 msgstr "Línea de Contrato a Reemplazar"
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__contract_template_id
 #: model:ir.model.fields,field_description:product_contract.field_product_product__property_contract_template_id
 #: model:ir.model.fields,field_description:product_contract.field_product_template__property_contract_template_id
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__contract_template_id
@@ -103,23 +133,40 @@ msgid "Create Contracts"
 msgstr "Crear Contratos"
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__date_end
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__date_end
 msgid "Date End"
 msgstr "Fecha de Finalización"
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__date_start
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__date_start
 msgid "Date Start"
 msgstr "Fecha de Inicio"
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_contract_configurator__auto_renew_rule_type__daily
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__auto_renew_rule_type__daily
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__daily
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__termination_notice_rule_type__daily
 #: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__auto_renew_rule_type__daily
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__daily
 msgid "Day(s)"
 msgstr "Días"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__12
+msgid "December"
+msgstr "Diciembre"
 
 #. module: product_contract
 #: model:ir.model.fields,field_description:product_contract.field_product_product__default_qty
@@ -128,6 +175,70 @@ msgid "Default Quantity"
 msgstr "Cantidad Predeterminada"
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__display_name
+msgid "Display Name"
+msgstr "Nombre Para Mostrar"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__end_this
+msgid "End of current period"
+msgstr "Final de este periodo"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__end_next
+msgid "End of next period"
+msgstr "Final del siguiente periodo"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__2
+msgid "February"
+msgstr "Febrero"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__5
+msgid "Fifth month"
+msgstr "Quinto mes"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_quarterly__1
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__1
+msgid "First month"
+msgstr "Primer mes"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_product__force_month_quarterly
+#: model:ir.model.fields,field_description:product_contract.field_product_product__force_month_semesterly
+#: model:ir.model.fields,field_description:product_contract.field_product_product__force_month_yearly
+#: model:ir.model.fields,field_description:product_contract.field_product_template__force_month_quarterly
+#: model:ir.model.fields,field_description:product_contract.field_product_template__force_month_semesterly
+#: model:ir.model.fields,field_description:product_contract.field_product_template__force_month_yearly
+msgid "Force Month"
+msgstr "Forzar mes"
+
+#. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_product__force_month_quarterly
+#: model:ir.model.fields,help:product_contract.field_product_template__force_month_quarterly
+msgid "Force the month to be used inside the quarter"
+msgstr "Forzar el mes usado en el trimestre"
+
+#. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_product__force_month_semesterly
+#: model:ir.model.fields,help:product_contract.field_product_template__force_month_semesterly
+msgid "Force the month to be used inside the semester"
+msgstr "Forzar el mes usado en el semestre"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__4
+msgid "Fourth month"
+msgstr "Cuarto mes"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__id
+msgid "ID"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__recurring_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_product_product__recurring_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_product_template__recurring_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__recurring_rule_type
@@ -135,6 +246,7 @@ msgid "Invoice Every"
 msgstr "Factura Cada"
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__recurring_invoicing_type
 #: model:ir.model.fields,field_description:product_contract.field_product_product__recurring_invoicing_type
 #: model:ir.model.fields,field_description:product_contract.field_product_template__recurring_invoicing_type
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__recurring_invoicing_type
@@ -150,17 +262,56 @@ msgid "Is a contract"
 msgstr "Es un contrato"
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__1
+msgid "January"
+msgstr "Enero"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__7
+msgid "July"
+msgstr "Julio"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__6
+msgid "June"
+msgstr "Junio"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__write_date
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__manual
+msgid "Manual"
+msgstr "Manual"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__3
+msgid "March"
+msgstr "Marzo"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__5
+msgid "May"
+msgstr "Mayo"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_contract_configurator__auto_renew_rule_type__monthly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__auto_renew_rule_type__monthly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__monthly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__termination_notice_rule_type__monthly
 #: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__auto_renew_rule_type__monthly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__monthly
 msgid "Month(s)"
 msgstr "Meses"
 
 #. module: product_contract
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__monthlylastday
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__monthlylastday
 msgid "Month(s) last day"
 msgstr "Mes (es) último día"
 
@@ -170,34 +321,64 @@ msgid "Need Contract Creation"
 msgstr "Necesita Creación de Contrato"
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__11
+msgid "November"
+msgstr "Noviembre"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__10
+msgid "October"
+msgstr "Octubre"
+
+#. module: product_contract
+#: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
+msgid "Ok"
+msgstr "Vale"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__partner_id
+msgid "Partner"
+msgstr "Contacto"
+
+#. module: product_contract
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_invoicing_type__post-paid
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_invoicing_type__post-paid
 msgid "Post-paid"
 msgstr "Pospago"
 
 #. module: product_contract
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_invoicing_type__pre-paid
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_invoicing_type__pre-paid
 msgid "Pre-paid"
 msgstr "Pagado por Adelantado"
 
 #. module: product_contract
 #: model:ir.model,name:product_contract.model_product_template
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__product_id
 msgid "Product"
+msgstr "Producto"
+
+#. module: product_contract
+#: model:ir.model,name:product_contract.model_product_contract_configurator
+msgid "Product Contract Configurator Wizard"
 msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__product_uom_qty
+msgid "Quantity"
+msgstr "Cantidad"
 
 #. module: product_contract
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__quarterly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__quarterly
 msgid "Quarter(s)"
-msgstr ""
+msgstr "Trimestre(s)"
 
 #. module: product_contract
+#: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
 #: model_terms:ir.ui.view,arch_db:product_contract.view_order_form
 msgid "Recurrence Invoicing"
 msgstr "Facturación Recurrente"
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__auto_renew_interval
 #: model:ir.model.fields,field_description:product_contract.field_product_product__auto_renew_interval
 #: model:ir.model.fields,field_description:product_contract.field_product_template__auto_renew_interval
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__auto_renew_interval
@@ -205,6 +386,7 @@ msgid "Renew Every"
 msgstr "Renovar cada"
 
 #. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__auto_renew_interval
 #: model:ir.model.fields,help:product_contract.field_product_product__auto_renew_interval
 #: model:ir.model.fields,help:product_contract.field_product_template__auto_renew_interval
 #: model:ir.model.fields,help:product_contract.field_sale_order_line__auto_renew_interval
@@ -212,6 +394,7 @@ msgid "Renew every (Days/Week/Month/Year)"
 msgstr "Renovar cada (días / semana / mes / año)"
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__auto_renew_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_product_product__auto_renew_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_product_template__auto_renew_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__auto_renew_rule_type
@@ -253,18 +436,36 @@ msgid "Sales Orders"
 msgstr "Pedidos de Ventas"
 
 #. module: product_contract
-#: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__semesterly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__semesterly
-msgid "Semester(s)"
-msgstr ""
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_quarterly__2
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__2
+msgid "Second month"
+msgstr "Segundo mes"
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__semesterly
+msgid "Semester(s)"
+msgstr "Semestre(s)"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__9
+msgid "September"
+msgstr "Septiembre"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__6
+msgid "Sixth month"
+msgstr "Sexto mes"
+
+#. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__recurring_rule_type
 #: model:ir.model.fields,help:product_contract.field_product_product__recurring_rule_type
 #: model:ir.model.fields,help:product_contract.field_product_template__recurring_rule_type
+#: model:ir.model.fields,help:product_contract.field_sale_order_line__recurring_rule_type
 msgid "Specify Interval for automatic invoice generation."
 msgstr "Especifique el intervalo para la generación automática de facturas."
 
 #. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__auto_renew_rule_type
 #: model:ir.model.fields,help:product_contract.field_product_product__auto_renew_rule_type
 #: model:ir.model.fields,help:product_contract.field_product_template__auto_renew_rule_type
 #: model:ir.model.fields,help:product_contract.field_sale_order_line__auto_renew_rule_type
@@ -272,6 +473,7 @@ msgid "Specify Interval for automatic renewal."
 msgstr "Especifique Intervalo para renovación automática."
 
 #. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__recurring_invoicing_type
 #: model:ir.model.fields,help:product_contract.field_product_product__recurring_invoicing_type
 #: model:ir.model.fields,help:product_contract.field_product_template__recurring_invoicing_type
 #: model:ir.model.fields,help:product_contract.field_sale_order_line__recurring_invoicing_type
@@ -279,6 +481,24 @@ msgid "Specify if process date is 'from' or 'to' invoicing date"
 msgstr ""
 "Especifique si la fecha del proceso es 'desde' o 'hasta' la fecha de "
 "facturación"
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__contract_start_date_method
+#: model:ir.model.fields,field_description:product_contract.field_product_product__contract_start_date_method
+#: model:ir.model.fields,field_description:product_contract.field_product_template__contract_start_date_method
+#: model:ir.model.fields,field_description:product_contract.field_sale_order_line__contract_start_date_method
+msgid "Start Date Method"
+msgstr "Método fecha de inicio"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__start_this
+msgid "Start of current period"
+msgstr "Inicio del periodo actual"
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__start_next
+msgid "Start of next period"
+msgstr "Inicio del siguiente periodo"
 
 #. module: product_contract
 #: model:ir.model.fields,field_description:product_contract.field_product_product__termination_notice_interval
@@ -293,19 +513,99 @@ msgid "Termination Notice type"
 msgstr "Tipo de aviso de Terminación"
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_quarterly__3
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__3
+msgid "Third month"
+msgstr "Tercer mes"
+
+#. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__contract_start_date_method
+#: model:ir.model.fields,help:product_contract.field_product_product__contract_start_date_method
+#: model:ir.model.fields,help:product_contract.field_product_template__contract_start_date_method
+#: model:ir.model.fields,help:product_contract.field_sale_order_line__contract_start_date_method
+msgid ""
+"This field allows to define how the start date of the contract will\n"
+"        be calculated:\n"
+"\n"
+"        - Manual: The start date will be selected by the user, by default "
+"will be the\n"
+"        date of sale confirmation.\n"
+"        - Start of current period: The start date will be the first day of "
+"the actual\n"
+"        period selected on 'Invoicing Every' field. Example: If we are on "
+"2024/08/27\n"
+"        and the period selected is 'Year(s)' the start date will be "
+"2024/01/01.\n"
+"        - End of current period: The start date will be the last day of the "
+"actual\n"
+"        period selected on 'Invoicing Every' field. Example: If we are on "
+"2024/08/27\n"
+"        and the period selected is 'Year(s)' the start date will be "
+"2024/12/31.\n"
+"        - Start of next period: The start date will be the first day of the "
+"next\n"
+"        period selected on 'Invoicing Every' field. Example: If we are on "
+"2024/08/27\n"
+"        and the period selected is 'Year(s)' the start date will be "
+"2025/01/01.\n"
+"        - End of next period: The start date will be the last day of the "
+"actual\n"
+"        period selected on 'Invoicing Every' field. Example: If we are on "
+"2024/08/27\n"
+"        and the period selected is 'Year(s)' the start date will be "
+"2025/12/31.\n"
+"        "
+msgstr ""
+"Este campo permite definir cómo se calculará la fecha de inicio \n"
+"        del contrato:\n"
+"\n"
+"        - Manual: La fecha de inicio será seleccionada por el usuario, por "
+"defecto \n"
+"        será la fecha de confirmación de la venta.\n"
+"        - Inicio del periodo actual: La fecha de inicio será el primer día "
+"del periodo \n"
+"        actual seleccionado en el campo 'Facturación cada'. Ejemplo: Si "
+"estamos en \n"
+"        2024/08/27 y el periodo seleccionado es 'Año(s)', la fecha de inicio "
+"será \n"
+"        2024/01/01.\n"
+"        - Fin del periodo actual: La fecha de inicio será el último día del "
+"periodo \n"
+"        actual seleccionado en el campo 'Facturación cada'. Ejemplo: Si "
+"estamos \n"
+"        en 2024/08/27 y el periodo seleccionado es 'Año(s)', la fecha de "
+"inicio \n"
+"        será 2024/12/31.\n"
+"        - Inicio del siguiente periodo: La fecha de inicio será el primer "
+"día del \n"
+"        siguiente periodo seleccionado en el campo 'Facturación cada'. "
+"Ejemplo: \n"
+"        Si estamos en 2024/08/27 y el periodo seleccionado es 'Año(s)', la "
+"fecha \n"
+"        de inicio será 2025/01/01.\n"
+"        - Fin del siguiente periodo: La fecha de inicio será el último día "
+"del siguiente \n"
+"        periodo seleccionado en el campo 'Facturación cada'. Ejemplo: Si "
+"estamos en \n"
+"        2024/08/27 y el periodo seleccionado es 'Año(s)', la fecha de inicio "
+"será \n"
+"        2025/12/31.\n"
+"        "
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_contract_configurator__auto_renew_rule_type__weekly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__auto_renew_rule_type__weekly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__weekly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__termination_notice_rule_type__weekly
 #: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__auto_renew_rule_type__weekly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__weekly
 msgid "Week(s)"
 msgstr "Semanas"
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_contract_configurator__auto_renew_rule_type__yearly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__auto_renew_rule_type__yearly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__yearly
 #: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__auto_renew_rule_type__yearly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__yearly
 msgid "Year(s)"
 msgstr "Años"
 
@@ -325,9 +625,25 @@ msgid ""
 "You must specify a contract template for '%(product_name)s' product in "
 "'%(company_name)s' company."
 msgstr ""
+"Debes especificar una plantilla de contrato para el producto "
+"'%(product_name)s' en la empresa '%(company_name)s'."
 
-#~ msgid "Display Name"
-#~ msgstr "Nombre Para Mostrar"
+#. module: product_contract
+#. odoo-python
+#: code:addons/product_contract/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"{product}\n"
+"    - Recurrency: {recurring_rule}\n"
+"    - Invoicing Type: {invoicing_type}\n"
+"    - Date: {date_text}\n"
+"                "
+msgstr ""
+"{product}\n"
+"    - Periodicidad: {recurring_rule}\n"
+"    - Tipo de facturación: {invoicing_type}\n"
+"    - Fecha: {date_text}\n"
+"                "
 
 #~ msgid "Product Template"
 #~ msgstr "Plantilla de producto"

--- a/product_contract/i18n/product_contract.pot
+++ b/product_contract/i18n/product_contract.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-30 12:54+0000\n"
+"PO-Revision-Date: 2024-08-30 12:54+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,6 +21,17 @@ msgid "<span class=\"o_stat_text\">Sale Orders</span>"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__4
+msgid "April"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__8
+msgid "August"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__is_auto_renew
 #: model:ir.model.fields,field_description:product_contract.field_product_product__is_auto_renew
 #: model:ir.model.fields,field_description:product_contract.field_product_template__is_auto_renew
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__is_auto_renew
@@ -33,8 +46,18 @@ msgid "Automatically Create Contracts At Sale Order Confirmation"
 msgstr ""
 
 #. module: product_contract
+#: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
+msgid "Cancel"
+msgstr ""
+
+#. module: product_contract
 #: model:ir.model,name:product_contract.model_res_company
 msgid "Companies"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__company_id
+msgid "Company"
 msgstr ""
 
 #. module: product_contract
@@ -43,8 +66,15 @@ msgid "Config Settings"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.actions.act_window,name:product_contract.product_contract_configurator_action
+msgid "Configure a contract"
+msgstr ""
+
+#. module: product_contract
 #: model:ir.model,name:product_contract.model_contract_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__contract_id
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__contract_id
+#: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
 #: model_terms:ir.ui.view,arch_db:product_contract.product_template_form_contract_view
 msgid "Contract"
 msgstr ""
@@ -60,11 +90,13 @@ msgid "Contract Line"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__contract_line_id
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__contract_line_id
 msgid "Contract Line to replace"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__contract_template_id
 #: model:ir.model.fields,field_description:product_contract.field_product_product__property_contract_template_id
 #: model:ir.model.fields,field_description:product_contract.field_product_template__property_contract_template_id
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__contract_template_id
@@ -96,22 +128,39 @@ msgid "Create Contracts"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__date_end
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__date_end
 msgid "Date End"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__date_start
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__date_start
 msgid "Date Start"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_contract_configurator__auto_renew_rule_type__daily
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__auto_renew_rule_type__daily
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__daily
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__termination_notice_rule_type__daily
 #: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__auto_renew_rule_type__daily
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__daily
 msgid "Day(s)"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__12
+msgid "December"
 msgstr ""
 
 #. module: product_contract
@@ -121,6 +170,70 @@ msgid "Default Quantity"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__end_this
+msgid "End of current period"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__end_next
+msgid "End of next period"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__2
+msgid "February"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__5
+msgid "Fifth month"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_quarterly__1
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__1
+msgid "First month"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_product__force_month_quarterly
+#: model:ir.model.fields,field_description:product_contract.field_product_product__force_month_semesterly
+#: model:ir.model.fields,field_description:product_contract.field_product_product__force_month_yearly
+#: model:ir.model.fields,field_description:product_contract.field_product_template__force_month_quarterly
+#: model:ir.model.fields,field_description:product_contract.field_product_template__force_month_semesterly
+#: model:ir.model.fields,field_description:product_contract.field_product_template__force_month_yearly
+msgid "Force Month"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_product__force_month_quarterly
+#: model:ir.model.fields,help:product_contract.field_product_template__force_month_quarterly
+msgid "Force the month to be used inside the quarter"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_product__force_month_semesterly
+#: model:ir.model.fields,help:product_contract.field_product_template__force_month_semesterly
+msgid "Force the month to be used inside the semester"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__4
+msgid "Fourth month"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__id
+msgid "ID"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__recurring_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_product_product__recurring_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_product_template__recurring_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__recurring_rule_type
@@ -128,6 +241,7 @@ msgid "Invoice Every"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__recurring_invoicing_type
 #: model:ir.model.fields,field_description:product_contract.field_product_product__recurring_invoicing_type
 #: model:ir.model.fields,field_description:product_contract.field_product_template__recurring_invoicing_type
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__recurring_invoicing_type
@@ -143,17 +257,56 @@ msgid "Is a contract"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__1
+msgid "January"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__7
+msgid "July"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__6
+msgid "June"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__manual
+msgid "Manual"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__3
+msgid "March"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__5
+msgid "May"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_contract_configurator__auto_renew_rule_type__monthly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__auto_renew_rule_type__monthly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__monthly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__termination_notice_rule_type__monthly
 #: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__auto_renew_rule_type__monthly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__monthly
 msgid "Month(s)"
 msgstr ""
 
 #. module: product_contract
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__monthlylastday
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__monthlylastday
 msgid "Month(s) last day"
 msgstr ""
 
@@ -163,34 +316,64 @@ msgid "Need Contract Creation"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__11
+msgid "November"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__10
+msgid "October"
+msgstr ""
+
+#. module: product_contract
+#: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
+msgid "Ok"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: product_contract
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_invoicing_type__post-paid
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_invoicing_type__post-paid
 msgid "Post-paid"
 msgstr ""
 
 #. module: product_contract
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_invoicing_type__pre-paid
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_invoicing_type__pre-paid
 msgid "Pre-paid"
 msgstr ""
 
 #. module: product_contract
 #: model:ir.model,name:product_contract.model_product_template
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__product_id
 msgid "Product"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model,name:product_contract.model_product_contract_configurator
+msgid "Product Contract Configurator Wizard"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__product_uom_qty
+msgid "Quantity"
+msgstr ""
+
+#. module: product_contract
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__quarterly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__quarterly
 msgid "Quarter(s)"
 msgstr ""
 
 #. module: product_contract
+#: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
 #: model_terms:ir.ui.view,arch_db:product_contract.view_order_form
 msgid "Recurrence Invoicing"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__auto_renew_interval
 #: model:ir.model.fields,field_description:product_contract.field_product_product__auto_renew_interval
 #: model:ir.model.fields,field_description:product_contract.field_product_template__auto_renew_interval
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__auto_renew_interval
@@ -198,6 +381,7 @@ msgid "Renew Every"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__auto_renew_interval
 #: model:ir.model.fields,help:product_contract.field_product_product__auto_renew_interval
 #: model:ir.model.fields,help:product_contract.field_product_template__auto_renew_interval
 #: model:ir.model.fields,help:product_contract.field_sale_order_line__auto_renew_interval
@@ -205,6 +389,7 @@ msgid "Renew every (Days/Week/Month/Year)"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__auto_renew_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_product_product__auto_renew_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_product_template__auto_renew_rule_type
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__auto_renew_rule_type
@@ -246,18 +431,36 @@ msgid "Sales Orders"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_quarterly__2
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__2
+msgid "Second month"
+msgstr ""
+
+#. module: product_contract
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__semesterly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__semesterly
 msgid "Semester(s)"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_yearly__9
+msgid "September"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__6
+msgid "Sixth month"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__recurring_rule_type
 #: model:ir.model.fields,help:product_contract.field_product_product__recurring_rule_type
 #: model:ir.model.fields,help:product_contract.field_product_template__recurring_rule_type
+#: model:ir.model.fields,help:product_contract.field_sale_order_line__recurring_rule_type
 msgid "Specify Interval for automatic invoice generation."
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__auto_renew_rule_type
 #: model:ir.model.fields,help:product_contract.field_product_product__auto_renew_rule_type
 #: model:ir.model.fields,help:product_contract.field_product_template__auto_renew_rule_type
 #: model:ir.model.fields,help:product_contract.field_sale_order_line__auto_renew_rule_type
@@ -265,10 +468,29 @@ msgid "Specify Interval for automatic renewal."
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__recurring_invoicing_type
 #: model:ir.model.fields,help:product_contract.field_product_product__recurring_invoicing_type
 #: model:ir.model.fields,help:product_contract.field_product_template__recurring_invoicing_type
 #: model:ir.model.fields,help:product_contract.field_sale_order_line__recurring_invoicing_type
 msgid "Specify if process date is 'from' or 'to' invoicing date"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__contract_start_date_method
+#: model:ir.model.fields,field_description:product_contract.field_product_product__contract_start_date_method
+#: model:ir.model.fields,field_description:product_contract.field_product_template__contract_start_date_method
+#: model:ir.model.fields,field_description:product_contract.field_sale_order_line__contract_start_date_method
+msgid "Start Date Method"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__start_this
+msgid "Start of current period"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__contract_start_date_method__start_next
+msgid "Start of next period"
 msgstr ""
 
 #. module: product_contract
@@ -284,19 +506,51 @@ msgid "Termination Notice type"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_quarterly__3
+#: model:ir.model.fields.selection,name:product_contract.selection__product_template__force_month_semesterly__3
+msgid "Third month"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,help:product_contract.field_product_contract_configurator__contract_start_date_method
+#: model:ir.model.fields,help:product_contract.field_product_product__contract_start_date_method
+#: model:ir.model.fields,help:product_contract.field_product_template__contract_start_date_method
+#: model:ir.model.fields,help:product_contract.field_sale_order_line__contract_start_date_method
+msgid ""
+"This field allows to define how the start date of the contract will\n"
+"        be calculated:\n"
+"\n"
+"        - Manual: The start date will be selected by the user, by default will be the\n"
+"        date of sale confirmation.\n"
+"        - Start of current period: The start date will be the first day of the actual\n"
+"        period selected on 'Invoicing Every' field. Example: If we are on 2024/08/27\n"
+"        and the period selected is 'Year(s)' the start date will be 2024/01/01.\n"
+"        - End of current period: The start date will be the last day of the actual\n"
+"        period selected on 'Invoicing Every' field. Example: If we are on 2024/08/27\n"
+"        and the period selected is 'Year(s)' the start date will be 2024/12/31.\n"
+"        - Start of next period: The start date will be the first day of the next\n"
+"        period selected on 'Invoicing Every' field. Example: If we are on 2024/08/27\n"
+"        and the period selected is 'Year(s)' the start date will be 2025/01/01.\n"
+"        - End of next period: The start date will be the last day of the actual\n"
+"        period selected on 'Invoicing Every' field. Example: If we are on 2024/08/27\n"
+"        and the period selected is 'Year(s)' the start date will be 2025/12/31.\n"
+"        "
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_contract_configurator__auto_renew_rule_type__weekly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__auto_renew_rule_type__weekly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__weekly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__termination_notice_rule_type__weekly
 #: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__auto_renew_rule_type__weekly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__weekly
 msgid "Week(s)"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields.selection,name:product_contract.selection__product_contract_configurator__auto_renew_rule_type__yearly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__auto_renew_rule_type__yearly
 #: model:ir.model.fields.selection,name:product_contract.selection__product_template__recurring_rule_type__yearly
 #: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__auto_renew_rule_type__yearly
-#: model:ir.model.fields.selection,name:product_contract.selection__sale_order_line__recurring_rule_type__yearly
 msgid "Year(s)"
 msgstr ""
 
@@ -315,4 +569,16 @@ msgstr ""
 msgid ""
 "You must specify a contract template for '%(product_name)s' product in "
 "'%(company_name)s' company."
+msgstr ""
+
+#. module: product_contract
+#. odoo-python
+#: code:addons/product_contract/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"{product}\n"
+"    - Recurrency: {recurring_rule}\n"
+"    - Invoicing Type: {invoicing_type}\n"
+"    - Date: {date_text}\n"
+"                "
 msgstr ""

--- a/product_contract/models/product_template.py
+++ b/product_contract/models/product_template.py
@@ -61,6 +61,73 @@ class ProductTemplate(models.Model):
         string="Renewal type",
         help="Specify Interval for automatic renewal.",
     )
+    contract_start_date_method = fields.Selection(
+        [
+            ("manual", "Manual"),
+            ("start_this", "Start of current period"),
+            ("end_this", "End of current period"),
+            ("start_next", "Start of next period"),
+            ("end_next", "End of next period"),
+        ],
+        "Start Date Method",
+        default="manual",
+        help="""This field allows to define how the start date of the contract will
+        be calculated:
+
+        - Manual: The start date will be selected by the user, by default will be the
+        date of sale confirmation.
+        - Start of current period: The start date will be the first day of the actual
+        period selected on 'Invoicing Every' field. Example: If we are on 2024/08/27
+        and the period selected is 'Year(s)' the start date will be 2024/01/01.
+        - End of current period: The start date will be the last day of the actual
+        period selected on 'Invoicing Every' field. Example: If we are on 2024/08/27
+        and the period selected is 'Year(s)' the start date will be 2024/12/31.
+        - Start of next period: The start date will be the first day of the next
+        period selected on 'Invoicing Every' field. Example: If we are on 2024/08/27
+        and the period selected is 'Year(s)' the start date will be 2025/01/01.
+        - End of next period: The start date will be the last day of the actual
+        period selected on 'Invoicing Every' field. Example: If we are on 2024/08/27
+        and the period selected is 'Year(s)' the start date will be 2025/12/31.
+        """,
+    )
+    force_month_yearly = fields.Selection(
+        [
+            ("1", "January"),
+            ("2", "February"),
+            ("3", "March"),
+            ("4", "April"),
+            ("5", "May"),
+            ("6", "June"),
+            ("7", "July"),
+            ("8", "August"),
+            ("9", "September"),
+            ("10", "October"),
+            ("11", "November"),
+            ("12", "December"),
+        ],
+        "Force Month",
+    )
+    force_month_quarterly = fields.Selection(
+        [
+            ("1", "First month"),
+            ("2", "Second month"),
+            ("3", "Third month"),
+        ],
+        "Force Month",
+        help="Force the month to be used inside the quarter",
+    )
+    force_month_semesterly = fields.Selection(
+        [
+            ("1", "First month"),
+            ("2", "Second month"),
+            ("3", "Third month"),
+            ("4", "Fourth month"),
+            ("5", "Fifth month"),
+            ("6", "Sixth month"),
+        ],
+        "Force Month",
+        help="Force the month to be used inside the semester",
+    )
 
     def write(self, vals):
         if "is_contract" in vals and vals["is_contract"] is False:

--- a/product_contract/models/sale_order.py
+++ b/product_contract/models/sale_order.py
@@ -67,6 +67,7 @@ class SaleOrder(models.Model):
             line_to_create_contract = rec.order_line.filtered(
                 lambda r: not r.contract_id and r.product_id.is_contract
             )
+            line_to_create_contract._set_contract_line_start_date()
             line_to_update_contract = rec.order_line.filtered(
                 lambda r: r.contract_id
                 and r.product_id.is_contract

--- a/product_contract/readme/CONTRIBUTORS.md
+++ b/product_contract/readme/CONTRIBUTORS.md
@@ -3,4 +3,5 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Ernesto Tejeda
   - Pedro M. Baeza
+  - Carlos Roca
 - David Jaen \<<david.jaen.revert@gmail.com>\>

--- a/product_contract/readme/ROADMAP.md
+++ b/product_contract/readme/ROADMAP.md
@@ -1,0 +1,2 @@
+- There's no support right now for computing the start date for the
+  following recurrent types: daily, weekly and monthlylastday.

--- a/product_contract/security/ir.model.access.csv
+++ b/product_contract/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_contract_configurator,access.product.contract.configurator,model_product_contract_configurator,sales_team.group_sale_salesman,1,1,1,0

--- a/product_contract/static/description/index.html
+++ b/product_contract/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -431,7 +432,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_contract/static/description/index.html
+++ b/product_contract/static/description/index.html
@@ -380,11 +380,12 @@ invoice directly.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -399,8 +400,15 @@ product</li>
 <li>Define default recurrence rules</li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>There’s no support right now for computing the start date for the
+following recurrent types: daily, weekly and monthlylastday.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/contract/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -408,29 +416,30 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>LasLabs</li>
 <li>ACSONE SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Ted Salmon &lt;<a class="reference external" href="mailto:tsalmon&#64;laslabs.com">tsalmon&#64;laslabs.com</a>&gt;</li>
 <li>Souheil Bejaoui &lt;<a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a>&gt;</li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Ernesto Tejeda</li>
 <li>Pedro M. Baeza</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 <li>David Jaen &lt;<a class="reference external" href="mailto:david.jaen.revert&#64;gmail.com">david.jaen.revert&#64;gmail.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/product_contract/static/src/js/contract_configurator_controller.esm.js
+++ b/product_contract/static/src/js/contract_configurator_controller.esm.js
@@ -15,8 +15,6 @@ export class ProductContractConfiguratorController extends formView.Controller {
         const {
             product_uom_qty,
             contract_id,
-            recurring_rule_type,
-            recurring_invoicing_type,
             date_start,
             date_end,
             contract_line_id,
@@ -30,8 +28,6 @@ export class ProductContractConfiguratorController extends formView.Controller {
                 productContractConfiguration: {
                     product_uom_qty,
                     contract_id,
-                    recurring_rule_type,
-                    recurring_invoicing_type,
                     date_start,
                     date_end,
                     contract_line_id,

--- a/product_contract/static/src/js/contract_configurator_controller.esm.js
+++ b/product_contract/static/src/js/contract_configurator_controller.esm.js
@@ -1,0 +1,50 @@
+/** @odoo-module **/
+
+import {formView} from "@web/views/form/form_view";
+import {registry} from "@web/core/registry";
+import {useService} from "@web/core/utils/hooks";
+
+export class ProductContractConfiguratorController extends formView.Controller {
+    setup() {
+        super.setup();
+        this.action = useService("action");
+    }
+
+    async onRecordSaved(record) {
+        await super.onRecordSaved(...arguments);
+        const {
+            product_uom_qty,
+            contract_id,
+            recurring_rule_type,
+            recurring_invoicing_type,
+            date_start,
+            date_end,
+            contract_line_id,
+            is_auto_renew,
+            auto_renew_interval,
+            auto_renew_rule_type,
+        } = record.data;
+        return this.action.doAction({
+            type: "ir.actions.act_window_close",
+            infos: {
+                productContractConfiguration: {
+                    product_uom_qty,
+                    contract_id,
+                    recurring_rule_type,
+                    recurring_invoicing_type,
+                    date_start,
+                    date_end,
+                    contract_line_id,
+                    is_auto_renew,
+                    auto_renew_interval,
+                    auto_renew_rule_type,
+                },
+            },
+        });
+    }
+}
+
+registry.category("views").add("product_contract_configurator_form", {
+    ...formView,
+    Controller: ProductContractConfiguratorController,
+});

--- a/product_contract/static/src/js/sale_product_field.esm.js
+++ b/product_contract/static/src/js/sale_product_field.esm.js
@@ -1,0 +1,54 @@
+/** @odoo-module **/
+
+import {SaleOrderLineProductField} from "@sale/js/sale_product_field";
+import {patch} from "@web/core/utils/patch";
+
+patch(SaleOrderLineProductField.prototype, {
+    async _onProductUpdate() {
+        super._onProductUpdate(...arguments);
+        if (this.props.record.data.is_contract) {
+            this._openContractConfigurator(true);
+        }
+    },
+
+    _editLineConfiguration() {
+        super._editLineConfiguration(...arguments);
+        if (this.props.record.data.is_contract) {
+            this._openContractConfigurator();
+        }
+    },
+
+    get isConfigurableLine() {
+        return super.isConfigurableLine || this.props.record.data.is_contract;
+    },
+
+    async _openContractConfigurator(isNew = false) {
+        const actionContext = {
+            default_product_id: this.props.record.data.product_id[0],
+            default_partner_id: this.props.record.model.root.data.partner_id[0],
+            default_company_id: this.props.record.model.root.data.company_id[0],
+            default_product_uom_qty: this.props.record.data.product_uom_qty,
+            default_contract_id: this.props.record.data.contract_id[0],
+            default_recurring_rule_type: this.props.record.data.recurring_rule_type,
+            default_recurring_invoicing_type:
+                this.props.record.data.recurring_invoicing_type,
+            default_date_start: this.props.record.data.date_start,
+            default_date_end: this.props.record.data.date_end,
+            default_is_auto_renew: this.props.record.data.is_auto_renew,
+            default_auto_renew_interval: this.props.record.data.auto_renew_interval,
+            default_auto_renew_rule_type: this.props.record.data.auto_renew_rule_type,
+        };
+        this.action.doAction("product_contract.product_contract_configurator_action", {
+            additionalContext: actionContext,
+            onClose: async (closeInfo) => {
+                if (closeInfo && !closeInfo.special) {
+                    this.props.record.update(closeInfo.productContractConfiguration);
+                } else if (isNew) {
+                    this.props.record.update({
+                        [this.props.name]: undefined,
+                    });
+                }
+            },
+        });
+    },
+});

--- a/product_contract/static/src/js/sale_product_field.esm.js
+++ b/product_contract/static/src/js/sale_product_field.esm.js
@@ -29,9 +29,6 @@ patch(SaleOrderLineProductField.prototype, {
             default_company_id: this.props.record.model.root.data.company_id[0],
             default_product_uom_qty: this.props.record.data.product_uom_qty,
             default_contract_id: this.props.record.data.contract_id[0],
-            default_recurring_rule_type: this.props.record.data.recurring_rule_type,
-            default_recurring_invoicing_type:
-                this.props.record.data.recurring_invoicing_type,
             default_date_start: this.props.record.data.date_start,
             default_date_end: this.props.record.data.date_end,
             default_is_auto_renew: this.props.record.data.is_auto_renew,

--- a/product_contract/views/product_template.xml
+++ b/product_contract/views/product_template.xml
@@ -36,6 +36,19 @@
                     </group>
                     <group>
                         <field name="is_auto_renew" />
+                        <field name="contract_start_date_method" required="True" />
+                        <field
+                            name="force_month_yearly"
+                            invisible="contract_start_date_method == 'manual' or recurring_rule_type != 'yearly'"
+                        />
+                        <field
+                            name="force_month_quarterly"
+                            invisible="contract_start_date_method == 'manual' or recurring_rule_type != 'quarterly'"
+                        />
+                        <field
+                            name="force_month_semesterly"
+                            invisible="contract_start_date_method == 'manual' or recurring_rule_type != 'semesterly'"
+                        />
                     </group>
                     <group>
                         <group invisible="is_auto_renew == False">

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -41,13 +41,13 @@
                 <field
                     name="contract_id"
                     options='{"no_create": True}'
-                    invisible="is_contract == False"
+                    invisible="not is_contract"
                     domain="['|',('contract_template_id','=',contract_template_id), ('contract_template_id','=',False), ('partner_id','=',parent.partner_id), ('is_terminated','=',False),
                        ]"
                 />
                 <field
                     name="contract_line_id"
-                    invible="is_contract == False"
+                    invisible="not is_contract"
                     domain="[('contract_id','=',contract_id)]"
                 />
             </xpath>
@@ -59,37 +59,37 @@
                 <separator
                     colspan="4"
                     string="Recurrence Invoicing"
-                    invisible="is_contract == False"
+                    invisible="not is_contract"
                 />
-                <group invisible="is_contract == False">
+                <group invisible="not is_contract">
                     <field name="recurring_rule_type" />
                 </group>
-                <group invisible="is_contract == False">
+                <group invisible="not is_contract">
                     <field name="recurring_invoicing_type" />
                 </group>
-                <group invisible="is_contract == False">
-                    <field name="date_start" required="is_contract == True" />
+                <group invisible="not is_contract">
+                    <field name="date_start" required="is_contract" />
                 </group>
-                <group invisible="is_contract == False">
-                    <field name="date_end" required="is_contract == True" />
+                <group invisible="not is_contract">
+                    <field name="date_end" required="is_contract" />
                 </group>
-                <group invisible="is_contract == False">
+                <group invisible="not is_contract">
                     <field name="is_auto_renew" />
                 </group>
-                <group invisible="is_auto_renew == False">
+                <group invisible="not is_auto_renew">
                     <label for="auto_renew_interval" />
                     <div>
                         <field
                             name="auto_renew_interval"
                             class="oe_inline"
                             nolabel="1"
-                            required="is_auto_renew == True"
+                            required="is_auto_renew"
                         />
                         <field
                             name="auto_renew_rule_type"
                             class="oe_inline"
                             nolabel="1"
-                            required="is_auto_renew == True"
+                            required="is_auto_renew"
                         />
                     </div>
                 </group>
@@ -98,14 +98,40 @@
                 expr="//field[@name='order_line']/tree//field[@name='price_total']"
                 position="after"
             >
+                <field name="contract_template_id" column_invisible="1" />
+                <field name="is_contract" column_invisible="1" />
                 <field
-                    name="date_start"
-                    column_invisible="parent.is_contract == False"
+                    name="contract_id"
+                    options='{"no_create": True}'
+                    domain="['|',('contract_template_id','=',contract_template_id), ('contract_template_id','=',False), ('partner_id','=',parent.partner_id), ('is_terminated','=',False),
+                    ]"
+                    optional="hide"
+                />
+                <field
+                    name="contract_line_id"
+                    domain="[('contract_id','=',contract_id)]"
+                    optional="hide"
+                />
+                <field name="recurring_rule_type" optional="hide" />
+                <field name="recurring_invoicing_type" optional="hide" />
+                <field name="date_start" optional="hide" required="is_contract" />
+                <field name="date_end" required="is_contract" optional="hide" />
+                <field name="is_auto_renew" optional="hide" />
+                <field
+                    name="auto_renew_interval"
+                    class="oe_inline"
+                    nolabel="1"
+                    required="is_auto_renew"
+                    optional="hide"
+                />
+                <field
+                    name="auto_renew_rule_type"
+                    class="oe_inline"
+                    nolabel="1"
+                    required="is_auto_renew"
+                    optional="hide"
                 />
                 <field name="date_end" column_invisible="parent.is_contract == False" />
-            </xpath>
-            <xpath expr="//field[@name='order_line']/tree" position="attributes">
-                <attribute name="editable" />
             </xpath>
         </field>
     </record>

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -71,7 +71,7 @@
                     <field name="date_start" required="is_contract" />
                 </group>
                 <group invisible="not is_contract">
-                    <field name="date_end" required="is_contract" />
+                    <field name="date_end" />
                 </group>
                 <group invisible="not is_contract">
                     <field name="is_auto_renew" />
@@ -114,8 +114,13 @@
                 />
                 <field name="recurring_rule_type" optional="hide" />
                 <field name="recurring_invoicing_type" optional="hide" />
-                <field name="date_start" optional="hide" required="is_contract" />
-                <field name="date_end" required="is_contract" optional="hide" />
+                <field name="contract_start_date_method" column_invisible="1" />
+                <field
+                    name="date_start"
+                    optional="hide"
+                    required="is_contract and contract_start_date_method == 'manual'"
+                />
+                <field name="date_end" optional="hide" />
                 <field name="is_auto_renew" optional="hide" />
                 <field
                     name="auto_renew_interval"
@@ -131,7 +136,6 @@
                     required="is_auto_renew"
                     optional="hide"
                 />
-                <field name="date_end" column_invisible="parent.is_contract == False" />
             </xpath>
         </field>
     </record>

--- a/product_contract/wizards/__init__.py
+++ b/product_contract/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import product_contract_configurator

--- a/product_contract/wizards/product_contract_configurator.py
+++ b/product_contract/wizards/product_contract_configurator.py
@@ -1,0 +1,124 @@
+# Copyright 2024 Tecnativa - Carlos Roca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import api, fields, models
+
+
+class ProductContractConfigurator(models.TransientModel):
+    _name = "product.contract.configurator"
+    _description = "Product Contract Configurator Wizard"
+
+    product_id = fields.Many2one("product.product")
+    partner_id = fields.Many2one("res.partner")
+    company_id = fields.Many2one("res.company")
+    product_uom_qty = fields.Float("Quantity")
+    contract_id = fields.Many2one(comodel_name="contract.contract", string="Contract")
+    contract_template_id = fields.Many2one(
+        comodel_name="contract.template",
+        string="Contract Template",
+        compute="_compute_contract_template_id",
+    )
+    recurring_rule_type = fields.Selection(
+        [
+            ("daily", "Day(s)"),
+            ("weekly", "Week(s)"),
+            ("monthly", "Month(s)"),
+            ("monthlylastday", "Month(s) last day"),
+            ("quarterly", "Quarter(s)"),
+            ("semesterly", "Semester(s)"),
+            ("yearly", "Year(s)"),
+        ],
+        default="monthly",
+        string="Invoice Every",
+    )
+    recurring_invoicing_type = fields.Selection(
+        [("pre-paid", "Pre-paid"), ("post-paid", "Post-paid")],
+        default="pre-paid",
+        string="Invoicing type",
+        help="Specify if process date is 'from' or 'to' invoicing date",
+    )
+    date_start = fields.Date()
+    date_end = fields.Date()
+    contract_line_id = fields.Many2one(
+        comodel_name="contract.line",
+        string="Contract Line to replace",
+        required=False,
+    )
+    is_auto_renew = fields.Boolean(
+        string="Auto Renew",
+        compute="_compute_auto_renew",
+        default=False,
+        store=True,
+        readonly=False,
+    )
+    auto_renew_interval = fields.Integer(
+        default=1,
+        string="Renew Every",
+        compute="_compute_auto_renew",
+        store=True,
+        readonly=False,
+        help="Renew every (Days/Week/Month/Year)",
+    )
+    auto_renew_rule_type = fields.Selection(
+        [
+            ("daily", "Day(s)"),
+            ("weekly", "Week(s)"),
+            ("monthly", "Month(s)"),
+            ("yearly", "Year(s)"),
+        ],
+        default="yearly",
+        compute="_compute_auto_renew",
+        store=True,
+        readonly=False,
+        string="Renewal type",
+        help="Specify Interval for automatic renewal.",
+    )
+
+    @api.depends("product_id", "company_id")
+    def _compute_contract_template_id(self):
+        for rec in self:
+            rec.contract_template_id = rec.product_id.with_company(
+                rec.company_id
+            ).property_contract_template_id
+
+    @api.depends("product_id")
+    def _compute_auto_renew(self):
+        for rec in self:
+            if rec.product_id.is_contract:
+                rec.product_uom_qty = rec.product_id.default_qty
+                rec.recurring_rule_type = rec.product_id.recurring_rule_type
+                rec.recurring_invoicing_type = rec.product_id.recurring_invoicing_type
+                rec.date_start = rec.date_start or fields.Date.today()
+
+                rec.date_end = rec._get_date_end()
+                rec.is_auto_renew = rec.product_id.is_auto_renew
+                if rec.is_auto_renew:
+                    rec.auto_renew_interval = rec.product_id.auto_renew_interval
+                    rec.auto_renew_rule_type = rec.product_id.auto_renew_rule_type
+
+    def _get_auto_renew_rule_type(self):
+        """monthly last day don't make sense for auto_renew_rule_type"""
+        self.ensure_one()
+        if self.recurring_rule_type == "monthlylastday":
+            return "monthly"
+        return self.recurring_rule_type
+
+    def _get_date_end(self):
+        self.ensure_one()
+        contract_line_model = self.env["contract.line"]
+        date_end = (
+            self.date_start
+            + contract_line_model.get_relative_delta(
+                self._get_auto_renew_rule_type(),
+                int(self.product_uom_qty),
+            )
+            - relativedelta(days=1)
+        )
+        return date_end
+
+    @api.onchange("date_start", "product_uom_qty", "recurring_rule_type")
+    def _onchange_date_start(self):
+        for rec in self.filtered("product_id.is_contract"):
+            rec.date_end = rec._get_date_end() if rec.date_start else False

--- a/product_contract/wizards/product_contract_configurator_views.xml
+++ b/product_contract/wizards/product_contract_configurator_views.xml
@@ -14,17 +14,27 @@
                     <separator colspan="4" string="Recurrence Invoicing" />
                     <group>
                         <field name="recurring_rule_type" />
-                         <field name="date_start" required="1" />
-                         <field name="is_auto_renew" />
+                        <field name="contract_start_date_method" />
+                        <field
+                            name="date_start"
+                            required="contract_start_date_method == 'manual'"
+                            invisible="contract_start_date_method != 'manual'"
+                        />
+                        <field name="is_auto_renew" invisible="not date_end" />
                     </group>
                     <group>
                         <field name="recurring_invoicing_type" />
-                        <field name="date_end" required="1" />
+                        <field
+                            name="date_end"
+                            invisible="contract_start_date_method != 'manual'"
+                        />
                         <label
                             for="auto_renew_interval"
-                            invisible="not is_auto_renew"
+                            invisible="not is_auto_renew or contract_start_date_method != 'manual'"
                         />
-                        <div invisible="not is_auto_renew">
+                        <div
+                            invisible="not is_auto_renew or contract_start_date_method != 'manual'"
+                        >
                             <field
                                 name="auto_renew_interval"
                                 class="oe_inline"

--- a/product_contract/wizards/product_contract_configurator_views.xml
+++ b/product_contract/wizards/product_contract_configurator_views.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="product_contract_configurator_form" model="ir.ui.view">
+        <field name="model">product.contract.configurator</field>
+        <field name="arch" type="xml">
+            <form js_class="product_contract_configurator_form">
+                <group>
+                    <field name="product_id" invisible="1" />
+                    <field name="partner_id" invisible="1" />
+                    <field name="contract_template_id" invisible="1" />
+                    <group colspan="2">
+                        <field name="product_uom_qty" />
+                    </group>
+                    <separator colspan="4" string="Recurrence Invoicing" />
+                    <group>
+                        <field name="recurring_rule_type" />
+                         <field name="date_start" required="1" />
+                         <field name="is_auto_renew" />
+                    </group>
+                    <group>
+                        <field name="recurring_invoicing_type" />
+                        <field name="date_end" required="1" />
+                        <label
+                            for="auto_renew_interval"
+                            invisible="not is_auto_renew"
+                        />
+                        <div invisible="not is_auto_renew">
+                            <field
+                                name="auto_renew_interval"
+                                class="oe_inline"
+                                nolabel="1"
+                                required="is_auto_renew"
+                            />
+                            <field
+                                name="auto_renew_rule_type"
+                                class="oe_inline"
+                                nolabel="1"
+                                required="is_auto_renew"
+                            />
+                        </div>
+                    </group>
+                    <separator colspan="4" string="Contract" />
+                    <group colspan="2">
+                        <field
+                            name="contract_id"
+                            options='{"no_create": True}'
+                            domain="['|',('contract_template_id','=',contract_template_id), ('contract_template_id','=',False), ('partner_id','=',partner_id), ('is_terminated','=',False),
+                            ]"
+                        />
+                        <field
+                            name="contract_line_id"
+                            domain="[('contract_id','=',contract_id)]"
+                        />
+                    </group>
+                </group>
+                <footer>
+                    <button
+                        string="Ok"
+                        class="btn-primary"
+                        special="save"
+                        data-hotkey="q"
+                    />
+                    <button
+                        string="Cancel"
+                        class="btn-secondary"
+                        special="cancel"
+                        data-hotkey="x"
+                    />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="product_contract_configurator_action" model="ir.actions.act_window">
+        <field name="name">Configure a contract</field>
+        <field name="res_model">product.contract.configurator</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="product_contract_configurator_form" />
+    </record>
+</odoo>


### PR DESCRIPTION
Before these changes, when trying to edit a line of sale order, it was opening the form of the line. But following the Odoo way of working with the events sales, we have make a new contract configurator that will be opened in a popup when selecting a contract product.

@Tecnativa TT50535