### PR TITLE
[17.0][FIX] product_contract: Make configuration tab compatible with sale_product_configurator

### DIFF
--- a/product_contract/README.rst
+++ b/product_contract/README.rst
@@ -65,8 +65,8 @@ To use this module, you need to:
 Known issues / Roadmap
 ======================
 
-- There's no support right now for computing the start date for the
-  following recurrent types: daily, weekly and monthlylastday.
+-  There's no support right now for computing the start date for the
+   following recurrent types: daily, weekly and monthlylastday.
 
 Bug Tracker
 ===========
@@ -90,16 +90,16 @@ Authors
 Contributors
 ------------
 
-- Ted Salmon <tsalmon@laslabs.com>
-- Souheil Bejaoui <souheil.bejaoui@acsone.eu>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Ted Salmon <tsalmon@laslabs.com>
+-  Souheil Bejaoui <souheil.bejaoui@acsone.eu>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Ernesto Tejeda
-  - Pedro M. Baeza
-  - Carlos Roca
-  - Sergio Teruel
+   -  Ernesto Tejeda
+   -  Pedro M. Baeza
+   -  Carlos Roca
+   -  Sergio Teruel
 
-- David Jaen <david.jaen.revert@gmail.com>
+-  David Jaen <david.jaen.revert@gmail.com>
 
 Maintainers
 -----------
@@ -117,10 +117,13 @@ promote its widespread use.
 .. |maintainer-sbejaoui| image:: https://github.com/sbejaoui.png?size=40px
     :target: https://github.com/sbejaoui
     :alt: sbejaoui
+.. |maintainer-CarlosRoca13| image:: https://github.com/CarlosRoca13.png?size=40px
+    :target: https://github.com/CarlosRoca13
+    :alt: CarlosRoca13
 
-Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-sbejaoui| 
+|maintainer-sbejaoui| |maintainer-CarlosRoca13| 
 
 This module is part of the `OCA/contract <https://github.com/OCA/contract/tree/17.0/product_contract>`_ project on GitHub.
 

--- a/product_contract/__manifest__.py
+++ b/product_contract/__manifest__.py
@@ -21,6 +21,6 @@
     "installable": True,
     "application": False,
     "external_dependencies": {"python": ["dateutil"]},
-    "maintainers": ["sbejaoui"],
+    "maintainers": ["sbejaoui", "CarlosRoca13"],
     "assets": {"web.assets_backend": ["product_contract/static/src/js/*"]},
 }

--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -420,24 +420,26 @@ class SaleOrderLine(models.Model):
         "date_start", "date_end", "recurring_rule_type", "recurring_invoicing_type"
     )
     def _compute_name(self):
-        res = super()._compute_name()
+        # This method is used for adding new dependencies
+        return super()._compute_name()
+
+    def _get_sale_order_line_multiline_description_sale(self):
+        self.ensure_one()
         ICP = self.env["ir.config_parameter"].sudo()
-        for line in self:
-            if line.is_contract:
-                description = ""
-                if str2bool(ICP.get_param("product_contract.show_recurrency")) and (
-                    recurring_rule_label
-                    := line._get_product_contract_recurring_rule_label()
-                ):
-                    description += "\n\t" + recurring_rule_label
-                if str2bool(ICP.get_param("product_contract.show_invoicing_type")) and (
-                    invoicing_type_label
-                    := line._get_product_contract_invoicing_type_label()
-                ):
-                    description += "\n\t" + invoicing_type_label
-                if str2bool(ICP.get_param("product_contract.show_date")) and (
-                    date_text := line._get_product_contract_date_text()
-                ):
-                    description += "\n\t" + date_text
-                line.name = f"{line.product_id.display_name}{description}"
-        return res
+        description = ""
+        if self.is_contract:
+            if str2bool(ICP.get_param("product_contract.show_recurrency")) and (
+                recurring_rule_label
+                := self._get_product_contract_recurring_rule_label()
+            ):
+                description += "\n\t" + recurring_rule_label
+            if str2bool(ICP.get_param("product_contract.show_invoicing_type")) and (
+                invoicing_type_label
+                := self._get_product_contract_invoicing_type_label()
+            ):
+                description += "\n\t" + invoicing_type_label
+            if str2bool(ICP.get_param("product_contract.show_date")) and (
+                date_text := self._get_product_contract_date_text()
+            ):
+                description += "\n\t" + date_text
+        return super()._get_sale_order_line_multiline_description_sale() + description

--- a/product_contract/static/description/index.html
+++ b/product_contract/static/description/index.html
@@ -459,8 +459,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/sbejaoui"><img alt="sbejaoui" src="https://github.com/sbejaoui.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/sbejaoui"><img alt="sbejaoui" src="https://github.com/sbejaoui.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/CarlosRoca13"><img alt="CarlosRoca13" src="https://github.com/CarlosRoca13.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/contract/tree/17.0/product_contract">OCA/contract</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
Before:
1. Create a contract product
2. Add variants and select Product Configurator
3. Add the product on a Sale Order
4. Try to edit the variants with the configurator

You will not be able to open the product configurator

After:
The product configurator will be opened first and then the contract configurator.

cc @Tecnativa TT55066

ping @pedrobaeza @carlos-lopez-tecnativa @sergio-teruel 