### PR TITLE
[18.0][FIX] contract: automatic pricing should resptect pricelist quantity-based rules

### DIFF
--- a/contract/models/contract_template_line.py
+++ b/contract/models/contract_template_line.py
@@ -194,8 +194,9 @@ class ContractTemplateLine(models.Model):
                         line.contract_id.company_id
                     ).property_product_pricelist
                 )
+                qty = line.env.context.get("contract_line_qty", line.quantity)
                 product = line.product_id.with_context(
-                    quantity=line.env.context.get("contract_line_qty", line.quantity),
+                    quantity=qty,
                     pricelist=pricelist.id,
                     partner=line.contract_id.partner_id.id,
                     uom=line.uom_id.id,
@@ -203,7 +204,7 @@ class ContractTemplateLine(models.Model):
                         "old_date", fields.Date.context_today(line)
                     ),
                 )
-                line.price_unit = pricelist._get_product_price(product, quantity=1)
+                line.price_unit = pricelist._get_product_price(product, quantity=qty)
             else:
                 line.price_unit = line.specific_price
 

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -74,6 +74,24 @@ class TestContractBase(common.TransactionCase):
                 "base": "list_price",
             }
         )
+        cls.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": cls.partner.property_product_pricelist.id,
+                "product_id": cls.product_2.id,
+                "compute_price": "fixed",
+                "fixed_price": 100,
+                "min_quantity": 1,
+            }
+        )
+        cls.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": cls.partner.property_product_pricelist.id,
+                "product_id": cls.product_2.id,
+                "compute_price": "fixed",
+                "fixed_price": 50,
+                "min_quantity": 10,
+            }
+        )
         cls.contract = cls.env["contract.contract"].create(
             {
                 "name": "Test Contract",
@@ -243,6 +261,23 @@ class TestContract(TestContractBase):
         self.acct_line.price_unit = 10
         self.acct_line.invalidate_model()
         self.assertEqual(self.acct_line.price_unit, 10)
+
+    def test_automatic_price_min_quantity(self):
+        """Test that automatic pricing respects pricelist quantity-based rules."""
+        self.acct_line.product_id = self.product_2.id
+        self.acct_line.automatic_price = True
+        self.acct_line.quantity = 1
+        self.assertEqual(
+            self.acct_line.price_unit,
+            100,
+            "Price should be 100 for quantity 1 based on pricelist rule",
+        )
+        self.acct_line.quantity = 10
+        self.assertEqual(
+            self.acct_line.price_unit,
+            50,
+            "Price should be 50 for quantity 10 based on pricelist rule",
+        )
 
     def test_automatic_price_change(self):
         self.acct_line.automatic_price = True


### PR DESCRIPTION
__get_product_price_ was sent with quantity=1 instead of the actual quantity of the line. This was causing incorrect prices when a pricelist has quantity-based rules

See the example added in the test