### PR TITLE
[18.0][FIX] subscription_oca: fix multi-company where the subscription id s…

### DIFF
--- a/subscription_oca/models/sale_order.py
+++ b/subscription_oca/models/sale_order.py
@@ -56,6 +56,7 @@ class SaleOrder(models.Model):
             ]
             rec = self.env["sale.subscription"].create(
                 {
+                    "company_id": self.company_id.id,
                     "partner_id": self.partner_id.id,
                     "user_id": self.env.context.get("uid", self.env.uid),
                     "template_id": subscription_tmpl.id,


### PR DESCRIPTION
…is set to the user's company instead of the sale order company

In multi company environment, it can be a mess if the subscription is not in the same company as the sale order's one

It can happen if the user who confirms the sale order is not in the same company as the sale order's