### PR TITLE
[FIX] contract_line_successor: create successor line with sudo() priv…

### DIFF
--- a/contract_line_successor/models/contract_line.py
+++ b/contract_line_successor/models/contract_line.py
@@ -502,7 +502,7 @@ class ContractLine(models.Model):
             if not rec.is_plan_successor_allowed:
                 raise ValidationError(_("Plan successor not allowed for this line"))
             rec.is_auto_renew = False
-            new_line = self.create(
+            new_line = self.sudo().create(
                 rec._prepare_value_for_plan_successor(
                     date_start, date_end, is_auto_renew, recurring_next_date
                 )


### PR DESCRIPTION
Creating a successor contract line can trigger internal mail.thread operations during the ORM flush, which may attempt to update protected mail.message fields such as `model` and `res_id`.

This previously resulted in the following error:
    **AccessError(_("Only administrators can modify 'model' and 'res_id' fields."))**

The successor line creation is now executed with sudo privileges.