### PR TITLE
[16.0][FIX] contract: when searching "in-progress" state don't check auto_renew if no date_end

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -216,6 +216,8 @@ class ContractLine(models.Model):
                 ("date_end", ">=", today),
                 ("date_end", "=", False),
                 "|",
+                ("date_end", "=", False),
+                "|",
                 ("is_auto_renew", "=", True),
                 "&",
                 ("is_auto_renew", "=", False),


### PR DESCRIPTION
When is_auto_renew is False, date_end is not required, if no date_end termination_notice_date is also False therefore lines with auto_renew False and date_end False, will not be found.