### PR TITLE
[16.0][FIX]contract: remove class `oe_edit_only`

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -92,7 +92,7 @@
                         attrs="{'invisible': [('active', '=', True)]}"
                     />
                     <div class="oe_title">
-                        <label for="name" string="Contract Name" class="oe_edit_only" />
+                        <label for="name" string="Contract Name" />
                         <h3>
                             <field
                                 name="name"


### PR DESCRIPTION
In odoo 16.0 the class `oe_edit_only` serves no purpose. With this PR we remove it, avoiding possible confusion