### PR TITLE
[18.0][IMP] contract: hook for line is invoiceable

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -568,14 +568,6 @@ class ContractContract(models.Model):
         """
         self.ensure_one()
 
-        def can_be_invoiced(contract_line):
-            return (
-                not contract_line.is_canceled
-                and contract_line.recurring_next_date
-                and contract_line.recurring_next_date <= date_ref
-                and contract_line.next_period_date_start
-            )
-
         lines2invoice = previous = self.env["contract.line"]
         current_section = current_note = False
         for line in self.contract_line_ids:
@@ -589,7 +581,7 @@ class ContractContract(models.Model):
                 elif line.note_invoicing_mode == "with_next_line":
                     current_note = line
             elif line.is_recurring_note or not line.display_type:
-                if can_be_invoiced(line):
+                if line._can_be_invoiced(date_ref):
                     if current_section:
                         lines2invoice |= current_section
                         current_section = False

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -261,6 +261,15 @@ class ContractLine(models.Model):
                 }
             )
 
+    def _can_be_invoiced(self, date_ref):
+        self.ensure_one()
+        return (
+            not self.is_canceled
+            and self.recurring_next_date
+            and self.recurring_next_date <= date_ref
+            and self.next_period_date_start
+        )
+
     @api.model
     def get_view(self, view_id=None, view_type="form", **options):
         default_contract_type = self.env.context.get("default_contract_type")


### PR DESCRIPTION
Make can_be_invoiced available on contract_line, so other modules can modify conditions.