### PR TITLE
[17.0][IMP] product_contract: New feature to avoid create contract line from the marked line

### DIFF
--- a/product_contract/i18n/es.po
+++ b/product_contract/i18n/es.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-24 14:18+0000\n"
-"PO-Revision-Date: 2025-01-24 15:19+0100\n"
+"POT-Creation-Date: 2026-01-19 16:41+0000\n"
+"PO-Revision-Date: 2026-01-19 17:45+0100\n"
 "Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: product_contract
 #. odoo-python
@@ -72,6 +72,12 @@ msgid "Automatically Create Contracts At Sale Order Confirmation"
 msgstr "Crear Contratos Automáticamente en la Confirmación del Pedido de Venta"
 
 #. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__avoid_create_contract
+#: model:ir.model.fields,field_description:product_contract.field_sale_order_line__avoid_create_contract
+msgid "Avoid Create Contract"
+msgstr "Evitar crear contrato"
+
+#. module: product_contract
 #: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
 msgid "Cancel"
 msgstr "Cancelar"
@@ -101,7 +107,7 @@ msgstr "Configurar un contrato"
 #: code:addons/product_contract/static/src/xml/sale_product_field.xml:0
 #, python-format
 msgid "Configure contract"
-msgstr ""
+msgstr "Configurar contrato"
 
 #. module: product_contract
 #: model:ir.model,name:product_contract.model_contract_contract
@@ -153,7 +159,7 @@ msgstr "El producto del contrato debe ser del tipo de servicio"
 #. module: product_contract
 #: model_terms:ir.ui.view,arch_db:product_contract.product_contract_configurator_form
 msgid "Contract renew"
-msgstr ""
+msgstr "Renovación de contrato"
 
 #. module: product_contract
 #: model_terms:ir.ui.view,arch_db:product_contract.view_order_form
@@ -268,7 +274,7 @@ msgstr "Cuarto mes"
 #. module: product_contract
 #: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: product_contract
 #: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__recurring_interval
@@ -284,7 +290,7 @@ msgstr "Factura Cada"
 #: model:ir.model.fields,help:product_contract.field_product_contract_configurator__recurring_interval
 #: model:ir.model.fields,help:product_contract.field_sale_order_line__recurring_interval
 msgid "Invoice every (Days/Week/Month/Year)"
-msgstr ""
+msgstr "Facturar cada (días/semana/mes/año)"
 
 #. module: product_contract
 #: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__recurring_invoicing_type
@@ -400,12 +406,12 @@ msgstr "Producto"
 #. module: product_contract
 #: model:ir.model,name:product_contract.model_product_contract_configurator
 msgid "Product Contract Configurator Wizard"
-msgstr ""
+msgstr "Asistente de configuración del producto contrato"
 
 #. module: product_contract
 #: model:ir.model.fields,field_description:product_contract.field_sale_order_line__product_contract_description
 msgid "Product Contract Description"
-msgstr ""
+msgstr "Descripción del producto contrato"
 
 #. module: product_contract
 #: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__product_uom_qty
@@ -467,7 +473,7 @@ msgstr "La orden de venta y el contrato deben estar vinculados al mismo socio"
 #. module: product_contract
 #: model:ir.model,name:product_contract.model_sale_order
 msgid "Sales Order"
-msgstr ""
+msgstr "Orden de venta"
 
 #. module: product_contract
 #: model:ir.model,name:product_contract.model_sale_order_line

--- a/product_contract/i18n/product_contract.pot
+++ b/product_contract/i18n/product_contract.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-01-19 16:41+0000\n"
+"PO-Revision-Date: 2026-01-19 16:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -62,6 +64,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:product_contract.field_res_config_settings__create_contract_at_sale_order_confirmation
 #: model_terms:ir.ui.view,arch_db:product_contract.res_config_settings_form_view
 msgid "Automatically Create Contracts At Sale Order Confirmation"
+msgstr ""
+
+#. module: product_contract
+#: model:ir.model.fields,field_description:product_contract.field_product_contract_configurator__avoid_create_contract
+#: model:ir.model.fields,field_description:product_contract.field_sale_order_line__avoid_create_contract
+msgid "Avoid Create Contract"
 msgstr ""
 
 #. module: product_contract

--- a/product_contract/models/sale_order.py
+++ b/product_contract/models/sale_order.py
@@ -44,7 +44,11 @@ class SaleOrder(models.Model):
 
     @api.depends("order_line")
     def _compute_is_contract(self):
-        self.is_contract = any(self.order_line.mapped("is_contract"))
+        self.is_contract = any(
+            self.order_line.filtered(lambda ol: not ol.avoid_create_contract).mapped(
+                "is_contract"
+            )
+        )
 
     def _prepare_contract_value(self, contract_template):
         self.ensure_one()
@@ -69,12 +73,15 @@ class SaleOrder(models.Model):
         lines_without_contract = self.env["sale.order.line"].browse()
         for rec in self.filtered("is_contract"):
             line_to_create_contract = rec.order_line.filtered(
-                lambda r: not r.contract_id and r.product_id.is_contract
+                lambda r: not r.contract_id
+                and r.product_id.is_contract
+                and not r.avoid_create_contract
             )
             line_to_create_contract._set_contract_line_start_date()
             line_to_update_contract = rec.order_line.filtered(
                 lambda r: r.contract_id
                 and r.product_id.is_contract
+                and not r.avoid_create_contract
                 and r
                 not in r.contract_id.contract_line_ids.mapped("sale_order_line_id")
             )

--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -86,6 +86,7 @@ class SaleOrderLine(models.Model):
     product_contract_description = fields.Text(
         compute="_compute_product_contract_description"
     )
+    avoid_create_contract = fields.Boolean()
 
     @api.constrains("contract_id")
     def _check_contact_is_not_terminated(self):
@@ -227,6 +228,8 @@ class SaleOrderLine(models.Model):
         contract_line = self.env["contract.line"]
         predecessor_contract_line = False
         for rec in self:
+            if rec.avoid_create_contract:
+                continue
             if rec.contract_line_id:
                 # If the upsell/downsell line start at the same date or before
                 # the contract line to replace supposed to start, we cancel

--- a/product_contract/static/src/js/contract_configurator_controller.esm.js
+++ b/product_contract/static/src/js/contract_configurator_controller.esm.js
@@ -22,6 +22,7 @@ export class ProductContractConfiguratorController extends formView.Controller {
             auto_renew_interval,
             auto_renew_rule_type,
             recurring_interval,
+            avoid_create_contract,
         } = record.data;
         return this.action.doAction({
             type: "ir.actions.act_window_close",
@@ -36,6 +37,7 @@ export class ProductContractConfiguratorController extends formView.Controller {
                     auto_renew_interval,
                     auto_renew_rule_type,
                     recurring_interval,
+                    avoid_create_contract,
                 },
             },
         });

--- a/product_contract/static/src/js/sale_product_field.esm.js
+++ b/product_contract/static/src/js/sale_product_field.esm.js
@@ -64,6 +64,7 @@ patch(SaleOrderLineProductField.prototype, {
             default_is_auto_renew: this.props.record.data.is_auto_renew,
             default_auto_renew_interval: this.props.record.data.auto_renew_interval,
             default_auto_renew_rule_type: this.props.record.data.auto_renew_rule_type,
+            default_avoid_create_contract: this.props.record.data.avoid_create_contract,
         };
     },
 
@@ -78,6 +79,7 @@ patch(SaleOrderLineProductField.prototype, {
             is_auto_renew: this.props.record.data.is_auto_renew,
             auto_renew_interval: this.props.record.data.auto_renew_interval,
             auto_renew_rule_type: this.props.record.data.auto_renew_rule_type,
+            avoid_create_contract: this.props.record.data.avoid_create_contract,
         };
     },
 

--- a/product_contract/tests/test_sale_order.py
+++ b/product_contract/tests/test_sale_order.py
@@ -122,6 +122,15 @@ class TestSaleOrder(TransactionCase):
         self.assertEqual(contract_line.date_end, Date.to_date("2018-12-31"))
         self.assertEqual(contract_line.recurring_next_date, Date.to_date("2018-01-31"))
 
+    def test_action_confirm_avoiding_create_contract(self):
+        """It shouldn't create a contract for lines marked as avoid_create_contract"""
+        self.order_line1.is_auto_renew = True
+        self.order_line1.avoid_create_contract = True
+        self.sale.action_confirm()
+        contracts = self.sale.order_line.mapped("contract_id")
+        self.assertEqual(len(contracts), 1)
+        self.assertFalse(self.order_line1.contract_id)
+
     def test_change_sale_company(self):
         self.assertTrue(self.sale.company_id)
         other_company = self.env["res.company"].create(

--- a/product_contract/views/sale_order.xml
+++ b/product_contract/views/sale_order.xml
@@ -166,6 +166,7 @@
                     optional="hide"
                     readonly="product_uom_readonly"
                 />
+                <field name="avoid_create_contract" optional="hide" />
             </xpath>
         </field>
     </record>

--- a/product_contract/wizards/product_contract_configurator.py
+++ b/product_contract/wizards/product_contract_configurator.py
@@ -67,6 +67,7 @@ class ProductContractConfigurator(models.TransientModel):
     contract_start_date_method = fields.Selection(
         related="product_id.contract_start_date_method"
     )
+    avoid_create_contract = fields.Boolean()
 
     @api.depends("product_id", "company_id")
     def _compute_contract_template_id(self):

--- a/product_contract/wizards/product_contract_configurator_views.xml
+++ b/product_contract/wizards/product_contract_configurator_views.xml
@@ -66,6 +66,7 @@
                     </group>
                     <separator colspan="4" string="Contract" />
                     <group colspan="2">
+                        <field name="avoid_create_contract" />
                         <field
                             name="contract_id"
                             options='{"no_create": True}'


### PR DESCRIPTION
With this changes we add a new way to avoid create a contract from the line marked with this new option. There are some cases where we want to invoice a contract product but we don't want to create that contract line.

cc @Tecnativa TT60386

ping @juancarlosonate-tecnativa @sergio-teruel 