### PR TITLE
[18.0][IMP] contract: add paths to actions

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -476,6 +476,7 @@
         <field name="name">Customer Contracts</field>
         <field name="res_model">contract.contract</field>
         <field name="view_mode">list,form</field>
+        <field name="path">customer-contracts</field>
         <field name="domain">[('contract_type', '=', 'sale')]</field>
         <field name="context">
             {'is_contract':1,
@@ -512,6 +513,7 @@
         <field name="name">Supplier Contracts</field>
         <field name="res_model">contract.contract</field>
         <field name="view_mode">list,form</field>
+        <field name="path">supplier-contracts</field>
         <field name="domain">[('contract_type', '=', 'purchase')]</field>
         <field name="context">
             {'is_contract':1,

--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -225,6 +225,7 @@
         <field name="name">Supplier Contract Lines</field>
         <field name="res_model">contract.line</field>
         <field name="view_mode">list,pivot,form</field>
+        <field name="path">supplier-contract-lines</field>
         <field name="domain">[('contract_id.contract_type', '=', 'purchase')]</field>
         <field name="context">
             {'search_default_group_by_contract': 1}
@@ -237,6 +238,7 @@
         <field name="name">Customer Contract Lines</field>
         <field name="res_model">contract.line</field>
         <field name="view_mode">list,pivot,form</field>
+        <field name="path">customer-contract-lines</field>
         <field name="domain">[('contract_id.contract_type', '=', 'sale')]</field>
         <field name="context">
             {'search_default_group_by_contract': 1}

--- a/contract/views/contract_tag.xml
+++ b/contract/views/contract_tag.xml
@@ -35,6 +35,7 @@
         <field name="name">Contract Tags</field>
         <field name="res_model">contract.tag</field>
         <field name="view_mode">list,form</field>
+        <field name="path">contract-tags</field>
     </record>
     <record model="ir.ui.menu" id="contract_tag_menu">
         <field name="name">Contract Tag</field>

--- a/contract/views/contract_template.xml
+++ b/contract/views/contract_template.xml
@@ -155,6 +155,7 @@
         <field name="name">Contract Templates</field>
         <field name="res_model">contract.template</field>
         <field name="view_mode">list,form</field>
+        <field name="path">contract-templates</field>
         <field name="search_view_id" ref="contract_template_search_view" />
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">


### PR DESCRIPTION
Goal is to have readable urls: `https://odoo.com/odoo/customer-contracts/1234` instead of `https://odoo.com/odoo/action-1717/1234` for eg.