### PR TITLE
[18][contract] FIX :  ignore date constraint for a note

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -92,7 +92,10 @@ class ContractLine(models.Model):
     @api.constrains("recurring_next_date", "date_start")
     def _check_recurring_next_date_start_date(self):
         for line in self:
-            if line.display_type == "line_section" or not line.recurring_next_date:
+            if (
+                line.display_type in ("line_section", "line_note")
+                or not line.recurring_next_date
+            ):
                 continue
             if line.date_start and line.recurring_next_date:
                 if line.date_start > line.recurring_next_date:


### PR DESCRIPTION
Forward port of https://github.com/OCA/contract/pull/1150

@bguillot @marcelsavegnago @pedrobaeza 

The 18 migration PR was already opened when it was merged in 17.