### PR TITLE
[IMP] product_contract: assign contract_line_id in sale line contract…

### DIFF
--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -224,6 +224,8 @@ class SaleOrderLine(models.Model):
                 new_contract_line = contract_line_model.create(
                     rec._prepare_contract_line_values(contract)
                 )
+            if new_contract_line:
+                rec.contract_line_id = new_contract_line.id
             contract_line |= new_contract_line
         return contract_line
 


### PR DESCRIPTION
… line creation

contract_line_id from sale.order.line model is never assisgned so when creating contract lines from sale order lines assign  the newly created contract line.