### PR TITLE
[16.0][IMP] subscription_oca: add the tag is_move_sent True when the invoice from subscription is sent by email

### DIFF
--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -339,6 +339,7 @@ class SaleSubscription(models.Model):
                         composition_mode="comment",
                         email_layout_xmlid="mail.mail_notification_paynow",
                     )
+                    invoice.write({"is_move_sent": True})
                 invoice_number = invoice.name
                 message_body = (
                     "<b>%s</b> <a href=# data-oe-model=account.move data-oe-id=%d>%s</a>"

--- a/subscription_oca/tests/test_subscription_oca.py
+++ b/subscription_oca/tests/test_subscription_oca.py
@@ -506,6 +506,7 @@ class TestSubscriptionOCA(TransactionCase):
         subscription.generate_invoice()
         subscription.template_id.invoicing_mode = "invoice_send"
         subscription.generate_invoice()
+        self.assertEqual(1, len(subscription.invoice_ids.filtered("is_move_sent")))
         subscription.template_id.invoicing_mode = "sale_and_invoice"
         order = subscription.create_sale_order()
         order.with_context(uid=1).action_confirm()


### PR DESCRIPTION
Small update to add the missing `is_move_sent` attribute on the invoice when it has been sent by email.
It concerns only the invoicing_mode `invoice_send`.