### PR TITLE
[17.0][FIX] contract: Use another condition for forcing a failure

### DIFF
--- a/contract/tests/test_contract_manually_create_invoice.py
+++ b/contract/tests/test_contract_manually_create_invoice.py
@@ -49,7 +49,7 @@ class TestContractManuallyCreateInvoice(TestContractBase):
         contracts = self.contract
 
         accounts = self.product_1.product_tmpl_id.get_product_accounts()
-        accounts["income"].deprecated = True  # To trigger a UserError
+        accounts["income"].internal_group = "off_balance"
 
         for _i in range(3):
             contracts |= self.contract.copy()


### PR DESCRIPTION
Odoo forced a change that makes the test fail:

https://github.com/odoo/odoo/pull/240230

This probably needs to be ported to 18 and 19 :disappointed: however, the change is not there yet.