### PR TITLE
[IMP] display generation_type on contract template

### DIFF
--- a/contract_sale_generation/__manifest__.py
+++ b/contract_sale_generation/__manifest__.py
@@ -14,6 +14,7 @@
     "data": [
         "data/contract_cron.xml",
         "views/contract.xml",
+        "views/contract_template.xml",
     ],
     "installable": True,
 }

--- a/contract_sale_generation/views/contract_template.xml
+++ b/contract_sale_generation/views/contract_template.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="contract_template_form_view_recurring_sale_form" model="ir.ui.view">
+        <field name="name">contract.template form view</field>
+        <field name="model">contract.template</field>
+        <field name="inherit_id" ref="contract.contract_template_form_view" />
+        <field name="arch" type="xml">
+            <field name="contract_type" position="after">
+                <field name="generation_type" />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Set the field generation_type on contract template. This allows to create automatically sale-generating contract with product_contract. 

internal task : https://gestion.coopiteasy.be/web#id=13411&action=475&active_id=605&model=project.task&view_type=form&menu_id=536