### PR TITLE
[18.0][IMP] subscription_oca: removing automatic date_start to today when subscription goes i…

### DIFF
--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -453,7 +453,8 @@ class SaleSubscription(models.Model):
                     if record.stage_id.type == "in_progress":
                         record.in_progress = True
                         today = date.today()
-                        record.date_start = today
+                        if not record.date_start:
+                            record.date_start = today
                         record.calculate_recurring_next_date(today)
                     elif record.stage_id.type == "post":
                         record.close_reason_id = values.get("close_reason_id", False)

--- a/subscription_oca/tests/test_subscription_oca.py
+++ b/subscription_oca/tests/test_subscription_oca.py
@@ -130,6 +130,12 @@ class TestSubscriptionOCA(BaseCommon):
                 "type": "pre",
             }
         )
+        cls.stage_3 = cls.env["sale.subscription.stage"].create(
+            {
+                "name": "Test Sub Stage 3 in progress",
+                "type": "in_progress",
+            }
+        )
         cls.tag = cls.env["sale.subscription.tag"].create(
             {
                 "name": "Test Tag",
@@ -630,6 +636,17 @@ class TestSubscriptionOCA(BaseCommon):
         invoice = self.sub1.create_invoice()
         action = invoice.action_open_subscription()
         self.assertEqual(action["res_id"], self.sub1.id)
+
+    def test_subscription_oca_date_start(self):
+        self.sub6.write({"stage_id": self.stage_3})
+        self.assertEqual(fields.Date.to_string(self.sub6.date_start), "2099-01-01")
+        self.sub3.write({"stage_id": self.stage_3})
+        self.assertEqual(self.sub3.date_start, fields.Date.today())
+
+    def test_subscription_oca_date_start_empty(self):
+        self.sub3.date_start = False
+        self.sub3.write({"stage_id": self.stage_3})
+        self.assertEqual(self.sub3.date_start, fields.Date.today())
 
     def _collect_all_sub_test_results(self, subscription):
         """Creates the invoice of a subscription and returns its data


### PR DESCRIPTION
…n progress. This could be useful when we launch a subscription with a date start different from today