### PR TITLE
[18.0][FIX] contract: Remove test flag from contract because of "unknown key 'test'" error

### DIFF
--- a/contract/static/src/js/contract_portal_tour.esm.js
+++ b/contract/static/src/js/contract_portal_tour.esm.js
@@ -2,7 +2,6 @@ import {redirect} from "@web/core/utils/urls";
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("contract_portal_tour", {
-    test: true,
     url: "/my",
     wait_for: Promise.resolve(odoo.__TipTemplateDef),
     steps: () => [


### PR DESCRIPTION
When activating the tours, this js error occurs and tours cannot be executed: 

<img width="915" height="317" alt="image" src="https://github.com/user-attachments/assets/45e43386-e445-457c-adca-ac9056f42d17" />
