### PR TITLE
[FIX] in view_product_suscribable_filter

### DIFF
--- a/subscription_oca/views/product_template_views.xml
+++ b/subscription_oca/views/product_template_views.xml
@@ -17,4 +17,22 @@
             </xpath>
         </field>
     </record>
+
+    <record id="product_template_search_view" model="ir.ui.view">
+        <field name="name">product.template.search.suscribable.filter</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_search_view" />
+        <field name="arch" type="xml">
+            <field name="categ_id" position="after">
+                <field name="subscribable" />
+            </field>
+            <group position="before">
+                <filter
+                    string="Suscribable products"
+                    name="subsproducts"
+                    domain="[('subscribable','=', True)]"
+                />
+            </group>
+        </field>
+    </record>
 </odoo>

--- a/subscription_oca/views/sale_subscription_views.xml
+++ b/subscription_oca/views/sale_subscription_views.xml
@@ -374,21 +374,6 @@
         </field>
     </record>
 
-    <record id="view_product_suscribable_filter" model="ir.ui.view">
-        <field name="name">product.suscribable.filter</field>
-        <field name="model">product.template</field>
-        <field name="arch" type="xml">
-            <search>
-                <field name="subscribable" />
-                <filter
-                    string="Suscribable products"
-                    name="subsproducts"
-                    domain="[('subscribable','=', True)]"
-                />
-            </search>
-        </field>
-    </record>
-
     <record id="view_subscription_close_reason_tree" model="ir.ui.view">
         <field name="name">view.subscription.close.reason.tree</field>
         <field name="model">sale.subscription.close.reason</field>


### PR DESCRIPTION
When viewing Products from Invoice (Customers or Suppliers) -> Products, the SEARCH view is broken and only displays the subscription_filter view.

The problem has been resolved by changing that view and making it inherit from the base Product Search view.
The view definition has been moved to product_template_views.xml

    Impacted versions:

17.0

    Steps to reproduce:

Go to the Invoice -> Product
