### PR TITLE
[FIX][16.0][contract] Fix issue on last_date_invoice contract line

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -575,7 +575,7 @@ class ContractContract(models.Model):
                     )
             invoices_values.append(invoice_vals)
             # Force the recomputation of journal items
-            contract_lines._update_recurring_next_date()
+            contract_lines._update_recurring_next_date(date_ref)
         return invoices_values
 
     def recurring_create_invoice(self):

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -609,7 +609,7 @@ class ContractLine(models.Model):
         for rec in self:
             last_date_invoiced = rec.next_period_date_end
             if invoicing_date:
-                last_date_invoiced = self.get_next_period_date_end(
+                last_date_invoiced = rec.get_next_period_date_end(
                     invoicing_date,
                     rec.recurring_rule_type,
                     rec.recurring_interval,

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -603,11 +603,18 @@ class ContractLine(models.Model):
         name = name.replace("#END#", last_date_invoiced.strftime(date_format))
         return name
 
-    def _update_recurring_next_date(self):
+    def _update_recurring_next_date(self, invoicing_date=False):
         # FIXME: Change method name according to real updated field
         # e.g.: _update_last_date_invoiced()
         for rec in self:
             last_date_invoiced = rec.next_period_date_end
+            if invoicing_date:
+                last_date_invoiced = self.get_next_period_date_end(
+                    invoicing_date,
+                    rec.recurring_rule_type,
+                    rec.recurring_interval,
+                    rec.date_end,
+                )
             rec.write(
                 {
                     "last_date_invoiced": last_date_invoiced,

--- a/contract/models/contract_recurrency_mixin.py
+++ b/contract/models/contract_recurrency_mixin.py
@@ -124,8 +124,6 @@ class ContractRecurrencyMixin(models.AbstractModel):
         "recurring_invoicing_offset",
         "recurring_rule_type",
         "recurring_interval",
-        "date_end",
-        "recurring_next_date",
     )
     def _compute_next_period_date_end(self):
         for rec in self:


### PR DESCRIPTION
## Module
contract

## Describe the bug
On multiline reccuring contract, the contract line last_date_invoice field is correct on the first line and is shift by 1 period time on the others lines (verified in database). This issue generate visible bug only when #START keywork is used in line note.

## To Reproduce
1. Generate a reccuring contract with a product and a line note using #START and #END keywords
2. Generate invoices for this contract
3. The first invoice will be OK but the next invoices will be shift in line note (for example "from 2024-10-01 to 2024-09-30" on september invoice)

**Expected behavior**
Have correct date in #START and #END keywords of line notes

## Correction
The bug came from `_update_recurring_next_date` method. This method is using `next_period_date_end` field to fill `last_date_invoiced` field but `last_date_invoiced` is used to recompute `recurring_next_date` of contract and impact `next_period_date_end`. So the first line is correctly edited but the next line use the new `recurring_next_date` and it create a shift for the next lines.

I keep the older mechanism of `_update_recurring_next_date` without `invoicing_date` and i've add a new mechanism with a specified `invoicing_date` to use the actual invoicing date.