### PR TITLE
[15.0][IMP] contract: Add INVOICEMONTHNAME marker to line description

### DIFF
--- a/contract/README.rst
+++ b/contract/README.rst
@@ -63,8 +63,8 @@ Usage
    * the recurrence parameters: interval (days, weeks, months, months last day or years),
      start date, date of next invoice (automatically computed, can be modified) and end date (optional)
    * auto-price, for having a price automatically obtained from the price list
-   * #START# or #END# in the description field to display the start/end date of
-     the invoiced period in the invoice line description
+   * #START# - #END# or #INVOICEMONTHNAME# in the description field to display
+     the start/end date or the start month of the invoiced period in the invoice line description
    * pre-paid (invoice at period start) or post-paid (invoice at start of next period)
 
 #. The "Generate Recurring Invoices from Contracts" cron runs daily to generate the invoices.

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -595,6 +595,23 @@ class ContractLine(models.Model):
         )
         return first_date_invoiced, last_date_invoiced, recurring_next_date
 
+    def _translate_marker_month_name(self, month_name):
+        months = {
+            "January": _("January"),
+            "February": _("February"),
+            "March": _("March"),
+            "April": _("April"),
+            "May": _("May"),
+            "June": _("June"),
+            "July": _("July"),
+            "August": _("August"),
+            "September": _("September"),
+            "October": _("October"),
+            "November": _("November"),
+            "December": _("December"),
+        }
+        return months[month_name]
+
     def _insert_markers(self, first_date_invoiced, last_date_invoiced):
         self.ensure_one()
         lang_obj = self.env["res.lang"]
@@ -603,6 +620,12 @@ class ContractLine(models.Model):
         name = self.name
         name = name.replace("#START#", first_date_invoiced.strftime(date_format))
         name = name.replace("#END#", last_date_invoiced.strftime(date_format))
+        name = name.replace(
+            "#INVOICEMONTHNAME#",
+            self.with_context(lang=lang.code)._translate_marker_month_name(
+                first_date_invoiced.strftime("%B")
+            ),
+        )
         return name
 
     def _update_recurring_next_date(self):

--- a/contract/readme/USAGE.rst
+++ b/contract/readme/USAGE.rst
@@ -10,8 +10,8 @@
    * the recurrence parameters: interval (days, weeks, months, months last day or years),
      start date, date of next invoice (automatically computed, can be modified) and end date (optional)
    * auto-price, for having a price automatically obtained from the price list
-   * #START# or #END# in the description field to display the start/end date of
-     the invoiced period in the invoice line description
+   * #START# - #END# or #INVOICEMONTHNAME# in the description field to display
+     the start/end date or the start month of the invoiced period in the invoice line description
    * pre-paid (invoice at period start) or post-paid (invoice at start of next period)
 
 #. The "Generate Recurring Invoices from Contracts" cron runs daily to generate the invoices.

--- a/contract/static/description/index.html
+++ b/contract/static/description/index.html
@@ -408,8 +408,8 @@ user access rights.</p>
 <li>the recurrence parameters: interval (days, weeks, months, months last day or years),
 start date, date of next invoice (automatically computed, can be modified) and end date (optional)</li>
 <li>auto-price, for having a price automatically obtained from the price list</li>
-<li>#START# or #END# in the description field to display the start/end date of
-the invoiced period in the invoice line description</li>
+<li>#START# - #END# or #INVOICEMONTHNAME# in the description field to display
+the start/end date or the start month of the invoiced period in the invoice line description</li>
 <li>pre-paid (invoice at period start) or post-paid (invoice at start of next period)</li>
 </ul>
 </li>

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
@@ -141,7 +142,7 @@ class TestContractBase(common.TransactionCase):
                         0,
                         {
                             "product_id": False,
-                            "name": "Header for Services",
+                            "name": "Header for #INVOICEMONTHNAME# Services",
                             "display_type": "line_section",
                         },
                     ),
@@ -2394,3 +2395,11 @@ class TestContract(TestContractBase):
         action = self.contract.action_preview()
         self.assertIn("/my/contracts/", action["url"])
         self.assertIn("access_token=", action["url"])
+
+    @freeze_time("2023-05-01")
+    def test_check_month_name_marker(self):
+        """Set fixed date to check test correctly."""
+        self.contract3.contract_line_ids.date_start = fields.Date.today()
+        self.contract3.contract_line_ids.recurring_next_date = fields.Date.today()
+        invoice_id = self.contract3.recurring_create_invoice()
+        self.assertEqual(invoice_id.invoice_line_ids[0].name, "Header for May Services")

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -450,6 +450,13 @@
                                     the
                                     invoiced period
                                 </p>
+                                <p colspan="2">
+                                    <strong>#INVOICEMONTHNAME#</strong>
+                                    : Invoice month name
+                                    of
+                                    the
+                                    invoiced period
+                                </p>
                             </group>
                         </page>
                     </notebook>

--- a/contract/views/contract_template.xml
+++ b/contract/views/contract_template.xml
@@ -68,6 +68,8 @@
                 >
                     <p> <strong>#START#</strong>: Start date of the invoiced period</p>
                     <p> <strong>#END#</strong>: End date of the invoiced period</p>
+                    <p> <strong
+                        >#INVOICEMONTHNAME#</strong>: Invoice month name of the invoiced period</p>
                 </group>
             </form>
         </field>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/contract/pull/946 + https://github.com/OCA/contract/pull/966

We want to add a new marker #INVOICEMONTHNAME#

It will print the name of the month of the invoice date

So if the invoice date is 01/06/2023, it will display "June" in label

@Tecnativa