### PR TITLE
[18.0][IMP] contract_line_successor: allow importing successor_contract_lin…

### DIFF
--- a/contract_line_successor/models/contract_line.py
+++ b/contract_line_successor/models/contract_line.py
@@ -24,7 +24,7 @@ class ContractLine(models.Model):
         comodel_name="contract.line",
         string="Successor Contract Line",
         required=False,
-        readonly=True,
+        readonly=False,
         index=True,
         copy=False,
         help="In case of restart after suspension, this field contain the new "
@@ -34,7 +34,7 @@ class ContractLine(models.Model):
         comodel_name="contract.line",
         string="Predecessor Contract Line",
         required=False,
-        readonly=True,
+        readonly=False,
         index=True,
         copy=False,
         help="Contract Line origin of this one.",

--- a/contract_line_successor/views/contract_line.xml
+++ b/contract_line_successor/views/contract_line.xml
@@ -26,8 +26,8 @@
                     invisible="display_type"
                 >
                     <group>
-                        <field name="predecessor_contract_line_id" />
-                        <field name="successor_contract_line_id" />
+                        <field name="predecessor_contract_line_id" readonly="True" />
+                        <field name="successor_contract_line_id" readonly="True" />
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION
…e_id and predecessor_contract_line_id

As outlined in https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-17.0 (which I believe applies to 18.0 as well) changing these from readonly=True to be able to  import.