### PR TITLE
[18.0][FIX] contract: migration scripts

### DIFF
--- a/contract/migrations/18.0.2.0.0/end-migrate.py
+++ b/contract/migrations/18.0.2.0.0/end-migrate.py
@@ -1,0 +1,27 @@
+# Copyright 2025 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env.cr.execute(
+        """
+        SELECT name
+        FROM ir_module_module
+        WHERE state='uninstalled' AND name IN (
+            'contract_line_successor', 'contract_termination');"""
+    )
+    uninstalled_modules = [x[0] for x in env.cr.fetchall()]
+    no_update_xml_ids = {
+        "contract_line_successor": [
+            "contract_line_cron_for_renew",
+        ],
+        "contract_termination": [],
+    }
+    xmlids_spec = []
+    for new_module, moved_xml_ids in no_update_xml_ids.items():
+        if new_module in uninstalled_modules:
+            xmlids_spec.extend([f"{new_module}.{xml_id}" for xml_id in moved_xml_ids])
+    if xmlids_spec:
+        openupgrade.delete_records_safely_by_xml_id(env, xmlids_spec)

--- a/contract/migrations/18.0.2.0.0/pre-migrate.py
+++ b/contract/migrations/18.0.2.0.0/pre-migrate.py
@@ -1,5 +1,5 @@
 # Copyright 2025 ACSONE SA/NV
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from openupgradelib import openupgrade
 
 
@@ -72,11 +72,13 @@ def migrate(env, version):
                 env.cr, moved_model, "contract", new_module
             )
     all_moved_xml_ids = {
-        "contract_line_successor": ["contract_line_wizard"],
+        "contract_line_successor": [
+            "contract_line_wizard",
+            "contract_line_cron_for_renew",
+        ],
         "contract_termination": [
             "contract_terminate_reason_access_manager",
             "contract_terminate_reason_access_user",
-            "can_terminate_contract",
             "can_terminate_contract",
             "contract_contract_terminate_wizard",
         ],


### PR DESCRIPTION
This PR fixes 2 things:

- "Renew Contract lines" cron was moved in a split module too.
- If you don't install the split modules (they should be optional), you should at least remove all `noupdate=1` data that is moved.