### PR TITLE
[18.0][IMP] contract_sale_invoicing: Add option to include sale lines in the same contract invoice

### DIFF
--- a/contract_sale_invoicing/models/contract.py
+++ b/contract_sale_invoicing/models/contract.py
@@ -12,9 +12,17 @@ class ContractContract(models.Model):
         help="If checked include sales with same analytic account to invoice "
         "in contract invoice creation.",
     )
+    invoicing_sales_into_contract = fields.Boolean(
+        help="If checked, include the sales order lines "
+        "in the contract invoice instead of creating separate invoices.",
+    )
 
     def _recurring_create_invoice(self, date_ref=False):
         invoices = super()._recurring_create_invoice(date_ref)
+        invoice_by_contract = {}
+        for invoice in invoices:
+            contract = invoice.invoice_line_ids.contract_line_id.contract_id
+            invoice_by_contract[contract.id] = invoice
         for contract in self:
             if not contract.invoicing_sales or not contract.recurring_next_date:
                 continue
@@ -41,6 +49,29 @@ class ContractContract(models.Model):
             sales = sales.with_context(
                 filter_on_analytic_account=contract.group_id.id
             ).filtered(lambda s: s._get_invoiceable_lines())
-            if sales:
+            if not sales:
+                continue
+            # Add sales lines to existing invoice
+            if contract.invoicing_sales_into_contract and invoice_by_contract.get(
+                contract.id
+            ):
+                invoice = invoice_by_contract[contract.id]
+                sale_lines_to_invoice = sales.with_context(
+                    filter_on_analytic_account=contract.group_id.id
+                )._get_invoiceable_lines()
+                next_sequence = (
+                    max(invoice.invoice_line_ids.mapped("sequence") or [0]) + 1
+                )
+                invoice_line_vals_list = []
+                for sale_line in sale_lines_to_invoice:
+                    invoice_line_vals = sale_line._prepare_invoice_line(
+                        sequence=next_sequence
+                    )
+                    next_sequence += 1
+                    invoice_line_vals["move_id"] = invoice.id
+                    invoice_line_vals_list.append(invoice_line_vals)
+                self.env["account.move.line"].create(invoice_line_vals_list)
+            else:
+                # Create separate invoices for sales
                 invoices |= sales._create_invoices()
         return invoices

--- a/contract_sale_invoicing/tests/test_contract_sale_invoicing.py
+++ b/contract_sale_invoicing/tests/test_contract_sale_invoicing.py
@@ -15,11 +15,23 @@ class TestContractSaleInvoicing(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.product_contract = cls.env["product.product"].create(
+            {"name": "Contract Product"}
+        )
         cls.contract = cls.env["contract.contract"].create(
             {
                 "name": "Test Contract",
                 "partner_id": cls.partner.id,
                 "company_id": cls.env.company.id,
+                "contract_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Test Contract Line",
+                            "product_id": cls.product_contract.id,
+                            "quantity": 1.0,
+                        }
+                    )
+                ],
             }
         )
         cls.contract.group_id = cls.env["account.analytic.account"].search([], limit=1)
@@ -77,11 +89,32 @@ class TestContractSaleInvoicing(BaseCommon):
     def test_sale_invoicing(self):
         """
         Do invoice Sale Order that matches on analytic account
+        this must create a new invoice in the sale order
         """
         self.contract.invoicing_sales = True
+        self.contract.invoicing_sales_into_contract = False
         self.sale_order.action_confirm()
         self.contract.recurring_create_invoice()
         self.assertEqual(self.sale_order.invoice_status, "invoiced")
+        contract_invoices = self.contract._get_related_invoices()
+        self.assertEqual(len(contract_invoices), 1)
+        self.assertEqual(len(self.sale_order.invoice_ids), 1)
+        self.assertNotEqual(self.sale_order.invoice_ids, contract_invoices)
+
+    def test_sale_invoicing_same_contract(self):
+        """
+        Do invoice Sale Order that matches on analytic account
+        this must add the sale order lines into the contract invoice
+        """
+        self.contract.invoicing_sales = True
+        self.contract.invoicing_sales_into_contract = True
+        self.sale_order.action_confirm()
+        self.contract.recurring_create_invoice()
+        self.assertEqual(self.sale_order.invoice_status, "invoiced")
+        contract_invoices = self.contract._get_related_invoices()
+        self.assertEqual(len(contract_invoices), 1)
+        self.assertEqual(len(self.sale_order.invoice_ids), 1)
+        self.assertEqual(self.sale_order.invoice_ids, contract_invoices)
 
     def test_contract_sale_invoicing_without(self):
         """

--- a/contract_sale_invoicing/views/contract_view.xml
+++ b/contract_sale_invoicing/views/contract_view.xml
@@ -11,6 +11,10 @@
                     name="invoicing_sales"
                     invisible="contract_type != 'sale' or generation_type != 'invoice'"
                 />
+                <field
+                    name="invoicing_sales_into_contract"
+                    invisible="contract_type != 'sale' or generation_type != 'invoice' or not invoicing_sales"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
FWP of https://github.com/OCA/contract/pull/1324
Before this commit, when a sale order was invoiced from a contract, it created a new invoice, resulting in two invoices, one for the contract and another for the sale order. After this commit, when this new field is checked in the contract, the sale order lines are invoiced in the same invoice as the contract.

TT58137
@Tecnativa @pedrobaeza @christian-ramos-tecnativa  could you please review this?
