### PR TITLE
[17.0][FIX] contract: link contract instead of move

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -615,7 +615,7 @@ class ContractContract(models.Model):
             for move in invoices & item._get_related_invoices():
                 body = Markup(_("%(msg)s by contract: %(contract_link)s")) % {
                     "msg": move._creation_message(),
-                    "contract_link": move._get_html_link(title=item.display_name),
+                    "contract_link": item._get_html_link(title=item.display_name),
                 }
                 move.message_post(body=body)
 


### PR DESCRIPTION
Before this commit, the posted message was linked to the move instead of the contract.

complementary to https://github.com/OCA/contract/pull/1123

TT52480 @pedrobaeza @sergio-teruel could you please check this