### PR TITLE
[17.0][IMP] contract: Add INVOICEMONTHNAME marker to line description

### DIFF
--- a/contract/README.rst
+++ b/contract/README.rst
@@ -57,21 +57,22 @@ Usage
 2. When creating a contract, fill fields for selecting the invoicing
    parameters:
 
-   - a journal
-   - a price list (optional)
+   -  a journal
+   -  a price list (optional)
 
 3. And add the lines to be invoiced with:
 
-   - the product with a description, a quantity and a price
-   - the recurrence parameters: interval (days, weeks, months, months
-     last day or years), start date, date of next invoice (automatically
-     computed, can be modified) and end date (optional)
-   - auto-price, for having a price automatically obtained from the
-     price list
-   - #START# or #END# in the description field to display the start/end
-     date of the invoiced period in the invoice line description
-   - pre-paid (invoice at period start) or post-paid (invoice at start
-     of next period)
+   -  the product with a description, a quantity and a price
+   -  the recurrence parameters: interval (days, weeks, months, months
+      last day or years), start date, date of next invoice
+      (automatically computed, can be modified) and end date (optional)
+   -  auto-price, for having a price automatically obtained from the
+      price list
+   -  #START# - #END# or #INVOICEMONTHNAME# in the description field to
+      display the start/end date or the start month of the invoiced
+      period in the invoice line description
+   -  pre-paid (invoice at period start) or post-paid (invoice at start
+      of next period)
 
 4. The "Generate Recurring Invoices from Contracts" cron runs daily to
    generate the invoices. If you are in debug mode, you can click on the
@@ -85,7 +86,7 @@ Usage
    price list and lines when creating a contract. To use it, just select
    the template on the contract and fields will be filled automatically.
 
-- Contracts appear in portal to following users in every contract:
+-  Contracts appear in portal to following users in every contract:
 
 |image|
 
@@ -100,8 +101,8 @@ Usage
 Known issues / Roadmap
 ======================
 
-- Recover states and others functional fields in Contracts.
-- Add recurrence flag at template level.
+-  Recover states and others functional fields in Contracts.
+-  Add recurrence flag at template level.
 
 Bug Tracker
 ===========
@@ -125,33 +126,33 @@ Authors
 Contributors
 ------------
 
-- Angel Moya <angel.moya@domatix.com>
+-  Angel Moya <angel.moya@domatix.com>
 
-- Dave Lasley <dave@laslabs.com>
+-  Dave Lasley <dave@laslabs.com>
 
-- Miquel Raïch <miquel.raich@eficent.com>
+-  Miquel Raïch <miquel.raich@eficent.com>
 
-- Souheil Bejaoui <souheil.bejaoui@acsone.eu>
+-  Souheil Bejaoui <souheil.bejaoui@acsone.eu>
 
-- Thomas Binsfeld <thomas.binsfeld@acsone.eu>
+-  Thomas Binsfeld <thomas.binsfeld@acsone.eu>
 
-- Guillaume Vandamme <guillaume.vandamme@acsone.eu>
+-  Guillaume Vandamme <guillaume.vandamme@acsone.eu>
 
-- Raphaël Reverdy <raphael.reverdy@akretion.com>
+-  Raphaël Reverdy <raphael.reverdy@akretion.com>
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-     - Pedro M. Baeza
-     - Carlos Dauden
-     - Vicent Cubells
-     - Rafael Blasco
-     - Víctor Martínez
+      -  Pedro M. Baeza
+      -  Carlos Dauden
+      -  Vicent Cubells
+      -  Rafael Blasco
+      -  Víctor Martínez
 
-- Iván Antón <ozono@ozonomultimedia.com>
+-  Iván Antón <ozono@ozonomultimedia.com>
 
-- `APSL <https://www.apsl.tech>`__:
+-  `APSL <https://www.apsl.tech>`__:
 
-     - Antoni Marroig <amarroig@apsl.net>
+      -  Antoni Marroig <amarroig@apsl.net>
 
 Maintainers
 -----------

--- a/contract/i18n/contract.pot
+++ b/contract/i18n/contract.pot
@@ -116,6 +116,23 @@ msgstr ""
 #. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 msgid ""
+"<strong>#INVOICEMONTHNAME#</strong>\n"
+"                                    : Invoice month name\n"
+"                                    of\n"
+"                                    the\n"
+"                                    invoiced period"
+msgstr ""
+
+#. module: contract
+#: model_terms:ir.ui.view,arch_db:contract.contract_template_form_view
+msgid ""
+"<strong>#INVOICEMONTHNAME#</strong>: Invoice month name of the invoiced "
+"period"
+msgstr ""
+
+#. module: contract
+#: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
+msgid ""
 "<strong>#START#</strong>\n"
 "                                    : Start\n"
 "                                    date\n"
@@ -321,6 +338,13 @@ msgid "Analytic Precision"
 msgstr ""
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "April"
+msgstr ""
+
+#. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_search_view
 msgid "Archived"
@@ -350,6 +374,13 @@ msgstr ""
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_contract__message_attachment_count
 msgid "Attachment Count"
+msgstr ""
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "August"
 msgstr ""
 
 #. module: contract
@@ -935,6 +966,13 @@ msgid "Day(s)"
 msgstr ""
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "December"
+msgstr ""
+
+#. module: contract
 #: model:ir.model.fields,help:contract.field_contract_abstract_contract_line__note_invoicing_mode
 #: model:ir.model.fields,help:contract.field_contract_line__note_invoicing_mode
 #: model:ir.model.fields,help:contract.field_contract_template_line__note_invoicing_mode
@@ -1014,6 +1052,13 @@ msgstr ""
 msgid ""
 "Failed to process the contract %(name)s [id: %(id)s]:\n"
 "%(ue)s"
+msgstr ""
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "February"
 msgstr ""
 
 #. module: contract
@@ -1244,6 +1289,13 @@ msgid "Is suspension without end date"
 msgstr ""
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "January"
+msgstr ""
+
+#. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract__journal_id
 #: model:ir.model.fields,field_description:contract.field_contract_contract__journal_id
 #: model:ir.model.fields,field_description:contract.field_contract_template__journal_id
@@ -1259,6 +1311,20 @@ msgstr ""
 #. module: contract
 #: model:ir.model,name:contract.model_account_move_line
 msgid "Journal Item"
+msgstr ""
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "July"
+msgstr ""
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "June"
 msgstr ""
 
 #. module: contract
@@ -1328,12 +1394,26 @@ msgid "Manually Invoice Sale Contracts"
 msgstr ""
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "March"
+msgstr ""
+
+#. module: contract
 #: model:ir.model.fields,help:contract.field_contract_abstract_contract__line_recurrence
 #: model:ir.model.fields,help:contract.field_contract_contract__line_recurrence
 #: model:ir.model.fields,help:contract.field_contract_template__line_recurrence
 msgid ""
 "Mark this check if you want to control recurrrence at line level instead of "
 "all together for the whole contract."
+msgstr ""
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "May"
 msgstr ""
 
 #. module: contract
@@ -1460,6 +1540,13 @@ msgid "Notes"
 msgstr ""
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "November"
+msgstr ""
+
+#. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_contract__message_needaction_counter
 msgid "Number of Actions"
 msgstr ""
@@ -1491,6 +1578,13 @@ msgstr ""
 #. module: contract
 #: model:ir.model.fields,help:contract.field_contract_contract__message_has_error_counter
 msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "October"
 msgstr ""
 
 #. module: contract
@@ -1766,6 +1860,13 @@ msgstr ""
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_modification__sent
 msgid "Sent"
+msgstr ""
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "September"
 msgstr ""
 
 #. module: contract

--- a/contract/i18n/es.po
+++ b/contract/i18n/es.po
@@ -9,8 +9,6 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-03 19:17+0000\n"
-"PO-Revision-Date: 2024-09-03 21:25+0200\n"
 "Last-Translator: Sergio Teruel <sergio.teruel@tecnativa.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -241,6 +239,29 @@ msgstr "<strong>#END#</strong>: Fecha fin del periodo facturado"
 #. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 msgid ""
+"<strong>#INVOICEMONTHNAME#</strong>\n"
+"                                    : Invoice month name\n"
+"                                    of\n"
+"                                    the\n"
+"                                    invoiced period"
+msgstr ""
+"<strong>#INVOICEMONTHNAME#</strong>\n"
+"                                    : Nombe del mes\n"
+"                                    del\n"
+"                                    periodo facturado"
+
+#. module: contract
+#: model_terms:ir.ui.view,arch_db:contract.contract_template_form_view
+msgid ""
+"<strong>#INVOICEMONTHNAME#</strong>: Invoice month name of the invoiced "
+"period"
+msgstr ""
+"<strong>#INVOICEMONTHNAME#</strong>: FechaNombre del mes del periodo "
+"facturado"
+
+#. module: contract
+#: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
+msgid ""
 "<strong>#START#</strong>\n"
 "                                    : Start\n"
 "                                    date\n"
@@ -452,6 +473,13 @@ msgid "Analytic Precision"
 msgstr "Precisión analítica"
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "April"
+msgstr "Abril"
+
+#. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_search_view
 msgid "Archived"
@@ -482,6 +510,13 @@ msgstr "Socio asociado"
 #: model:ir.model.fields,field_description:contract.field_contract_contract__message_attachment_count
 msgid "Attachment Count"
 msgstr "Nº de archivos adjuntos"
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "August"
+msgstr "Agosto"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract_line__is_auto_renew
@@ -1095,6 +1130,13 @@ msgid "Day(s)"
 msgstr "Día(s)"
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "December"
+msgstr "Diciembre"
+
+#. module: contract
 #: model:ir.model.fields,help:contract.field_contract_abstract_contract_line__note_invoicing_mode
 #: model:ir.model.fields,help:contract.field_contract_line__note_invoicing_mode
 #: model:ir.model.fields,help:contract.field_contract_template_line__note_invoicing_mode
@@ -1183,6 +1225,13 @@ msgid ""
 msgstr ""
 "Fallo al procesar el contrato %(name)s [id: %(id)s]:\n"
 "%(ue)s"
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "February"
+msgstr "Febrero"
 
 #. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_search_view
@@ -1420,6 +1469,13 @@ msgid "Is suspension without end date"
 msgstr "Es suspensión sin fecha de finalización"
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "January"
+msgstr "Enero"
+
+#. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract__journal_id
 #: model:ir.model.fields,field_description:contract.field_contract_contract__journal_id
 #: model:ir.model.fields,field_description:contract.field_contract_template__journal_id
@@ -1436,6 +1492,20 @@ msgstr "Entrada diaria"
 #: model:ir.model,name:contract.model_account_move_line
 msgid "Journal Item"
 msgstr "Apunte contable"
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "July"
+msgstr "Julio"
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "June"
+msgstr "Junio"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract_line__last_date_invoiced
@@ -1505,6 +1575,13 @@ msgid "Manually Invoice Sale Contracts"
 msgstr "Facturar manualmente contratos de venta"
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "March"
+msgstr "Marzo"
+
+#. module: contract
 #: model:ir.model.fields,help:contract.field_contract_abstract_contract__line_recurrence
 #: model:ir.model.fields,help:contract.field_contract_contract__line_recurrence
 #: model:ir.model.fields,help:contract.field_contract_template__line_recurrence
@@ -1514,6 +1591,13 @@ msgid ""
 msgstr ""
 "Marque esta casilla si desea controlar la recurrencia a nivel de línea en "
 "lugar de todos juntos para todo el contrato."
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "May"
+msgstr "Mayo"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_contract__message_has_error
@@ -1639,6 +1723,13 @@ msgid "Notes"
 msgstr "Notas"
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "November"
+msgstr "Noviembre"
+
+#. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_contract__message_needaction_counter
 msgid "Number of Actions"
 msgstr "Número de Acciones"
@@ -1673,6 +1764,13 @@ msgstr "Número de mensajes que requieren una acción"
 #: model:ir.model.fields,help:contract.field_contract_contract__message_has_error_counter
 msgid "Number of messages with delivery error"
 msgstr "Número de mensajes con error de entrega"
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "October"
+msgstr "Octubre"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_account_bank_statement_line__old_contract_id
@@ -1949,6 +2047,13 @@ msgstr "Enviar por correo electrónico"
 #: model:ir.model.fields,field_description:contract.field_contract_modification__sent
 msgid "Sent"
 msgstr "Enviado"
+
+#. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract_line.py:0
+#, python-format
+msgid "September"
+msgstr "Septiembre"
 
 #. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract_line__sequence
@@ -2419,8 +2524,3 @@ msgid ""
 msgstr ""
 "{{ object.company_id.name }} Contrato (Ref {{ object.name or 'n/a' }}) - "
 "Modificaciones"
-
-#, fuzzy
-#~| msgid "Next Activity Deadline"
-#~ msgid "Next Activity Calendar Event"
-#~ msgstr "Fecha límite de la siguiente actividad"

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -595,6 +595,23 @@ class ContractLine(models.Model):
         )
         return first_date_invoiced, last_date_invoiced, recurring_next_date
 
+    def _translate_marker_month_name(self, month_name):
+        months = {
+            "January": _("January"),
+            "February": _("February"),
+            "March": _("March"),
+            "April": _("April"),
+            "May": _("May"),
+            "June": _("June"),
+            "July": _("July"),
+            "August": _("August"),
+            "September": _("September"),
+            "October": _("October"),
+            "November": _("November"),
+            "December": _("December"),
+        }
+        return months[month_name]
+
     def _insert_markers(self, first_date_invoiced, last_date_invoiced):
         self.ensure_one()
         lang_obj = self.env["res.lang"]
@@ -603,6 +620,12 @@ class ContractLine(models.Model):
         name = self.name
         name = name.replace("#START#", first_date_invoiced.strftime(date_format))
         name = name.replace("#END#", last_date_invoiced.strftime(date_format))
+        name = name.replace(
+            "#INVOICEMONTHNAME#",
+            self.with_context(lang=lang.code)._translate_marker_month_name(
+                first_date_invoiced.strftime("%B")
+            ),
+        )
         return name
 
     def _update_recurring_next_date(self):

--- a/contract/readme/USAGE.md
+++ b/contract/readme/USAGE.md
@@ -11,9 +11,9 @@
       (automatically computed, can be modified) and end date (optional)
     - auto-price, for having a price automatically obtained from the
       price list
-    - \#START# or \#END# in the description field to display the
-      start/end date of the invoiced period in the invoice line
-      description
+    - \#START# - \#END# or \#INVOICEMONTHNAME# in the description field
+      to display the start/end date or the start month of the invoiced
+      period in the invoice line description
     - pre-paid (invoice at period start) or post-paid (invoice at start
       of next period)
 4.  The "Generate Recurring Invoices from Contracts" cron runs daily to

--- a/contract/static/description/index.html
+++ b/contract/static/description/index.html
@@ -410,12 +410,13 @@ parameters:<ul>
 <li>And add the lines to be invoiced with:<ul>
 <li>the product with a description, a quantity and a price</li>
 <li>the recurrence parameters: interval (days, weeks, months, months
-last day or years), start date, date of next invoice (automatically
-computed, can be modified) and end date (optional)</li>
+last day or years), start date, date of next invoice
+(automatically computed, can be modified) and end date (optional)</li>
 <li>auto-price, for having a price automatically obtained from the
 price list</li>
-<li>#START# or #END# in the description field to display the start/end
-date of the invoiced period in the invoice line description</li>
+<li>#START# - #END# or #INVOICEMONTHNAME# in the description field to
+display the start/end date or the start month of the invoiced
+period in the invoice line description</li>
 <li>pre-paid (invoice at period start) or post-paid (invoice at start
 of next period)</li>
 </ul>

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
@@ -141,7 +142,7 @@ class TestContractBase(common.TransactionCase):
                         0,
                         {
                             "product_id": False,
-                            "name": "Header for Services",
+                            "name": "Header for #INVOICEMONTHNAME# Services",
                             "display_type": "line_section",
                         },
                     ),
@@ -2385,3 +2386,11 @@ class TestContract(TestContractBase):
         self.assertEqual(len(self.contract._get_related_invoices()), 4)
         self.contract.recurring_create_invoice()
         self.assertEqual(len(self.contract._get_related_invoices()), 4)
+
+    @freeze_time("2023-05-01")
+    def test_check_month_name_marker(self):
+        """Set fixed date to check test correctly."""
+        self.contract3.contract_line_ids.date_start = fields.Date.today()
+        self.contract3.contract_line_ids.recurring_next_date = fields.Date.today()
+        invoice_id = self.contract3.recurring_create_invoice()
+        self.assertEqual(invoice_id.invoice_line_ids[0].name, "Header for May Services")

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -478,6 +478,13 @@
                                     the
                                     invoiced period
                                 </p>
+                                <p colspan="2">
+                                    <strong>#INVOICEMONTHNAME#</strong>
+                                    : Invoice month name
+                                    of
+                                    the
+                                    invoiced period
+                                </p>
                             </group>
                         </page>
                     </notebook>

--- a/contract/views/contract_template.xml
+++ b/contract/views/contract_template.xml
@@ -76,6 +76,8 @@
                         <p> <strong
                             >#START#</strong>: Start date of the invoiced period</p>
                         <p> <strong>#END#</strong>: End date of the invoiced period</p>
+                        <p> <strong
+                            >#INVOICEMONTHNAME#</strong>: Invoice month name of the invoiced period</p>
                     </div>
                 </group>
             </form>


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/contract/pull/1154

We want to add a new marker #INVOICEMONTHNAME#

It will print the name of the month of the invoice date

So if the invoice date is 01/06/2023, it will display "June" in label

@Tecnativa