### PR TITLE
[18.0][IMP] subscription_oca: propagate salesman from sale order to subscri…

### DIFF
--- a/subscription_oca/models/sale_order.py
+++ b/subscription_oca/models/sale_order.py
@@ -57,7 +57,7 @@ class SaleOrder(models.Model):
             rec = self.env["sale.subscription"].create(
                 {
                     "partner_id": self.partner_id.id,
-                    "user_id": self.env.context.get("uid", self.env.uid),
+                    "user_id": self.user_id.id or self.env.uid,
                     "template_id": subscription_tmpl.id,
                     "pricelist_id": self.partner_id.property_product_pricelist.id,
                     "date_start": date.today(),


### PR DESCRIPTION
…ption
Before this commit, the salesman of the subscription is the user who validates the sale order. If the sale order is confirmed by the customer, it's Administrator instead of the sale order salesman