### PR TITLE
[16][FIX] contract : ignore date constraint for a note

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -453,7 +453,10 @@ class ContractLine(models.Model):
     @api.constrains("recurring_next_date", "date_start")
     def _check_recurring_next_date_start_date(self):
         for line in self:
-            if line.display_type == "line_section" or not line.recurring_next_date:
+            if (
+                line.display_type in ("line_section", "line_note")
+                or not line.recurring_next_date
+            ):
                 continue
             if line.date_start and line.recurring_next_date:
                 if line.date_start > line.recurring_next_date:


### PR DESCRIPTION
In some cases there is a constraint  when adding a note because of the `recurring_next_date`.
Ignore the constraint for note, as it is already the cases for section

@bguillot 