### PR TITLE
[16.0] [IMP] _compute_auto_renew on quotation sent

### DIFF
--- a/product_contract/models/sale_order.py
+++ b/product_contract/models/sale_order.py
@@ -110,6 +110,11 @@ class SaleOrder(models.Model):
                 line.create_contract_line(line.contract_id)
         return contract_model.browse(contracts)
 
+    def action_quotation_sent(self):
+        for line in self.order_line:
+            line._compute_auto_renew()
+        return super().action_quotation_sent()
+
     def action_confirm(self):
         """If we have a contract in the order, set it up"""
         self.filtered(


### PR DESCRIPTION
This allows to make the product contract settings work on ecommerce orders. The product auto-renew settings are only applied on product change. This doesn't happen for sale orders created from the ecommerce. This PR force the computation of auto-renew settings on checkout. 