### PR TITLE
[IMP] contract: skip assignment when value unchanged to avoid triggering onchanges

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -243,7 +243,10 @@ class ContractContract(models.Model):
                     field.name in self.NO_SYNC,
                 )
             ):
-                if self.contract_template_id[field_name]:
+                if (
+                    self.contract_template_id[field_name]
+                    and self.contract_template_id[field_name] != self[field_name]
+                ):
                     self[field_name] = self.contract_template_id[field_name]
 
     @api.onchange("partner_id", "company_id")


### PR DESCRIPTION
When copying values from the contract template, skip assignment if the value is already the same on the contract. This prevents triggering unnecessary onchanges without altering the behavior.

cc/ @qgroulard , @marielejeune , @bjouini-acsone 