### PR TITLE
[17.0][FIX]subscription_oca: Search by user company cron

### DIFF
--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -134,7 +134,9 @@ class SaleSubscription(models.Model):
 
     def cron_subscription_management(self):
         today = date.today()
-        for subscription in self.search([]):
+        for subscription in self.search(
+            [("company_id", "=", self.env.user.company_id.id)]
+        ):
             if subscription.in_progress:
                 if (
                     subscription.recurring_next_date == today


### PR DESCRIPTION
Adding a search filter specific to the user of the company to prevent the validation of invoices without being on the correct company