### PR TITLE
[17.0][IMP] contract: Terminate contract lines with last_date_invoiced if it is higher than terminate date from wizard

### DIFF
--- a/contract/i18n/contract.pot
+++ b/contract/i18n/contract.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-09 20:32+0000\n"
+"PO-Revision-Date: 2025-01-09 20:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1740,11 +1742,6 @@ msgid "Quarter(s)"
 msgstr ""
 
 #. module: contract
-#: model:ir.model.fields,field_description:contract.field_contract_contract__rating_ids
-msgid "Ratings"
-msgstr ""
-
-#. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract__recurring_rule_type
 #: model:ir.model.fields,field_description:contract.field_contract_abstract_contract_line__recurring_rule_type
 #: model:ir.model.fields,field_description:contract.field_contract_contract__recurring_rule_type
@@ -2076,6 +2073,18 @@ msgstr ""
 #. module: contract
 #: model:ir.model,name:contract.model_contract_contract_terminate
 msgid "Terminate Contract Wizard"
+msgstr ""
+
+#. module: contract
+#: model:ir.model.fields,field_description:contract.field_contract_contract_terminate__terminate_with_last_date_invoiced
+msgid "Terminate lines with last date invoiced"
+msgstr ""
+
+#. module: contract
+#: model:ir.model.fields,help:contract.field_contract_contract_terminate__terminate_with_last_date_invoiced
+msgid ""
+"Terminate the contract lines with the last invoiced date if they cannot be "
+"terminated with the date reported in the wizard."
 msgstr ""
 
 #. module: contract

--- a/contract/i18n/es.po
+++ b/contract/i18n/es.po
@@ -2272,6 +2272,20 @@ msgid "Terminate Contract Wizard"
 msgstr "Asistente de finalización de contrato"
 
 #. module: contract
+#: model:ir.model.fields,field_description:contract.field_contract_contract_terminate__terminate_with_last_date_invoiced
+msgid "Terminate lines with last date invoiced"
+msgstr "Finalizar líneas con la última fecha facturada"
+
+#. module: contract
+#: model:ir.model.fields,help:contract.field_contract_contract_terminate__terminate_with_last_date_invoiced
+msgid ""
+"Terminate the contract lines with the last invoiced date if they cannot be "
+"terminated with the date reported in the wizard."
+msgstr ""
+"Terminar las lineas de los contratos con la ultima fecha facturada si no se "
+"pueden terminar con la fecha informada en el asistente."
+
+#. module: contract
 #: model:ir.model.fields,field_description:contract.field_contract_contract__is_terminated
 msgid "Terminated"
 msgstr "Finalizado"

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -2295,6 +2295,15 @@ class TestContract(TestContractBase):
                 "terminate_comment",
                 to_date("2018-02-13"),
             )
+        # Try terminate contract line with last_date_invoiced allowed
+        self.contract._terminate_contract(
+            self.terminate_reason,
+            "terminate_comment",
+            to_date("2018-02-13"),
+            terminate_lines_with_last_date_invoiced=True,
+        )
+        self.assertTrue(self.contract.is_terminated)
+        self.assertEqual(self.acct_line.date_end, to_date("2018-02-14"))
 
     def test_recurrency_propagation(self):
         # Existing contract

--- a/contract/wizards/contract_contract_terminate.py
+++ b/contract/wizards/contract_contract_terminate.py
@@ -25,6 +25,11 @@ class ContractContractTerminate(models.TransientModel):
     terminate_comment_required = fields.Boolean(
         related="terminate_reason_id.terminate_comment_required"
     )
+    terminate_with_last_date_invoiced = fields.Boolean(
+        string="Terminate lines with last date invoiced",
+        help="Terminate the contract lines with the last invoiced date if they cannot "
+        "be terminated with the date reported in the wizard.",
+    )
 
     def terminate_contract(self):
         for wizard in self:
@@ -32,5 +37,6 @@ class ContractContractTerminate(models.TransientModel):
                 wizard.terminate_reason_id,
                 wizard.terminate_comment,
                 wizard.terminate_date,
+                wizard.terminate_with_last_date_invoiced,
             )
         return True

--- a/contract/wizards/contract_contract_terminate.xml
+++ b/contract/wizards/contract_contract_terminate.xml
@@ -15,6 +15,7 @@
                         name="terminate_comment"
                         required="terminate_comment_required"
                     />
+                    <field name="terminate_with_last_date_invoiced" />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
cc @Tecnativa TT52602

Well, when you have a contract with some lines with diferents recurrences you can different last date invoiced values so if you try to terminate all contrat from wizard you can obtain an error because the date in the wizard is lower than the last date invoiced in the line.

With this improvement user can choose if terminate the line with last date invoiced instead if is higher than the date of the wizard.

ping @carlosdauden @carlos-lopez-tecnativa 