### PR TITLE
[17.0][FIX] contract: Visual hint for cancelled lines in portal

### DIFF
--- a/contract/views/contract_portal_templates.xml
+++ b/contract/views/contract_portal_templates.xml
@@ -241,7 +241,7 @@
                                         t-as="line"
                                     >
                                         <tr
-                                            t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else ''"
+                                            t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else 'text-muted' if line.is_canceled else ''"
                                         >
                                             <t t-if="not line.display_type">
                                                 <td name="td_name">
@@ -294,6 +294,7 @@
                                                 >
                                                     <span
                                                         t-field="line.recurring_next_date"
+                                                        t-if="not line.is_canceled"
                                                     />
                                                 </td>
                                             </t>


### PR DESCRIPTION
On portal, the cancelled lines are not distinguished from running ones, as the next invoice date is still displayed, and the color is the same (on contrary than the backend, that appears greyed).

So let's do something similar in portal:

- Put the row as grey.
- Hide the nexte invoice date on that case.

Before:

<img width="1257" height="506" alt="image" src="https://github.com/user-attachments/assets/3b8ef77d-590c-4436-b04f-53d3cc724cd4" />

After:

<img width="1257" height="506" alt="image" src="https://github.com/user-attachments/assets/b285f4f9-fc1d-4f16-b23c-fad3e6845acd" />


@Tecnativa TT59704