### PR TITLE
[16.0][FIX] contract: Invoice creation message translatable

### DIFF
--- a/contract/i18n/contract.pot
+++ b/contract/i18n/contract.pot
@@ -2335,6 +2335,13 @@ msgid "You must supply a date of next invoice for contract line '%s'"
 msgstr ""
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract.py:0
+#, python-format
+msgid "by contract"
+msgstr ""
+
+#. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 msgid "e.g. Contract XYZ"
 msgstr ""

--- a/contract/i18n/es.po
+++ b/contract/i18n/es.po
@@ -2544,6 +2544,13 @@ msgstr ""
 "'%s'"
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract.py:0
+#, python-format
+msgid "by contract"
+msgstr "por el contrato"
+
+#. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 msgid "e.g. Contract XYZ"
 msgstr "ejemplo Contrato XYZ"

--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -619,17 +619,12 @@ class ContractContract(models.Model):
     def _add_contract_origin(self, invoices):
         for item in self:
             for move in invoices & item._get_related_invoices():
+                translation = _("by contract")
                 move.message_post(
                     body=(
-                        _(
-                            (
-                                "%(msg)s by contract <a href=# data-oe-model=contract.contract"
-                                " data-oe-id=%(contract_id)d>%(contract)s</a>."
-                            ),
-                            msg=move._creation_message(),
-                            contract_id=item.id,
-                            contract=item.display_name,
-                        )
+                        f"{move._creation_message()} {translation} "
+                        f"<a href=# data-oe-model=contract.contract"
+                        f" data-oe-id={item.id}>{item.display_name}</a>."
                     )
                 )
 


### PR DESCRIPTION
As it was, the text to translate is not correctly extracted, so it's not translated, creating a mix of languages, as `_creation_message` is returning a translated sentence.

We take also the opportunity to change the way the sentence is built for having as translatable only the "by contract" words, to avoid possible errors in translations due to the placeholders.

Before:
![imagen](https://github.com/user-attachments/assets/7037193c-ab28-4cea-989b-f5d218e438b5)

After:
![imagen](https://github.com/user-attachments/assets/25689be4-291f-43f1-a144-f2579464fa47)

@Tecnativa 