### PR TITLE
[17.0][IMP] product_contract: Set new button to configure contract

### DIFF
--- a/product_contract/README.rst
+++ b/product_contract/README.rst
@@ -42,16 +42,6 @@ invoice directly.
 .. contents::
    :local:
 
-Configuration
-=============
-
-You can include the contract details on the sales order description by
-using the following system parameters:
-
-1. **Recurrency** -> product_contract.show_recurrency
-2. **Invoicing Type** -> product_contract.show_invoicing_type
-3. **Date** -> product_contract.show_date
-
 Usage
 =====
 
@@ -67,6 +57,10 @@ Known issues / Roadmap
 
 -  There's no support right now for computing the start date for the
    following recurrent types: daily, weekly and monthlylastday.
+-  It would be interesting to be able to configure what to display in
+   the line description using a configuration option, but using
+   \_compute_name is not valid because, if nothing is configured, it
+   would reset what we have in the description.
 
 Bug Tracker
 ===========

--- a/product_contract/README.rst
+++ b/product_contract/README.rst
@@ -65,8 +65,8 @@ To use this module, you need to:
 Known issues / Roadmap
 ======================
 
-- There's no support right now for computing the start date for the
-  following recurrent types: daily, weekly and monthlylastday.
+-  There's no support right now for computing the start date for the
+   following recurrent types: daily, weekly and monthlylastday.
 
 Bug Tracker
 ===========
@@ -90,16 +90,16 @@ Authors
 Contributors
 ------------
 
-- Ted Salmon <tsalmon@laslabs.com>
-- Souheil Bejaoui <souheil.bejaoui@acsone.eu>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Ted Salmon <tsalmon@laslabs.com>
+-  Souheil Bejaoui <souheil.bejaoui@acsone.eu>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Ernesto Tejeda
-  - Pedro M. Baeza
-  - Carlos Roca
-  - Sergio Teruel
+   -  Ernesto Tejeda
+   -  Pedro M. Baeza
+   -  Carlos Roca
+   -  Sergio Teruel
 
-- David Jaen <david.jaen.revert@gmail.com>
+-  David Jaen <david.jaen.revert@gmail.com>
 
 Maintainers
 -----------

--- a/product_contract/__manifest__.py
+++ b/product_contract/__manifest__.py
@@ -22,5 +22,14 @@
     "application": False,
     "external_dependencies": {"python": ["dateutil"]},
     "maintainers": ["sbejaoui", "CarlosRoca13"],
-    "assets": {"web.assets_backend": ["product_contract/static/src/js/*"]},
+    "assets": {
+        "web.assets_backend": [
+            "product_contract/static/src/js/*",
+            (
+                "after",
+                "sale/static/src/xml/sale_product_field.xml",
+                "product_contract/static/src/xml/*",
+            ),
+        ]
+    },
 }

--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -6,7 +6,6 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools import str2bool
 
 MONTH_NB_MAPPING = {
     "monthly": 1,
@@ -415,31 +414,3 @@ class SaleOrderLine(models.Model):
                 if date_text := line._get_product_contract_date_text():
                     description += date_text + "||"
                 line.product_contract_description = description
-
-    @api.depends(
-        "date_start", "date_end", "recurring_rule_type", "recurring_invoicing_type"
-    )
-    def _compute_name(self):
-        # This method is used for adding new dependencies
-        return super()._compute_name()
-
-    def _get_sale_order_line_multiline_description_sale(self):
-        self.ensure_one()
-        ICP = self.env["ir.config_parameter"].sudo()
-        description = ""
-        if self.is_contract:
-            if str2bool(ICP.get_param("product_contract.show_recurrency")) and (
-                recurring_rule_label
-                := self._get_product_contract_recurring_rule_label()
-            ):
-                description += "\n\t" + recurring_rule_label
-            if str2bool(ICP.get_param("product_contract.show_invoicing_type")) and (
-                invoicing_type_label
-                := self._get_product_contract_invoicing_type_label()
-            ):
-                description += "\n\t" + invoicing_type_label
-            if str2bool(ICP.get_param("product_contract.show_date")) and (
-                date_text := self._get_product_contract_date_text()
-            ):
-                description += "\n\t" + date_text
-        return super()._get_sale_order_line_multiline_description_sale() + description

--- a/product_contract/readme/CONFIGURE.md
+++ b/product_contract/readme/CONFIGURE.md
@@ -1,5 +1,0 @@
-You can include the contract details on the sales order description by using the following system parameters:
-
-1.  **Recurrency** -\> product_contract.show_recurrency
-2.  **Invoicing Type** -\> product_contract.show_invoicing_type
-3.  **Date** -\> product_contract.show_date

--- a/product_contract/readme/ROADMAP.md
+++ b/product_contract/readme/ROADMAP.md
@@ -1,2 +1,6 @@
 - There's no support right now for computing the start date for the
   following recurrent types: daily, weekly and monthlylastday.
+- It would be interesting to be able to configure what to display in
+  the line description using a configuration option, but using
+  _compute_name is not valid because, if nothing is configured,
+  it would reset what we have in the description.

--- a/product_contract/static/description/index.html
+++ b/product_contract/static/description/index.html
@@ -379,30 +379,19 @@ invoice directly.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
-<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
-<div class="section" id="configuration">
-<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
-<p>You can include the contract details on the sales order description by
-using the following system parameters:</p>
-<ol class="arabic simple">
-<li><strong>Recurrency</strong> -&gt; product_contract.show_recurrency</li>
-<li><strong>Invoicing Type</strong> -&gt; product_contract.show_invoicing_type</li>
-<li><strong>Date</strong> -&gt; product_contract.show_date</li>
-</ol>
-</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go to Sales -&gt; Products and select or create a product.</li>
@@ -412,14 +401,18 @@ product</li>
 </ol>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>There’s no support right now for computing the start date for the
 following recurrent types: daily, weekly and monthlylastday.</li>
+<li>It would be interesting to be able to configure what to display in
+the line description using a configuration option, but using
+_compute_name is not valid because, if nothing is configured, it
+would reset what we have in the description.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/contract/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -427,16 +420,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>LasLabs</li>
 <li>ACSONE SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Ted Salmon &lt;<a class="reference external" href="mailto:tsalmon&#64;laslabs.com">tsalmon&#64;laslabs.com</a>&gt;</li>
 <li>Souheil Bejaoui &lt;<a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a>&gt;</li>
@@ -451,7 +444,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/product_contract/static/src/xml/sale_product_field.xml
+++ b/product_contract/static/src/xml/sale_product_field.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-inherit="sale.SaleProductField" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='hasExternalButton']" position="before">
+            <t t-if="isConfigurableContract">
+                <button
+                    type="button"
+                    class="btn btn-secondary fa fa-pencil-square-o"
+                    tabindex="-1"
+                    draggable="false"
+                    aria-label="Configure contract"
+                    data-tooltip="Configure contract"
+                    t-on-click="onEditContractConfiguration"
+                />
+            </t>
+        </xpath>
+    </t>
+
+</templates>


### PR DESCRIPTION
With this change, we allow the user to modify the contract without going through the product configuration stage, which overwrites the product and causes the loss of some information, even when no changes are made.

Removed too the description feature because is changing the description when no option is activated. Since we have the information about what has been configured under the product, this is not a completely necessary feature. Added BTW on the ROADMAP.

cc @Tecnativa TT55066

ping @pedrobaeza @carlos-lopez-tecnativa 