### PR TITLE
[IMP] product_contract - non contract sale order lines should not have contract dates

### DIFF
--- a/product_contract/models/sale_order_line_contract_mixin.py
+++ b/product_contract/models/sale_order_line_contract_mixin.py
@@ -205,7 +205,7 @@ class SaleOrderLineContractMixin(models.AbstractModel):
     @api.depends("contract_start_date_method")
     def _compute_contract_line_date_start(self):
         for rec in self:
-            if rec.contract_start_date_method == "manual":
+            if rec.is_contract and rec.contract_start_date_method == "manual":
                 rec.date_start = rec.date_start or fields.Date.today()
 
     @api.depends("date_start", "recurrence_interval", "recurrence_number")


### PR DESCRIPTION
While migrating stuff from v12 to v18, we noticed that a behaviour changed in between these versions.

On a new database, install product_contract and sale.
Then, create a new product that is not a contract.
And finally, you create a sale order line with the new product.

In v12, dates won't be filled on the sale order line. In v18, they will. We think that it is not normal and that this behaviour should be the same as v12: non contract products in sale order lines should not fill dates fields.