### PR TITLE
[18.0][IMP] contract: make label for notes visible on contract view form

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -256,7 +256,7 @@
                                     />
                                 </list>
                             </field>
-                            <field name="note" />
+                            <field name="note" placeholder="Put some note here..." />
                         </page>
                         <page name="invoicing" string="Invoicing">
                             <group name="invoicing">


### PR DESCRIPTION
The note label is not visible on contract view form so i changed the it's declared to make it visible.