### PR TITLE
[17.0][FIX] contract: Malformed expression in the column_invisible attribute.

### DIFF
--- a/contract/views/contract_template.xml
+++ b/contract/views/contract_template.xml
@@ -46,11 +46,10 @@
                             <field name="product_id" />
                             <field name="name" widget="section_and_note_text" />
                             <field name="quantity" />
-                            <field name="is_auto_renew" column_invisible="True" />
                             <field name="uom_id" />
                             <field
                                 name="automatic_price"
-                                column_invisible="parent.contract_type == 'purchase' and not is_auto_renew"
+                                column_invisible="parent.contract_type == 'purchase'"
                             />
                             <field name="price_unit" readonly="automatic_price" />
                             <field name="specific_price" column_invisible="True" />


### PR DESCRIPTION
Good morning, we have identified an error when creating a contract template for suppliers. This error occurs because the following Python expression is being evaluated in a `column_invisible ` attribute.

`parent.contract_type == 'purchase' and not is_auto_renew`

According to the Odoo documentation (https://github.com/odoo/documentation/blob/8f1d5d428c2bbb6f420577d02c28d5eef7678096/content/developer/reference/user_interface/view_architectures/generic_attribute_column_invisible.rst), I understand that in these cases, it is not possible to use the values from the tree in the expression. Instead, one must use the values from the parent or a value from the context.

I’m attaching a screenshot of the error.
![Captura desde 2025-02-13 11-11-11](https://github.com/user-attachments/assets/142eeaf7-32a9-452b-9fa5-e3d2f0da0955)



