### PR TITLE
[18.0][FIX] contract: Enforce company on tests

### DIFF
--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -36,7 +36,11 @@ class TestContractBase(common.TransactionCase):
         cls.product_1 = cls.env.ref("product.product_product_1")
         cls.product_2 = cls.env.ref("product.product_product_2")
         cls.product_1.taxes_id += cls.env["account.tax"].search(
-            [("type_tax_use", "=", "sale")], limit=1
+            [
+                ("type_tax_use", "=", "sale"),
+                ("company_id", "=", cls.env.company.id),
+            ],
+            limit=1,
         )
         cls.product_1.description_sale = "Test description sale"
         cls.line_template_vals = {


### PR DESCRIPTION
We should add a validation of company as it might collide if we have multiple companies installed and this companies have a sequence.

One example would be to test contract and l10n_es in the same instance.