### PR TITLE
[18.0][FIX] subscription_oca: Adapt test after Odoo Peppol update

### DIFF
--- a/subscription_oca/tests/test_subscription_oca.py
+++ b/subscription_oca/tests/test_subscription_oca.py
@@ -254,6 +254,9 @@ class TestSubscriptionOCA(BaseCommon):
                 "fixed_price": 1000,
             }
         )
+        # Required to post out invoices
+        for bank in cls.env.company.partner_id.bank_ids:
+            bank.allow_out_payment = True
 
     @classmethod
     def create_sub_template(cls, vals):


### PR DESCRIPTION
After Odoo Peppol security issue and latest updates:

Fix failing test: when posting invoices, the bank needs to be trusted.