### PR TITLE
[FIX] contract_forecast: multi-company rule for all authorized companies

### DIFF
--- a/contract_forecast/security/contract_line_forecast_period.xml
+++ b/contract_forecast/security/contract_line_forecast_period.xml
@@ -16,7 +16,7 @@
         <field name="name">Forecast multi company rule</field>
         <field name="model_id" ref="model_contract_line_forecast_period" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','child_of', company_ids)]
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Modification of the multi-company rule taking all authorized companies into account against the default company. This allows checking failed forecast jobs of child companies for example.