### PR TITLE
[16.0][TEST] Add unit test to demonstrate incorrect customer assignment when generating contract invoices

### DIFF
--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -1745,12 +1745,9 @@ class TestContract(TestContractBase):
         )
 
     def test_cron_recurring_create_invoice_several_partners(self):
-        self.acct_line.date_start = "2018-01-01"
-        self.acct_line.recurring_invoicing_type = "post-paid"
-        self.acct_line.date_end = "2018-03-15"
-        other_partner = self.env.ref('base.res_partner_1')
-        contracts = self.contract2
-        contracts |= self.contract.copy({'partner_id': other_partner.id})
+        other_partner = self.env.ref("base.res_partner_1")
+        contracts = self.contract
+        contracts |= self.contract.copy({"invoice_partner_id": other_partner.id})
         self.env["contract.contract"].cron_recurring_create_invoice()
         invoice_lines = self.env["account.move.line"].search(
             [("contract_line_id", "in", contracts.mapped("contract_line_ids").ids)]
@@ -1759,10 +1756,9 @@ class TestContract(TestContractBase):
             len(contracts.mapped("contract_line_ids")),
             len(invoice_lines),
         )
-        self.assertEqual(len(invoice_lines.mapped('move_id')), 2)
-        self.assertEqual(len(invoice_lines.mapped('move_id.partner_id')), 2)
-        self.assertIn(
-            other_partner, invoice_lines.mapped('move_id.partner_id'))
+        self.assertEqual(len(invoice_lines.mapped("move_id")), 2)
+        self.assertEqual(len(invoice_lines.mapped("move_id.partner_id")), 2)
+        self.assertIn(other_partner, invoice_lines.mapped("move_id.partner_id"))
 
     def test_recurring_create_invoice(self):
         self.acct_line.date_start = "2024-01-01"


### PR DESCRIPTION
This Pull Request adds a unit test in the contract module that highlights an error in the invoice generation process using the cron_recurring_create_invoice cron job.

**Error Description**
The issue occurs when multiple invoices are generated for contracts with different customers. Although the cron successfully creates the required invoices, the customer assigned to all the invoices is incorrect. Instead of assigning the correct customer to each invoice, the same customer is for all invoices.

**Unit Test**
The unit test configures multiple contracts with different customers and runs the cron job to generate recurring invoices. It checks that each invoice has the correct customer assigned, but the test fails, demonstrating the existing error.
