### PR TITLE
[15.0][IMP] subscription_oca: Improve subscription lines view with section/note support and improve search view with filters and group by.

### DIFF
--- a/subscription_oca/models/sale_subscription_line.py
+++ b/subscription_oca/models/sale_subscription_line.py
@@ -40,9 +40,33 @@ class SaleSubscriptionLine(models.Model):
         readonly=False,
     )
 
-    @api.depends("product_id", "price_unit", "product_uom_qty", "discount", "tax_ids")
+    sequence = fields.Integer(default=10, help="Display order on the subscription.")
+    display_type = fields.Selection(
+        selection=[("line_section", "Section"), ("line_note", "Note")],
+        default=False,
+        help="Technical field for UX purpose.",
+    )
+
+    @api.depends(
+        "product_id",
+        "price_unit",
+        "product_uom_qty",
+        "discount",
+        "tax_ids",
+        "display_type",
+    )
     def _compute_subtotal(self):
         for record in self:
+            if record.display_type:
+                record.update(
+                    {
+                        "amount_tax_line_amount": 0.0,
+                        "price_total": 0.0,
+                        "price_subtotal": 0.0,
+                    }
+                )
+                continue
+
             price = record.price_unit * (1 - (record.discount or 0.0) / 100.0)
             taxes = record.tax_ids.compute_all(
                 price,
@@ -80,9 +104,11 @@ class SaleSubscriptionLine(models.Model):
         index=True,
     )
 
-    @api.depends("product_id")
+    @api.depends("product_id", "display_type")
     def _compute_name(self):
         for record in self:
+            if record.display_type:
+                continue
             if not record.product_id:
                 record.name = False
             lang = get_lang(self.env, record.sale_subscription_id.partner_id.lang).code
@@ -91,9 +117,14 @@ class SaleSubscriptionLine(models.Model):
                 lang=lang
             ).get_product_multiline_description_sale()
 
-    @api.depends("product_id", "sale_subscription_id.fiscal_position_id")
+    @api.depends(
+        "product_id", "display_type", "sale_subscription_id.fiscal_position_id"
+    )
     def _compute_tax_ids(self):
         for line in self:
+            if line.display_type:
+                line.tax_ids = [(5, 0, 0)]
+                continue
             fpos = (
                 line.sale_subscription_id.fiscal_position_id
                 or line.sale_subscription_id.fiscal_position_id.get_fiscal_position(
@@ -110,9 +141,13 @@ class SaleSubscriptionLine(models.Model):
         "product_id",
         "sale_subscription_id.partner_id",
         "sale_subscription_id.pricelist_id",
+        "display_type",
     )
     def _compute_price_unit(self):
         for record in self:
+            if record.display_type:
+                record.price_unit = 0.0
+                continue
             if not record.product_id:
                 continue
             if (
@@ -143,9 +178,13 @@ class SaleSubscriptionLine(models.Model):
         "tax_ids",
         "sale_subscription_id.partner_id",
         "sale_subscription_id.pricelist_id",
+        "display_type",
     )
     def _compute_discount(self):
         for record in self:
+            if record.display_type:
+                record.discount = 0.0
+                continue
             if not (
                 record.product_id
                 and record.product_id.uom_id
@@ -292,6 +331,12 @@ class SaleSubscriptionLine(models.Model):
 
     def _prepare_sale_order_line(self):
         self.ensure_one()
+        if self.display_type:
+            return {
+                "display_type": self.display_type,
+                "name": self.name or "",
+                "sequence": self.sequence,
+            }
         return {
             "product_id": self.product_id.id,
             "name": self.name,
@@ -301,10 +346,17 @@ class SaleSubscriptionLine(models.Model):
             "price_subtotal": self.price_subtotal,
             "tax_id": self.tax_ids,
             "product_uom": self.product_id.uom_id.id,
+            "sequence": self.sequence,
         }
 
     def _prepare_account_move_line(self):
         self.ensure_one()
+        if self.display_type:
+            return {
+                "display_type": self.display_type,
+                "name": self.name or "",
+                "sequence": self.sequence,
+            }
         account = (
             self.product_id.property_account_income_id
             or self.product_id.categ_id.property_account_income_categ_id
@@ -319,4 +371,5 @@ class SaleSubscriptionLine(models.Model):
             "tax_ids": [(6, 0, self.tax_ids.ids)],
             "product_uom_id": self.product_id.uom_id.id,
             "account_id": account.id,
+            "sequence": self.sequence,
         }

--- a/subscription_oca/views/sale_subscription_views.xml
+++ b/subscription_oca/views/sale_subscription_views.xml
@@ -118,19 +118,59 @@
                             string="Subscription lines"
                             name="subscription_lines_page"
                         >
-                            <field name="sale_subscription_line_ids">
+                            <field
+                                name="sale_subscription_line_ids"
+                                widget="section_and_note_one2many"
+                            >
                                 <tree editable="bottom">
-                                    <field name="product_id" required="True" />
+                                    <control>
+                                        <create string="Add a line" />
+                                        <create
+                                            string="Add a section"
+                                            context="{'default_display_type': 'line_section'}"
+                                        />
+                                        <create
+                                            string="Add a note"
+                                            context="{'default_display_type': 'line_note'}"
+                                        />
+                                    </control>
+
+                                    <field name="display_type" invisible="1" />
+                                    <field name="sequence" widget="handle" />
+
+                                    <!-- Optional product: only required when NOT section/note -->
+                                    <field
+                                        name="product_id"
+                                        attrs="{'required': [('display_type','=',False)], 'readonly': [('display_type','!=',False)]}"
+                                    />
+
                                     <field
                                         name="name"
-                                        required="True"
                                         widget="section_and_note_text"
+                                        attrs="{'required': [('display_type','=',False)]}"
                                     />
+
                                     <field name="currency_id" invisible="1" />
-                                    <field name="product_uom_qty" required="True" />
-                                    <field name="price_unit" required="True" />
-                                    <field name="discount" required="True" />
-                                    <field name="tax_ids" widget="many2many_tags" />
+
+                                    <field
+                                        name="product_uom_qty"
+                                        attrs="{'invisible': [('display_type','!=', False)]}"
+                                    />
+                                    <field
+                                        name="price_unit"
+                                        attrs="{'invisible': [('display_type','!=', False)]}"
+                                    />
+                                    <field
+                                        name="discount"
+                                        attrs="{'invisible': [('display_type','!=', False)]}"
+                                    />
+
+                                    <field
+                                        name="tax_ids"
+                                        widget="many2many_tags"
+                                        attrs="{'invisible': [('display_type','!=', False)]}"
+                                    />
+
                                     <field
                                         name="price_subtotal"
                                         options="{'currency_field': 'currency_id'}"
@@ -202,6 +242,43 @@
                     <field name="activity_ids" widget="mail_activity" />
                     <field name="message_ids" widget="mail_thread" />
                 </div>
+            </form>
+        </field>
+    </record>
+
+    <record id="sale_subscription_line_form" model="ir.ui.view">
+        <field name="name">sale.subscription.line.form</field>
+        <field name="model">sale.subscription.line</field>
+        <field name="arch" type="xml">
+            <form>
+            <sheet>
+                <field name="display_type" invisible="1" />
+                <group attrs="{'invisible': [('display_type','!=', False)]}">
+                <field name="product_id" required="1" />
+                <field name="product_uom_qty" />
+                <field name="price_unit" />
+                <field name="discount" />
+                <field name="tax_ids" widget="many2many_tags" />
+                </group>
+
+                <label
+                        for="name"
+                        string="Description"
+                        attrs="{'invisible': [('display_type','!=', False)]}"
+                    />
+                <label
+                        for="name"
+                        string="Section"
+                        attrs="{'invisible': [('display_type','!=','line_section')]}"
+                    />
+                <label
+                        for="name"
+                        string="Note"
+                        attrs="{'invisible': [('display_type','!=','line_note')]}"
+                    />
+                <field name="name" nolabel="1" />
+
+            </sheet>
             </form>
         </field>
     </record>
@@ -365,6 +442,71 @@
         </field>
     </record>
 
+    <!--SEARCH view-->
+    <record id="sale_subscription_search_view" model="ir.ui.view">
+        <field name="name">sale.subscription.search</field>
+        <field name="model">sale.subscription</field>
+        <field name="arch" type="xml">
+            <search>
+                <!-- searches by text -->
+                <field name="to_renew" />
+                <filter
+                    string="Pending subscriptions"
+                    name="pendingsubs"
+                    domain="[('to_renew','=', True)]"
+                />
+                <field name="name" filter_domain="[('name','ilike', self)]" />
+                <field
+                    name="partner_id"
+                    filter_domain="[('partner_id','ilike',self)]"
+                />
+
+                <separator />
+
+                <!-- STATES -->
+                <!-- In progress -->
+                <filter
+                    name="in_progress"
+                    string="In progress"
+                    domain="[('in_progress','=', True)]"
+                />
+
+                <!-- Expired (end date < today and not archived) -->
+                <filter
+                    name="expired"
+                    string="Expired"
+                    domain="[('active','=', True), ('date','!=', False), ('date','&lt;', context_today().strftime('%Y-%m-%d'))]"
+                />
+
+                <!-- Archived -->
+                <filter
+                    name="inactive"
+                    string="Archived"
+                    domain="[('active','=', False)]"
+                />
+
+                <group expand="0" string="Group by...">
+                    <filter
+                        name="group_by_partner"
+                        string="Customer"
+                        context="{'group_by': 'partner_id'}"
+                    />
+                    <filter
+                        name="group_by_stage"
+                        string="Stage"
+                        context="{'group_by': 'stage_id'}"
+                    />
+                    <filter
+                        name="group_by_next"
+                        string="Next invoice"
+                        domain="[('recurring_next_date','!=', False)]"
+                        context="{'group_by': 'recurring_next_date'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
     <record id="view_sale_order_pending_filter" model="ir.ui.view">
         <field name="name">sale.order.pending.filter</field>
         <field name="model">sale.subscription</field>
@@ -415,6 +557,13 @@
         <field name="name">Subscriptions</field>
         <field name="res_model">sale.subscription</field>
         <field name="view_mode">tree,kanban,form</field>
+
+        <field name="search_view_id" ref="sale_subscription_search_view" />
+
+        <!-- Default filter: activate 'in_progress' -->
+        <field name="context">
+            {'search_default_in_progress': 1}
+        </field>
     </record>
 
     <record id="subscription_product_template_action" model="ir.actions.act_window">


### PR DESCRIPTION
This PR improves the subscription form view:
- Adds `section_and_note_one2many` widget to subscription lines.
- Makes section/note lines display across the full row.
- Added text search by name and customer.
- Added filters for In progress, Expired, and Archived subscriptions.
- Added group by partner, stage, and next invoice date.
- Set 'In progress' as the default filter in the action.