### PR TITLE
[18.0][IMP] contract: Improve contract lines view with section/note support

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -105,7 +105,7 @@
                             <field
                                 name="contract_line_fixed_ids"
                                 invisible="line_recurrence"
-                                widget="section_and_note_one2many"
+                                widget="product_label_section_and_note_field_o2m"
                                 context="{'default_contract_type': contract_type, 'default_recurring_rule_type': recurring_rule_type, 'default_recurring_invoicing_type': recurring_invoicing_type, 'default_recurring_interval': recurring_interval, 'default_date_start': date_start, 'default_recurring_next_date': recurring_next_date}"
                             >
                                 <list
@@ -129,12 +129,20 @@
                                         column_invisible="True"
                                     />
                                     <field name="sequence" widget="handle" />
-                                    <field name="product_id" />
+                                    <field
+                                        name="product_id"
+                                        widget="product_label_section_and_note_field"
+                                    />
+                                    <field
+                                        name="name"
+                                        widget="section_and_note_text"
+                                        optional="show"
+                                    />
                                     <field
                                         name="product_uom_category_id"
                                         column_invisible="True"
                                     />
-                                    <field name="name" widget="section_and_note_text" />
+
                                     <field
                                         name="analytic_distribution"
                                         widget="analytic_distribution"
@@ -187,7 +195,7 @@
                             <field
                                 name="contract_line_ids"
                                 invisible="not line_recurrence"
-                                widget="section_and_note_one2many"
+                                widget="product_label_section_and_note_field_o2m"
                                 context="{'default_contract_type': contract_type}"
                             >
                                 <list decoration-info="create_invoice_visibility">
@@ -208,8 +216,16 @@
                                         column_invisible="True"
                                     />
                                     <field name="sequence" widget="handle" />
-                                    <field name="product_id" />
-                                    <field name="name" widget="section_and_note_text" />
+                                    <field
+                                        name="product_id"
+                                        widget="product_label_section_and_note_field"
+                                    />
+                                    <field
+                                        name="name"
+                                        widget="section_and_note_text"
+                                        optional="show"
+                                    />
+
                                     <field
                                         name="analytic_distribution"
                                         widget="analytic_distribution"


### PR DESCRIPTION
This PR improves the contract form view:
- Apply section_and_note_text widget to name field
- Apply product_label_section_and_note_field widget to product_id

@Tecnativa TT60295
@christian-ramos-tecnativa 