### PR TITLE
[16.0][FIX] contract_sale_generation: fix tests not running

### DIFF
--- a/contract_sale_generation/tests/common.py
+++ b/contract_sale_generation/tests/common.py
@@ -5,14 +5,13 @@
 from freezegun import freeze_time
 
 from odoo import fields
-from odoo.tests import Form, tagged
+from odoo.tests import Form
 
 
 def to_date(date):
     return fields.Date.to_date(date)
 
 
-@tagged("post_install", "-at_install")
 class ContractSaleCommon:
     # Use case : Prepare some data for current test case
 

--- a/contract_sale_generation/tests/test_contract_sale.py
+++ b/contract_sale_generation/tests/test_contract_sale.py
@@ -4,11 +4,13 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import ValidationError
+from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 from .common import ContractSaleCommon, to_date
 
 
+@tagged("post_install", "-at_install")
 class TestContractSale(ContractSaleCommon, TransactionCase):
     def test_check_discount(self):
         with self.assertRaises(ValidationError):

--- a/contract_sale_generation/tests/test_contract_sale_recurrency.py
+++ b/contract_sale_generation/tests/test_contract_sale_recurrency.py
@@ -4,7 +4,7 @@
 from freezegun.api import freeze_time
 
 from odoo import fields
-from odoo.tests import Form
+from odoo.tests import Form, tagged
 from odoo.tests.common import TransactionCase
 
 from .common import ContractSaleCommon
@@ -12,6 +12,7 @@ from .common import ContractSaleCommon
 today = "2020-01-15"
 
 
+@tagged("post_install", "-at_install")
 class TestContractSale(ContractSaleCommon, TransactionCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
fix tests not running because `ContractSaleCommon` was tagged as `post_install` but that only works on the test classes themselves.