### PR TITLE
[18.0][IMP] contract: reintroduce date field in contract 

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -33,6 +33,12 @@ class ContractContract(models.Model):
     active = fields.Boolean(default=True)
     code = fields.Char(string="Reference")
     name = fields.Char()
+    date = fields.Date(
+        required=True,
+        default=lambda self: fields.Date.today(),
+        help="This is the date the contract is taken into account \
+        (e.g.: signature date)",
+    )
     user_id = fields.Many2one(
         comodel_name="res.users",
         string="Responsible",

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -59,6 +59,7 @@
                         <group>
                             <field name="partner_id" required="1" />
                             <field name="user_id" />
+                            <field name="date" />
                         </group>
                         <group>
                             <field


### PR DESCRIPTION
The date field has been removed in v14 --> we might have a signature date different than the date of the first invoice