### PR TITLE
[18.0][IMP] contract: compute group_id based on analytic accounts in contract lines

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -42,6 +42,9 @@ class ContractContract(models.Model):
     group_id = fields.Many2one(
         string="Group",
         comodel_name="account.analytic.account",
+        compute="_compute_group_id",
+        store=True,
+        readonly=False,
         ondelete="restrict",
     )
     tag_ids = fields.Many2many(comodel_name="contract.tag", string="Tags")
@@ -214,6 +217,32 @@ class ContractContract(models.Model):
                 rec.invoice_partner_id = rec.partner_id.address_get(["invoice"])[
                     "invoice"
                 ]
+
+    @api.depends(
+        "contract_line_ids",
+        "contract_line_ids.analytic_distribution",
+        "contract_line_fixed_ids",
+        "contract_line_fixed_ids.analytic_distribution",
+    )
+    def _compute_group_id(self):
+        """Compute the group_id based on the analytic_distribution
+        in the contract lines.
+        If all contract lines have the same analytic account, set it as group_id.
+        Otherwise, set group_id to False.
+        """
+        for record in self:
+            record.group_id = False
+            all_analytic_accounts = []
+            contract_lines = record.contract_line_ids | record.contract_line_fixed_ids
+            for line in contract_lines:
+                if line.analytic_distribution:
+                    all_analytic_accounts.extend(
+                        int(acc_id)
+                        for account_ids in line.analytic_distribution.keys()
+                        for acc_id in account_ids.split(",")
+                    )
+            if len(set(all_analytic_accounts)) == 1:
+                record.group_id = all_analytic_accounts[0]
 
     # === Onchange Methods ===
 

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -1557,3 +1557,39 @@ class TestContract(TestContractBase):
         self.contract3.contract_line_ids.recurring_next_date = fields.Date.today()
         invoice_id = self.contract3.recurring_create_invoice()
         self.assertEqual(invoice_id.invoice_line_ids[0].name, "Header for May Services")
+
+    def test_analytic_account(self):
+        """Tests the automatic setting of the analytic account on the contract
+        depending on the analytic accounts set on the contract lines.
+        # Case 1: only one contract line with one analytic account
+            => the analytic account is set on the contract
+        # Case 2: only one contract line with two analytic accounts
+            => the analytic account is not set on the contract
+        # Case 3: two contract lines, with the same analytic account
+            => the analytic account is set on the contract
+        # Case 4: two contract lines, each one with one analytic account
+            => the analytic account is not set on the contract
+        """
+        plan = self.env["account.analytic.plan"].create({"name": "Test plan contract"})
+        self.analytic_account_1 = self.env["account.analytic.account"].create(
+            {"name": "Test account contract 1", "plan_id": plan.id}
+        )
+        self.analytic_account_2 = self.env["account.analytic.account"].create(
+            {"name": "Test account contract 2", "plan_id": plan.id}
+        )
+        # Case 1: only one contract line with one analytic account
+        self.acct_line.analytic_distribution = {self.analytic_account_1.id: 100}
+        self.assertEqual(self.contract.group_id, self.analytic_account_1)
+        # Case 2: only one contract line with two analytic accounts
+        self.acct_line.analytic_distribution = {
+            self.analytic_account_1.id: 50,
+            self.analytic_account_2.id: 50,
+        }
+        self.assertFalse(self.contract.group_id)
+        # Case 3: two contract lines, with the same analytic account
+        self.acct_line.analytic_distribution = {self.analytic_account_1.id: 100}
+        new_contract_line = self.acct_line.copy()
+        self.assertEqual(self.contract.group_id, self.analytic_account_1)
+        # Case 4: two contract lines, each one with one analytic account
+        new_contract_line.analytic_distribution = {self.analytic_account_2.id: 100}
+        self.assertFalse(self.contract.group_id)


### PR DESCRIPTION
This field is unused in this module, but in the contract_sale_invoicing module it is used to search Sales Orders. However, many times this field goes unnoticed and users set the analytic distribution directly on the lines.

After this commit, the field is computed automatically based on the contract lines.

Partial FWP of https://github.com/OCA/contract/pull/1313

TT57029
@Tecnativa @pedrobaeza @victoralmau  @tobiaszehntner @sbejaoui @rousseldenis Could you please review this?