### PR TITLE
[17.0][FIX] contract: Invoice creation message translatable

### DIFF
--- a/contract/i18n/contract.pot
+++ b/contract/i18n/contract.pot
@@ -2335,6 +2335,13 @@ msgid "You must supply a date of next invoice for contract line '%s'"
 msgstr ""
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract.py:0
+#, python-format
+msgid "by contract"
+msgstr ""
+
+#. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 msgid "e.g. Contract XYZ"
 msgstr ""

--- a/contract/i18n/es.po
+++ b/contract/i18n/es.po
@@ -2543,6 +2543,13 @@ msgstr ""
 "'%s'"
 
 #. module: contract
+#. odoo-python
+#: code:addons/contract/models/contract.py:0
+#, python-format
+msgid "by contract"
+msgstr "por el contrato"
+
+#. module: contract
 #: model_terms:ir.ui.view,arch_db:contract.contract_contract_form_view
 msgid "e.g. Contract XYZ"
 msgstr "ejemplo Contrato XYZ"

--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -613,11 +613,13 @@ class ContractContract(models.Model):
     def _add_contract_origin(self, invoices):
         for item in self:
             for move in invoices & item._get_related_invoices():
-                body = Markup(_("%(msg)s by contract: %(contract_link)s")) % {
-                    "msg": move._creation_message(),
-                    "contract_link": item._get_html_link(title=item.display_name),
-                }
-                move.message_post(body=body)
+                translation = _("by contract")
+                move.message_post(
+                    body=Markup(
+                        f"{move._creation_message()} {translation} "
+                        f"{item._get_html_link(title=item.display_name)}."
+                    )
+                )
 
     def _recurring_create_invoice(self, date_ref=False):
         invoices_values = self._prepare_recurring_invoices_values(date_ref)


### PR DESCRIPTION
Forward-port of #1189 

As it was, the text to translate is not correctly extracted, so it's not translated, creating a mix of languages, as `_creation_message` is returning a translated sentence.

We take also the opportunity to change the way the sentence is built for having as translatable only the "by contract" words, to avoid possible errors in translations due to the placeholders.

Before:
![imagen](https://github.com/user-attachments/assets/7037193c-ab28-4cea-989b-f5d218e438b5)

After:
![imagen](https://github.com/user-attachments/assets/25689be4-291f-43f1-a144-f2579464fa47)

@Tecnativa 