### PR TITLE
[16.0][IMP] contract: Use %m instead of %B to obtain month

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -598,18 +598,18 @@ class ContractLine(models.Model):
 
     def _translate_marker_month_name(self, month_name):
         months = {
-            "January": _("January"),
-            "February": _("February"),
-            "March": _("March"),
-            "April": _("April"),
-            "May": _("May"),
-            "June": _("June"),
-            "July": _("July"),
-            "August": _("August"),
-            "September": _("September"),
-            "October": _("October"),
-            "November": _("November"),
-            "December": _("December"),
+            "01": _("January"),
+            "02": _("February"),
+            "03": _("March"),
+            "04": _("April"),
+            "05": _("May"),
+            "06": _("June"),
+            "07": _("July"),
+            "08": _("August"),
+            "09": _("September"),
+            "10": _("October"),
+            "11": _("November"),
+            "12": _("December"),
         }
         return months[month_name]
 
@@ -624,7 +624,7 @@ class ContractLine(models.Model):
         name = name.replace(
             "#INVOICEMONTHNAME#",
             self.with_context(lang=lang.code)._translate_marker_month_name(
-                first_date_invoiced.strftime("%B")
+                first_date_invoiced.strftime("%m")
             ),
         )
         return name


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/contract/pull/1163

Use `%m` instead of `%B` to obtain month

Related to https://github.com/OCA/contract/pull/1153 Fixes https://github.com/OCA/contract/issues/1160

Use the month number to set the text of the month and avoid problems according to the language defined in locale.

Please @pedrobaeza can you review it?

@Tecnativa