### PR TITLE
[18.0][IMP] Contract line: compute display name

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -42,6 +42,11 @@ class ContractLine(models.Model):
     )
     product_id = fields.Many2one(index=True)
 
+    @api.depends("name", "date_start")
+    def _compute_display_name(self):
+        for rec in self:
+            rec.display_name = f"{rec.date_start} - {rec.name}"
+
     @api.model
     def _compute_first_recurring_next_date(
         self,


### PR DESCRIPTION
Forward port of feature lost between branches `14.0` and `15.0`.

Compute the `display_name` as it was until `14.0` instead of always `False` as it is now.

Original commit: https://github.com/OCA/contract/pull/933/commits/72c77432932d28bf19d47d2dfe73d01e4f33c3cf