### PR TITLE
[18.0][IMP] product_contract - add class o_row to auto_renew fields

### DIFF
--- a/product_contract/views/product_template.xml
+++ b/product_contract/views/product_template.xml
@@ -69,7 +69,7 @@
                             string="Renewal Frequency"
                         >
                             <label for="auto_renew_interval" />
-                            <div>
+                            <div class="o_row">
                                 <field
                                     name="auto_renew_interval"
                                     class="oe_inline"
@@ -89,7 +89,7 @@
                             string="Termination Notice"
                         >
                             <label for="termination_notice_interval" />
-                            <div>
+                            <div class="o_row">
                                 <field
                                     name="termination_notice_interval"
                                     class="oe_inline"

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -87,7 +87,7 @@
                 </group>
                 <group invisible="not is_auto_renew">
                     <label for="auto_renew_interval" />
-                    <div>
+                    <div class="o_row">
                         <field
                             name="auto_renew_interval"
                             class="oe_inline"


### PR DESCRIPTION
Added `class="o_row"` to the auto-renew divs to ensure consistent layout and styling with the recurrence section.