### PR TITLE
[16.0][IMP] contract: make invoicing offset modifiable

### DIFF
--- a/contract/models/contract_recurrency_mixin.py
+++ b/contract/models/contract_recurrency_mixin.py
@@ -36,6 +36,8 @@ class ContractRecurrencyBasicMixin(models.AbstractModel):
     )
     recurring_invoicing_offset = fields.Integer(
         compute="_compute_recurring_invoicing_offset",
+        readonly=False,
+        store=True,
         string="Invoicing offset",
         help=(
             "Number of days to offset the invoice from the period end "


### PR DESCRIPTION
This is not perfect as apparently the line must
be saved for this to take effect, as the on-screen value is not refreshed immediately.