### PR TITLE
[FIX] subscription_oca: replace mail_notification_paynow layout with mail_notification_layout_with_responsible_signature

### DIFF
--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -325,7 +325,8 @@ class SaleSubscription(models.Model):
                     invoice.with_context(force_send=True).message_post_with_template(
                         mail_template.id,
                         composition_mode="comment",
-                        email_layout_xmlid="mail.mail_notification_paynow",
+                        email_layout_xmlid="mail."
+                        "mail_notification_layout_with_responsible_signature",
                     )
                 invoice_number = invoice.name
                 message_body = (


### PR DESCRIPTION
This PR aims to replace the deprecated email layout  - mail_notification_paynow with the new mail_notification_layout_with_responsible_signature email layout