### PR TITLE
[16.0][FIX] contract: proper condition for auto price

### DIFF
--- a/contract/models/abstract_contract_line.py
+++ b/contract/models/abstract_contract_line.py
@@ -193,7 +193,11 @@ class ContractAbstractContractLine(models.AbstractModel):
         from the pricelist otherwise.
         """
         for line in self:
-            if line.automatic_price and line.product_id:
+            if (
+                line.automatic_price
+                and line.product_id
+                and (line.contract_id.pricelist_id or line.contract_id.partner_id)
+            ):
                 pricelist = (
                     line.contract_id.pricelist_id
                     or line.contract_id.partner_id.with_company(


### PR DESCRIPTION
IMPORTANT EDIT: the bug is present on 16.0 but it is not present in 15.0 nor 17.0. So no port will be needed for these versions.

without these conditions, if you create a new contract template with a new line with the price set as "automatic" (checkbox) while the contract has no pricelist, then you get this error (easy to reproduce on the Runboat):

```
  File "/opt/odoo/odoo/models.py", line 6622, in onchange
    todo = [
  File "/opt/odoo/odoo/models.py", line 6625, in <listcomp>
    if name not in done and snapshot0.has_changed(name)
  File "/opt/odoo/odoo/models.py", line 6408, in has_changed
    return self[name] != record[name]
  File "/opt/odoo/odoo/models.py", line 5957, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "/opt/odoo/odoo/fields.py", line 1210, in __get__
    self.compute_value(recs)
  File "/opt/odoo/odoo/fields.py", line 1392, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/odoo/models.py", line 4241, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/odoo/fields.py", line 98, in determine
    return needle(*args)
  File "/mnt/data/odoo-addons-dir/contract/models/abstract_contract_line.py", line 214, in _compute_price_unit
    line.price_unit = pricelist._get_product_price(product, quantity=1)
  File "/opt/odoo/addons/product/models/product_pricelist.py", line 84, in _get_product_price
    self.ensure_one()
  File "/opt/odoo/odoo/models.py", line 5186, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: product.pricelist()
```