### PR TITLE
Fix: Respect company context for product category

### DIFF
--- a/subscription_oca/models/sale_subscription_line.py
+++ b/subscription_oca/models/sale_subscription_line.py
@@ -303,8 +303,10 @@ class SaleSubscriptionLine(models.Model):
         self.ensure_one()
         account = (
             self.product_id.property_account_income_id
-            # added company context to the product category account defaults for multi-company setups
-            or self.product_id.categ_id.with_context(company_id=self.sale_subscription_id.company_id.id).property_account_income_categ_id
+            #company context for product category account defaults
+            or self.product_id.categ_id.with_context(
+                company_id=self.sale_subscription_id.company_id.id
+            ).property_account_income_categ_id
         )
         return {
             "product_id": self.product_id.id,

--- a/subscription_oca/models/sale_subscription_line.py
+++ b/subscription_oca/models/sale_subscription_line.py
@@ -303,7 +303,8 @@ class SaleSubscriptionLine(models.Model):
         self.ensure_one()
         account = (
             self.product_id.property_account_income_id
-            or self.product_id.categ_id.property_account_income_categ_id
+            # added company context to the product category account defaults for multi-company setups
+            or self.product_id.categ_id.with_context(company_id=self.sale_subscription_id.company_id.id).property_account_income_categ_id
         )
         return {
             "product_id": self.product_id.id,

--- a/subscription_oca/models/sale_subscription_line.py
+++ b/subscription_oca/models/sale_subscription_line.py
@@ -303,7 +303,7 @@ class SaleSubscriptionLine(models.Model):
         self.ensure_one()
         account = (
             self.product_id.property_account_income_id
-            #company context for product category account defaults
+            # company context for product category account defaults
             or self.product_id.categ_id.with_context(
                 company_id=self.sale_subscription_id.company_id.id
             ).property_account_income_categ_id


### PR DESCRIPTION
Fix default account behavior in subscription module when reference multi-company 'product category' value