### PR TITLE
[18.0][IMP] product_contract - remove unnecessary defaults

### DIFF
--- a/product_contract/models/sale_order_line_contract_mixin.py
+++ b/product_contract/models/sale_order_line_contract_mixin.py
@@ -36,7 +36,6 @@ class SaleOrderLineContractMixin(models.AbstractModel):
             ("semesterly", "Semester(s)"),
             ("yearly", "Year(s)"),
         ],
-        default="monthly",
         help="Specify Interval for contract duration.",
         compute="_compute_product_contract_data",
         precompute=True,
@@ -44,7 +43,6 @@ class SaleOrderLineContractMixin(models.AbstractModel):
         readonly=False,
     )
     recurring_interval = fields.Integer(
-        default=1,
         string="Invoice Every",
         help="Invoice every (Days/Week/Month/Year)",
         compute="_compute_product_contract_data",
@@ -62,7 +60,6 @@ class SaleOrderLineContractMixin(models.AbstractModel):
             ("semesterly", "Semester(s)"),
             ("yearly", "Year(s)"),
         ],
-        default="monthly",
         string="Recurrence",
         help="Specify Interval for automatic invoice generation.",
         compute="_compute_product_contract_data",
@@ -72,7 +69,6 @@ class SaleOrderLineContractMixin(models.AbstractModel):
     )
     recurring_invoicing_type = fields.Selection(
         [("pre-paid", "Pre-paid"), ("post-paid", "Post-paid")],
-        default="pre-paid",
         string="Invoicing type",
         help=(
             "Specify if the invoice must be generated at the beginning "
@@ -104,12 +100,10 @@ class SaleOrderLineContractMixin(models.AbstractModel):
         string="Auto Renew",
         compute="_compute_product_contract_data",
         precompute=True,
-        default=False,
         store=True,
         readonly=False,
     )
     auto_renew_interval = fields.Integer(
-        default=1,
         string="Renew Every",
         compute="_compute_product_contract_data",
         precompute=True,
@@ -124,7 +118,6 @@ class SaleOrderLineContractMixin(models.AbstractModel):
             ("monthly", "Month(s)"),
             ("yearly", "Year(s)"),
         ],
-        default="yearly",
         compute="_compute_product_contract_data",
         precompute=True,
         store=True,
@@ -141,7 +134,6 @@ class SaleOrderLineContractMixin(models.AbstractModel):
             ("end_next", "End of next period"),
         ],
         "Start Date Method",
-        default="manual",
         help="""This field allows to define how the start date of the contract will
         be calculated:
 


### PR DESCRIPTION
The default attributes are no longer necessary since the fields are set by the compute method with a precompute attribute.