### PR TITLE
[FIX] Surround setting view added fields by more standard markup

### DIFF
--- a/contract_forecast/views/res_config_settings.xml
+++ b/contract_forecast/views/res_config_settings.xml
@@ -25,13 +25,26 @@
                     class="row mt16 o_settings_container"
                     attrs="{'invisible': [('enable_contract_forecast', '=', False)]}"
                 >
-                    <label
-                        for="contract_forecast_interval"
-                        string="Forecast Interval"
-                        class="oe_inline"
-                    />
-                    <field name="contract_forecast_interval" class="oe_inline" />
-                    <field name="contract_forecast_rule_type" class="oe_inline" />
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane" />
+                        <div class="o_setting_right_pane">
+                            <label
+                                for="contract_forecast_interval"
+                                string="Forecast Interval"
+                                class="oe_inline"
+                            />
+                            <div>
+                                <field
+                                    name="contract_forecast_interval"
+                                    class="oe_inline"
+                                />
+                                <field
+                                    name="contract_forecast_rule_type"
+                                    class="oe_inline"
+                                />
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </xpath>
         </field>

--- a/contract_forecast/views/res_config_settings.xml
+++ b/contract_forecast/views/res_config_settings.xml
@@ -20,12 +20,10 @@
                             <label for="enable_contract_forecast" />
                         </div>
                     </div>
-                </div>
-                <div
-                    class="row mt16 o_settings_container"
-                    attrs="{'invisible': [('enable_contract_forecast', '=', False)]}"
-                >
-                    <div class="col-12 col-lg-6 o_setting_box">
+                    <div
+                        class="col-12 col-lg-6 o_setting_box"
+                        attrs="{'invisible': [('enable_contract_forecast', '=', False)]}"
+                    >
                         <div class="o_setting_left_pane" />
                         <div class="o_setting_right_pane">
                             <label

--- a/contract_forecast/views/res_config_settings.xml
+++ b/contract_forecast/views/res_config_settings.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="contract.res_config_settings_form_view" />
         <field name="arch" type="xml">
             <xpath
-                expr="//field[@name='create_new_line_at_contract_line_renew']/parent::div/parent::div/parent::div"
+                expr="//field[@name='create_new_line_at_contract_line_renew']/ancestor::div[hasclass('o_settings_container')]"
                 position="after"
             >
                 <div class="row mt16 o_settings_container">


### PR DESCRIPTION
A `div` tag with the `o_setting_box` class is added around the fields and their label.

This seems to be a more standard markup among the OCA. At least the remove_odoo_enterprise module expects it, see issue https://github.com/OCA/server-brand/issues/116