### PR TITLE
[18.0][FIX] contract line successor: use parent.is_auto_renew to avoid EvalError in column_invisible

### DIFF
--- a/contract/static/src/js/contract_portal_tour.esm.js
+++ b/contract/static/src/js/contract_portal_tour.esm.js
@@ -1,5 +1,5 @@
-import {registry} from "@web/core/registry";
 import {redirect} from "@web/core/utils/urls";
+import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("contract_portal_tour", {
     test: true,

--- a/contract_line_successor/models/__init__.py
+++ b/contract_line_successor/models/__init__.py
@@ -1,5 +1,6 @@
 from . import contract_contract
 from . import contract_line
+from . import contract_template
 from . import contract_template_line
 from . import res_company
 from . import res_config_settings

--- a/contract_line_successor/models/contract_template.py
+++ b/contract_line_successor/models/contract_template.py
@@ -1,0 +1,17 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ContractTemplate(models.Model):
+    _inherit = "contract.template"
+
+    is_auto_renew = fields.Boolean(compute="_compute_is_auto_renew")
+
+    @api.depends("contract_line_ids.is_auto_renew")
+    def _compute_is_auto_renew(self):
+        for record in self:
+            record.is_auto_renew = all(
+                line.is_auto_renew for line in record.contract_line_ids
+            )

--- a/contract_line_successor/tests/test_contract.py
+++ b/contract_line_successor/tests/test_contract.py
@@ -845,3 +845,17 @@ class TestContractSuccessor(TestContract):
         self.acct_line.stop(to_date("2019-05-31"))
         self.assertEqual(self.acct_line.date_end, to_date("2019-05-31"))
         self.assertEqual(self.acct_line.recurring_next_date, to_date("2019-06-01"))
+
+    def test_contract_template_is_auto_renew(self):
+        contract_template = self.env["contract.template"].create(
+            {
+                "name": "Template Auto Renew Test",
+                "contract_line_ids": [
+                    (0, 0, {"name": "Line 1", "is_auto_renew": True}),
+                    (0, 0, {"name": "Line 2", "is_auto_renew": True}),
+                ],
+            }
+        )
+        self.assertTrue(contract_template.is_auto_renew)
+        contract_template.contract_line_ids[1].write({"is_auto_renew": False})
+        self.assertFalse(contract_template.is_auto_renew)

--- a/contract_line_successor/views/contract_template.xml
+++ b/contract_line_successor/views/contract_template.xml
@@ -12,7 +12,7 @@
             >
                 <attribute
                     name="column_invisible"
-                >parent.contract_type == 'purchase'  and not is_auto_renew</attribute>
+                >parent.contract_type == 'purchase' and not parent.is_auto_renew</attribute>
             </xpath>
         </field>
     </record>

--- a/product_contract/static/src/js/contract_configurator_controller.esm.js
+++ b/product_contract/static/src/js/contract_configurator_controller.esm.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import {formView} from "@web/views/form/form_view";
 import {registry} from "@web/core/registry";
 import {useService} from "@web/core/utils/hooks";

--- a/product_contract/static/src/js/sale_product_field.esm.js
+++ b/product_contract/static/src/js/sale_product_field.esm.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import {SaleOrderLineProductField} from "@sale/js/sale_product_field";
 import {patch} from "@web/core/utils/patch";
 


### PR DESCRIPTION
@HaraldPanten 
[T-8579]
When creating a new contract template and selecting "supplier" as the contract_type, show an EvalError _"Can not evaluate python expression: (bool(parent.contract_type == 'purchase'  and not is_auto_renew))"_

![image](https://github.com/user-attachments/assets/4f8212c6-2824-435a-a640-734f2fa96aad)

The fix replaces `is_auto_renew` with `parent.is_auto_renew` to ensure the expression is evaluated correctly in the context of the parent form. To make this work, the is_auto_renew field was added as a computed Boolean field on the contract.template model.
