### PR TITLE
[16.0][IMP] subscription_oca: improve config UX and duplication

### DIFF
--- a/subscription_oca/models/__init__.py
+++ b/subscription_oca/models/__init__.py
@@ -3,6 +3,7 @@ from . import product_template
 from . import res_partner
 from . import sale_order
 from . import sale_order_line
+from . import subscription_generic_field_mixin
 from . import sale_subscription
 from . import sale_subscription_close_reason
 from . import sale_subscription_line

--- a/subscription_oca/models/sale_subscription_close_reason.py
+++ b/subscription_oca/models/sale_subscription_close_reason.py
@@ -1,10 +1,11 @@
 # Copyright 2023 Domatix - Carlos Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+
+from odoo import models
 
 
 class SaleSubscriptionCloseReason(models.Model):
     _name = "sale.subscription.close.reason"
+    _inherit = ["subscription.generic.field.mixin"]
     _description = "Close reason model"
-
-    name = fields.Char(required=True)
+    _order = "sequence, name, id"

--- a/subscription_oca/models/sale_subscription_stage.py
+++ b/subscription_oca/models/sale_subscription_stage.py
@@ -1,16 +1,16 @@
 # Copyright 2023 Domatix - Carlos Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
 class SaleSubscriptionStage(models.Model):
     _name = "sale.subscription.stage"
+    _inherit = ["subscription.generic.field.mixin"]
     _description = "Subscription stage"
     _order = "sequence, name, id"
 
-    name = fields.Char(required=True, translate=True)
-    sequence = fields.Integer()
     display_name = fields.Char(string="Display name", compute="_compute_display_name")
     in_progress = fields.Boolean(string="In progress", default=False)
     fold = fields.Boolean(string="Kanban folded")

--- a/subscription_oca/models/sale_subscription_tag.py
+++ b/subscription_oca/models/sale_subscription_tag.py
@@ -1,10 +1,10 @@
 # Copyright 2023 Domatix - Carlos Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+
+from odoo import models
 
 
 class SaleSubscriptionTag(models.Model):
     _name = "sale.subscription.tag"
+    _inherit = ["subscription.generic.field.mixin"]
     _description = "Tags for sale subscription"
-
-    name = fields.Char("Tag name", required=True)

--- a/subscription_oca/models/sale_subscription_template.py
+++ b/subscription_oca/models/sale_subscription_template.py
@@ -8,6 +8,7 @@ from odoo import api, fields, models
 class SaleSubscriptionTemplate(models.Model):
     _name = "sale.subscription.template"
     _description = "Subscription templates"
+    _inherit = ["subscription.generic.field.mixin"]
 
     name = fields.Char(required=True)
     description = fields.Text(string="Terms and conditions")

--- a/subscription_oca/models/subscription_generic_field_mixin.py
+++ b/subscription_oca/models/subscription_generic_field_mixin.py
@@ -1,0 +1,21 @@
+# Copyright 2023 Domatix - Carlos Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, fields, models
+
+
+class SubscriptionGenericFieldMixin(models.AbstractModel):
+    """Generic mixin for reusable fields and duplication behavior."""
+
+    _name = "subscription.generic.field.mixin"
+    _description = "Generic mixin for subscription-related models"
+    _order = "sequence, name"
+    name = fields.Char(required=True, translate=True)
+    sequence = fields.Integer(default=10, index=True)
+
+    def copy(self, default=None):
+        """Add '(copy)' suffix when duplicating a record."""
+        default = dict(default or {})
+        if "name" not in default and self.name:
+            default["name"] = _("%s (copy)", self.name)
+        return super().copy(default)

--- a/subscription_oca/tests/test_subscription_oca.py
+++ b/subscription_oca/tests/test_subscription_oca.py
@@ -692,3 +692,29 @@ class TestSubscriptionOCA(TransactionCase):
         )
         test_res.append(group_stage_ids)
         return test_res
+
+    def test_subscription_generic_field_mixin_copy(self):
+        """Test that copying a record adds '(copy)' suffix to name."""
+        # Create a test model that uses the mixin
+        TestModel = self.env["sale.subscription.template"]
+
+        # Create original record
+        original = TestModel.create(
+            {
+                "name": "Original Template",
+                "code": "test_copy_template",
+            }
+        )
+
+        # Test copy without default
+        copied = original.copy()
+        self.assertIn("(copy)", copied.name)
+        self.assertIn("Original Template", copied.name)
+
+        # Test copy with custom name in default
+        custom_name = "Custom Name"
+        copied_custom = original.copy({"name": custom_name})
+        self.assertEqual(copied_custom.name, custom_name)
+
+        # Test that original name wasn't changed
+        self.assertEqual(original.name, "Original Template")

--- a/subscription_oca/views/sale_subscription_stage_views.xml
+++ b/subscription_oca/views/sale_subscription_stage_views.xml
@@ -43,8 +43,8 @@
         <field name="model">sale.subscription.stage</field>
         <field name="arch" type="xml">
             <tree>
+                <field name="sequence" widget="handle" />
                 <field name="name" />
-
             </tree>
         </field>
     </record>

--- a/subscription_oca/views/sale_subscription_views.xml
+++ b/subscription_oca/views/sale_subscription_views.xml
@@ -439,6 +439,7 @@
         <field name="model">sale.subscription.close.reason</field>
         <field name="arch" type="xml">
             <tree editable="bottom">
+                <field name="sequence" widget="handle" />
                 <field name="name" />
             </tree>
         </field>


### PR DESCRIPTION
Add '(copy)' suffix on duplication and sequence handles for stages, templates, tags, and close reasons.
Enable tree,form views and remove inline editing.

Task: 5020