### PR TITLE
[17.0][FIX]contract_variable_qty: Fixes bad attribute inherit, setting the …

### DIFF
--- a/contract_variable_quantity/views/contract_template.xml
+++ b/contract_variable_quantity/views/contract_template.xml
@@ -25,8 +25,8 @@
                 expr="//field[@name='contract_line_ids']//field[@name='quantity']"
                 position="attributes"
             >
-                <attribute name="required">"qty_type == 'fixed'"</attribute>
-                <attribute name="invisible">"qty_type != 'fixed'"</attribute>
+                <attribute name="required">qty_type == 'fixed'</attribute>
+                <attribute name="invisible">qty_type != 'fixed'</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
…value to a boolean expresion instead of string.

Since the invisibility condition of the quantity field was set as a string, it was always evaluated as True, which caused the tests of other modules to fail.

See #1234 to underestand the tests problem.