### PR TITLE
[17.0][FIX] contract: Don't lose modification email layout

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -197,6 +197,7 @@ class ContractContract(models.Model):
                     record.message_post_with_source(
                         template_id,
                         subtype_id=subtype_id,
+                        email_layout_xmlid="contract.template_contract_modification",
                     )
                 modification_ids_not_sent.write({"sent": True})
 


### PR DESCRIPTION
It was lost in 17.0 migration.

https://github.com/OCA/contract/commit/d1cb9312ae2354823e365718f7dae1beef3b1061#diff-bd92412e26bfd77a1e9fb18d4a493b62b8a9c1ec64cbf57a807f244f12c198fcL195

Before:

![image](https://github.com/user-attachments/assets/f6447610-40d9-4392-b6ee-b5dd0b735df5)

After:

![image](https://github.com/user-attachments/assets/f9df6ea5-01ff-4c12-a0f9-245d84c91478)

@Tecnativa