### PR TITLE
[17.0][IMP] product_contract: Set description under product name instead of description

### DIFF
--- a/product_contract/README.rst
+++ b/product_contract/README.rst
@@ -42,6 +42,16 @@ invoice directly.
 .. contents::
    :local:
 
+Configuration
+=============
+
+You can include the contract details on the sales order description by
+using the following system parameters:
+
+1. **Recurrency** -> product_contract.show_recurrency
+2. **Invoicing Type** -> product_contract.show_invoicing_type
+3. **Date** -> product_contract.show_date
+
 Usage
 =====
 

--- a/product_contract/i18n/es.po
+++ b/product_contract/i18n/es.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-30 12:54+0000\n"
-"PO-Revision-Date: 2024-08-30 15:06+0200\n"
+"POT-Creation-Date: 2025-01-24 14:18+0000\n"
+"PO-Revision-Date: 2025-01-24 15:19+0100\n"
 "Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -19,6 +19,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.0.1\n"
+
+#. module: product_contract
+#. odoo-python
+#: code:addons/product_contract/models/sale_order_line.py:0
+#, python-format
+msgid "- Date: {}"
+msgstr "- Fecha: {}"
+
+#. module: product_contract
+#. odoo-python
+#: code:addons/product_contract/models/sale_order_line.py:0
+#, python-format
+msgid "- Invoicing Type: {}"
+msgstr "- Tipo de facturación: {}"
+
+#. module: product_contract
+#. odoo-python
+#: code:addons/product_contract/models/sale_order_line.py:0
+#, python-format
+msgid "- Recurrency: {}"
+msgstr "- Recurrencia: {}"
 
 #. module: product_contract
 #: model_terms:ir.ui.view,arch_db:product_contract.contract_contract_customer_form_view
@@ -362,6 +383,11 @@ msgid "Product Contract Configurator Wizard"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_sale_order_line__product_contract_description
+msgid "Product Contract Description"
+msgstr ""
+
+#. module: product_contract
 #: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__product_uom_qty
 msgid "Quantity"
 msgstr "Cantidad"
@@ -616,53 +642,3 @@ msgstr "Años"
 #, python-format
 msgid "You can't upsell or downsell a terminated contract"
 msgstr "No puede vender o vender un contrato terminado"
-
-#. module: product_contract
-#. odoo-python
-#: code:addons/product_contract/models/sale_order.py:0
-#, python-format
-msgid ""
-"You must specify a contract template for '%(product_name)s' product in "
-"'%(company_name)s' company."
-msgstr ""
-"Debes especificar una plantilla de contrato para el producto "
-"'%(product_name)s' en la empresa '%(company_name)s'."
-
-#. module: product_contract
-#. odoo-python
-#: code:addons/product_contract/models/sale_order_line.py:0
-#, python-format
-msgid ""
-"{product}:\n"
-"    - Recurrency: {recurring_rule}\n"
-"    - Invoicing Type: {invoicing_type}\n"
-"    - Date: {date_text}\n"
-"                "
-msgstr ""
-
-#, python-format
-#~ msgid ""
-#~ "{product}\n"
-#~ "    - Recurrency: {recurring_rule}\n"
-#~ "    - Invoicing Type: {invoicing_type}\n"
-#~ "    - Date: {date_text}\n"
-#~ "                "
-#~ msgstr ""
-#~ "{product}\n"
-#~ "    - Periodicidad: {recurring_rule}\n"
-#~ "    - Tipo de facturación: {invoicing_type}\n"
-#~ "    - Fecha: {date_text}\n"
-#~ "                "
-
-#~ msgid "Product Template"
-#~ msgstr "Plantilla de producto"
-
-#~ msgid "Sale Order"
-#~ msgstr "Pedido de Venta"
-
-#, python-format
-#~ msgid ""
-#~ "You must specify a contract template for '{}' product in '{}' company."
-#~ msgstr ""
-#~ "Debe especificar una plantilla de contrato para el producto '{}' en la "
-#~ "compañía '{}'."

--- a/product_contract/i18n/product_contract.pot
+++ b/product_contract/i18n/product_contract.pot
@@ -6,12 +6,35 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-24 14:18+0000\n"
+"PO-Revision-Date: 2025-01-24 14:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: product_contract
+#. odoo-python
+#: code:addons/product_contract/models/sale_order_line.py:0
+#, python-format
+msgid "- Date: {}"
+msgstr ""
+
+#. module: product_contract
+#. odoo-python
+#: code:addons/product_contract/models/sale_order_line.py:0
+#, python-format
+msgid "- Invoicing Type: {}"
+msgstr ""
+
+#. module: product_contract
+#. odoo-python
+#: code:addons/product_contract/models/sale_order_line.py:0
+#, python-format
+msgid "- Recurrency: {}"
+msgstr ""
 
 #. module: product_contract
 #: model_terms:ir.ui.view,arch_db:product_contract.contract_contract_customer_form_view
@@ -355,6 +378,11 @@ msgid "Product Contract Configurator Wizard"
 msgstr ""
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_sale_order_line__product_contract_description
+msgid "Product Contract Description"
+msgstr ""
+
+#. module: product_contract
 #: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__product_uom_qty
 msgid "Quantity"
 msgstr ""
@@ -558,25 +586,4 @@ msgstr ""
 #: code:addons/product_contract/models/sale_order_line.py:0
 #, python-format
 msgid "You can't upsell or downsell a terminated contract"
-msgstr ""
-
-#. module: product_contract
-#. odoo-python
-#: code:addons/product_contract/models/sale_order.py:0
-#, python-format
-msgid ""
-"You must specify a contract template for '%(product_name)s' product in "
-"'%(company_name)s' company."
-msgstr ""
-
-#. module: product_contract
-#. odoo-python
-#: code:addons/product_contract/models/sale_order_line.py:0
-#, python-format
-msgid ""
-"{product}:\n"
-"    - Recurrency: {recurring_rule}\n"
-"    - Invoicing Type: {invoicing_type}\n"
-"    - Date: {date_text}\n"
-"                "
 msgstr ""

--- a/product_contract/readme/CONFIGURE.md
+++ b/product_contract/readme/CONFIGURE.md
@@ -1,0 +1,5 @@
+You can include the contract details on the sales order description by using the following system parameters:
+
+1.  **Recurrency** -\> product_contract.show_recurrency
+2.  **Invoicing Type** -\> product_contract.show_invoicing_type
+3.  **Date** -\> product_contract.show_date

--- a/product_contract/static/description/index.html
+++ b/product_contract/static/description/index.html
@@ -379,19 +379,30 @@ invoice directly.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>You can include the contract details on the sales order description by
+using the following system parameters:</p>
+<ol class="arabic simple">
+<li><strong>Recurrency</strong> -&gt; product_contract.show_recurrency</li>
+<li><strong>Invoicing Type</strong> -&gt; product_contract.show_invoicing_type</li>
+<li><strong>Date</strong> -&gt; product_contract.show_date</li>
+</ol>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go to Sales -&gt; Products and select or create a product.</li>
@@ -401,14 +412,14 @@ product</li>
 </ol>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>There’s no support right now for computing the start date for the
 following recurrent types: daily, weekly and monthlylastday.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/contract/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -416,16 +427,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>LasLabs</li>
 <li>ACSONE SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li>Ted Salmon &lt;<a class="reference external" href="mailto:tsalmon&#64;laslabs.com">tsalmon&#64;laslabs.com</a>&gt;</li>
 <li>Souheil Bejaoui &lt;<a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a>&gt;</li>
@@ -439,7 +450,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/product_contract/static/src/js/sale_product_field.esm.js
+++ b/product_contract/static/src/js/sale_product_field.esm.js
@@ -4,6 +4,21 @@ import {SaleOrderLineProductField} from "@sale/js/sale_product_field";
 import {patch} from "@web/core/utils/patch";
 
 patch(SaleOrderLineProductField.prototype, {
+    get extraLines() {
+        var res = super.extraLines;
+        if (
+            this.props.record.data.is_contract &&
+            this.props.record.data.product_contract_description
+        ) {
+            for (var val of this.props.record.data.product_contract_description.split(
+                "||"
+            )) {
+                res.push(val);
+            }
+        }
+        return res;
+    },
+
     async _onProductUpdate() {
         super._onProductUpdate(...arguments);
         if (this.props.record.data.is_contract) {

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -100,6 +100,7 @@
             >
                 <field name="contract_template_id" column_invisible="1" />
                 <field name="is_contract" column_invisible="1" />
+                <field name="product_contract_description" column_invisible="1" />
                 <field
                     name="contract_id"
                     options='{"no_create": True}'


### PR DESCRIPTION
Using the feature extraLines of Many2one field Component we can add the info under the product and avoid noice on the product description.

You can show this info on the description by using the system parameters:
    - product_contract.show_recurrency
    - product_contract.show_invoicing_type
    - product_contract.show_date

cc @Tecnativa TT54693

ping @pedrobaeza @carlos-lopez-tecnativa @sergio-teruel 