### PR TITLE
[16.0][IMP] product_contract: Contract recurring interval from sale lines

### DIFF
--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -43,6 +43,12 @@ class SaleOrderLine(models.Model):
         help="Specify if process date is 'from' or 'to' invoicing date",
         copy=False,
     )
+    recurring_interval = fields.Integer(
+        string="Invoice Every",
+        default=1,
+        help="Invoice every (Days/Week/Month/Year)",
+        copy=False,
+    )
     date_start = fields.Date()
     date_end = fields.Date()
 
@@ -114,7 +120,7 @@ class SaleOrderLine(models.Model):
             self.date_start
             + contract_line_model.get_relative_delta(
                 self._get_auto_renew_rule_type(),
-                int(self.product_uom_qty),
+                int(self.recurring_interval),
             )
             - relativedelta(days=1)
         )
@@ -124,7 +130,7 @@ class SaleOrderLine(models.Model):
     def _compute_auto_renew(self):
         for rec in self:
             if rec.product_id.is_contract:
-                rec.product_uom_qty = rec.product_id.default_qty
+                rec.recurring_interval = rec.product_id.default_qty
                 rec.recurring_rule_type = rec.product_id.recurring_rule_type
                 rec.recurring_invoicing_type = rec.product_id.recurring_invoicing_type
                 rec.date_start = rec.date_start or fields.Date.today()
@@ -164,7 +170,7 @@ class SaleOrderLine(models.Model):
             self.date_start or fields.Date.today(),
             self.recurring_invoicing_type,
             self.recurring_rule_type,
-            1,
+            self.recurring_interval,
         )
         termination_notice_interval = self.product_id.termination_notice_interval
         termination_notice_rule_type = self.product_id.termination_notice_rule_type
@@ -179,7 +185,7 @@ class SaleOrderLine(models.Model):
             "date_end": self.date_end,
             "date_start": self.date_start or fields.Date.today(),
             "recurring_next_date": recurring_next_date,
-            "recurring_interval": 1,
+            "recurring_interval": self.recurring_interval,
             "recurring_invoicing_type": self.recurring_invoicing_type,
             "recurring_rule_type": self.recurring_rule_type,
             "is_auto_renew": self.is_auto_renew,

--- a/product_contract/tests/test_sale_order.py
+++ b/product_contract/tests/test_sale_order.py
@@ -117,7 +117,7 @@ class TestSaleOrder(TransactionCase):
         contract_line = self.order_line1.contract_id.contract_line_ids
         self.assertEqual(contract_line.date_start, Date.to_date("2018-01-01"))
         self.assertEqual(contract_line.date_end, Date.to_date("2018-12-31"))
-        self.assertEqual(contract_line.recurring_next_date, Date.to_date("2018-01-31"))
+        self.assertEqual(contract_line.recurring_next_date, Date.to_date("2018-12-31"))
 
     def test_change_sale_company(self):
         self.assertTrue(self.sale.company_id)
@@ -166,7 +166,7 @@ class TestSaleOrder(TransactionCase):
         contract_line = self.order_line1.contract_id.contract_line_ids
         self.assertEqual(contract_line.date_start, Date.to_date("2018-01-01"))
         self.assertEqual(contract_line.date_end, Date.to_date("2018-12-31"))
-        self.assertEqual(contract_line.recurring_next_date, Date.to_date("2018-01-31"))
+        self.assertEqual(contract_line.recurring_next_date, Date.to_date("2018-12-31"))
 
     def test_sale_contract_count(self):
         """It should count contracts as many different contract template used
@@ -186,6 +186,10 @@ class TestSaleOrder(TransactionCase):
         self.assertEqual(
             self.order_line1.recurring_invoicing_type,
             self.product1.recurring_invoicing_type,
+        )
+        self.assertEqual(
+            self.order_line1.recurring_interval,
+            self.product1.default_qty,
         )
         self.assertEqual(self.order_line1.date_end, Date.to_date("2018-12-31"))
 

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -62,7 +62,19 @@
                     attrs="{'invisible': [('is_contract', '=', False)]}"
                 />
                 <group attrs="{'invisible': [('is_contract', '=', False)]}">
-                    <field name="recurring_rule_type" />
+                    <label for="recurring_rule_type" />
+                    <div class="o_row">
+                        <field
+                            name="recurring_interval"
+                            class="oe_inline"
+                            nolabel="1"
+                        />
+                        <field
+                            name="recurring_rule_type"
+                            class="oe_inline"
+                            nolabel="1"
+                        />
+                    </div>
                 </group>
                 <group attrs="{'invisible': [('is_contract', '=', False)]}">
                     <field name="recurring_invoicing_type" />


### PR DESCRIPTION
The idea is to set contract.line.recurring_interval field from sale lines.

Changes:

- New field recurring_interval in sale.order.line computed from product.template.default_qty field.
- When creating contract.line from sale.order.line recurring_interval is set from recurring_interval not 1