### PR TITLE
[FIX] contract: fix price_unit computation with different UoM

### DIFF
--- a/contract/models/abstract_contract_line.py
+++ b/contract/models/abstract_contract_line.py
@@ -9,6 +9,7 @@
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools.translate import _
+from odoo.tools.float_utils import float_round
 
 
 class ContractAbstractContractLine(models.AbstractModel):
@@ -189,6 +190,7 @@ class ContractAbstractContractLine(models.AbstractModel):
         "quantity",
         "contract_id.pricelist_id",
         "contract_id.partner_id",
+        "uom_id",
     )
     def _compute_price_unit(self):
         """Get the specific price if no auto-price, and the price obtained
@@ -206,18 +208,20 @@ class ContractAbstractContractLine(models.AbstractModel):
                         line.contract_id.company_id
                     ).property_product_pricelist
                 )
+                quantity = line.env.context.get("contract_line_qty", line.quantity)
                 product = line.product_id.with_context(
-                    quantity=line.env.context.get(
-                        "contract_line_qty",
-                        line.quantity,
-                    ),
+                    quantity=quantity,
                     pricelist=pricelist.id,
                     partner=line.contract_id.partner_id.id,
                     date=line.env.context.get(
                         "old_date", fields.Date.context_today(line)
                     ),
                 )
-                line.price_unit = pricelist._get_product_price(product, quantity=1)
+                base_price = pricelist._get_product_price(product, quantity=quantity)
+                price = product.uom_id._compute_price(base_price, line.uom_id)
+                line.price_unit = float_round(
+                    price, precision_digits=line.currency_id.decimal_places or 2
+                )
             else:
                 line.price_unit = line.specific_price
 


### PR DESCRIPTION
Before this fix, the computed 'price_unit' on contract lines did not reflect the correct value when selecting a unit of measure different from the product's reference UoM.

This fix ensures the price is converted using `_compute_price()` to reflect the selected UoM, similar to how Sales and Invoices work.

Steps to reproduce:
- Create a product with UoM "License" (e.g. yearly, 12€)
- Add a secondary UoM "Month" with a 1/12 factor
- Add this product to a contract line using the "Month" UoM
- Before: price_unit = 12 (wrong)
- After: price_unit = 1 (correct)

This brings contract pricing logic in line with standard Odoo behavior.