### PR TITLE
[18.0] [FIX] contract: implement missing _compute_analytic_distribution on contract line

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -69,6 +69,26 @@ class ContractLine(models.Model):
             max_date_end=False,
         )
 
+    def _get_analytic_distribution_arguments(self):
+        self.ensure_one()
+        partner_categ_ids = self.contract_id.partner_id.category_id.ids
+        return {
+            "product_id": self.product_id.id,
+            "product_categ_id": self.product_id.categ_id.id,
+            "partner_id": self.contract_id.partner_id.id,
+            "partner_category_id": partner_categ_ids,
+            "company_id": self.company_id.id,
+        }
+
+    @api.depends("contract_id.partner_id", "product_id")
+    def _compute_analytic_distribution(self):
+        for line in self:
+            if not line.display_type:
+                distribution = line.env[
+                    "account.analytic.distribution.model"
+                ]._get_distribution(line._get_analytic_distribution_arguments())
+                line.analytic_distribution = distribution or line.analytic_distribution
+
     @api.constrains("recurring_next_date", "date_start")
     def _check_recurring_next_date_start_date(self):
         for line in self:

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -1593,3 +1593,20 @@ class TestContract(TestContractBase):
         # Case 4: two contract lines, each one with one analytic account
         new_contract_line.analytic_distribution = {self.analytic_account_2.id: 100}
         self.assertFalse(self.contract.group_id)
+
+    def test_analytic_distribution(self):
+        # Create an analytic distribution model for product 1
+        analytic_plan = self.env["account.analytic.plan"].create({"name": "Plan"})
+        analytic_account = self.env["account.analytic.account"].create(
+            {"name": "Test", "plan_id": analytic_plan.id}
+        )
+        self.env["account.analytic.distribution.model"].create(
+            {
+                "product_id": self.product_1.id,
+                "analytic_distribution": {str(analytic_account.id): 100},
+            }
+        )
+        new_contract_line = self.env["contract.line"].create(self.line_vals)
+        self.assertEqual(
+            new_contract_line.analytic_distribution, {str(analytic_account.id): 100}
+        )


### PR DESCRIPTION
Adding analytic.mixin on a model adds the analytic_distribution compute field. 

In the mixin the compute is not implemented, letting the method being implemented in each concrete model. This wasn't done yet for contract line.

Before this commit: adding a product to a contract line didn't fill the analytic distribution.

After this commit: adding a product to a contract line triggers the compute method (similarly to the one on sale order lines), evaluating the account analytic distribution models and setting the correct analytic distribution