### PR TITLE
[17.0][FIX] contract_sale_invoicing: Proper flag visualization

### DIFF
--- a/contract_sale_invoicing/views/contract_view.xml
+++ b/contract_sale_invoicing/views/contract_view.xml
@@ -7,8 +7,11 @@
         <field name="model">contract.contract</field>
         <field name="inherit_id" ref="contract.contract_contract_form_view" />
         <field name="arch" type="xml">
-            <field name="recurring_next_date" position="after">
-                <field name="invoicing_sales" />
+            <field name="generation_type" position="after">
+                <field
+                    name="invoicing_sales"
+                    invisible="contract_type != 'sale' or generation_type != 'invoice'"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
The flag is not seen when doing recurrency by line, and the position anyway is a bit weird, so let's put it with the generation type selection. This also doesn't make sense for supplier invoices or other kind of generation.

<img width="1023" height="92" alt="image" src="https://github.com/user-attachments/assets/c5776d5c-75b4-4e12-828c-fc7a266d3c5d" />

@Tecnativa TT58137