### PR TITLE
[18.0][IMP] contract: remove blocking view in migration script

### DIFF
--- a/contract/migrations/18.0.2.0.0/pre-migrate.py
+++ b/contract/migrations/18.0.2.0.0/pre-migrate.py
@@ -16,6 +16,8 @@ def migrate(env, version):
     );
     """
     )
+    views_to_delete = ["contract.contract_template_line_form_view"]
+    openupgrade.delete_records_safely_by_xml_id(env, views_to_delete, True)
     all_moved_fields = {
         "contract_line_successor": {
             "contract.line": [


### PR DESCRIPTION
@rousseldenis could we add this to the upgrade script. This wasn't added in the migration of the module.

I still get this error when upgrading my database with odoo.sh.

`2025-06-03 08:06:56,339 99 ERROR odoo.modules.registry: Failed to load registry 2025-06-03 08:06:56,343 99 CRITICAL odoo.service.server: Failed to initialize database ` `. Traceback (most recent call last): File "/home/odoo/src/odoo/odoo/service/server.py", line 1328, in preload_registries registry = Registry.new(dbname, update_module=update_module) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/lib/python3/dist-packages/decorator.py", line 232, in fun return caller(func, *(extras + args), **kw) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/odoo/src/odoo/odoo/tools/func.py", line 97, in locked return func(inst, *args, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/odoo/src/odoo/odoo/modules/registry.py", line 127, in new odoo.modules.load_modules(registry, force_demo, status, update_module) File "/home/odoo/src/odoo/odoo/modules/loading.py", line 480, in load_modules processed_modules += load_marked_modules(env, graph, ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/odoo/src/odoo/odoo/modules/loading.py", line 365, in load_marked_modules loaded, processed = load_module_graph( ^^^^^^^^^^^^^^^^^^ File "/home/odoo/src/odoo/odoo/modules/loading.py", line 228, in load_module_graph load_data(env, idref, mode, kind='data', package=package) File "/home/odoo/src/odoo/odoo/modules/loading.py", line 72, in load_data tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind) File "/home/odoo/src/odoo/odoo/tools/convert.py", line 608, in convert_file convert_xml_import(env, module, fp, idref, mode, noupdate) File "/home/odoo/src/odoo/odoo/tools/convert.py", line 679, in convert_xml_import obj.parse(doc.getroot()) File "/home/odoo/src/odoo/odoo/tools/convert.py", line 594, in parse self._tag_root(de) File "/home/odoo/src/odoo/odoo/tools/convert.py", line 548, in _tag_root raise ParseError(msg) from None # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ odoo.tools.convert.ParseError: while parsing /home/odoo/src/user/modules/oca/contract/contract/views/contract_template_line.xml:4 Error while validating view near: </group> <group invisible="display_type"> <field name="is_auto_renew"/> <field name="is_canceled" invisible="1"/> </group> Field "is_auto_renew" does not exist in model "contract.template.line" View error context: {'file': '/home/odoo/src/user/modules/oca/contract/contract/views/contract_template_line.xml', 'line': 33, 'name': 'contract.template.line form view (in contract)', 'view': ir.ui.view(3100,), 'view.model': 'contract.template.line', 'view.parent': ir.ui.view(3086,), 'xmlid': 'contract_template_line_form_view'}`