### PR TITLE
[18.0][FIX] contract_manually_invoiced: wizard invoice manually view

### DIFF
--- a/contract_invoice_manually/readme/CONTRIBUTORS.md
+++ b/contract_invoice_manually/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - Tobias Zehntner <tobias.zehntner@acsone.eu> (https://www.acsone.eu)
+- Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/contract_invoice_manually/wizards/contract_manually_create_invoice.py
+++ b/contract_invoice_manually/wizards/contract_manually_create_invoice.py
@@ -1,14 +1,18 @@
 # Copyright 2026 ACSONE SA/NV
+# Copyright 2026 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
 from odoo import api, fields, models
-from odoo.osv import expression
 from odoo.tools.safe_eval import safe_eval
 
 
 class ContractManuallyCreateInvoice(models.TransientModel):
     _inherit = "contract.manually.create.invoice"
+
+    manually_invoiced = fields.Boolean(
+        default=lambda self: self.env.company.enable_contract_invoice_manually
+    )
 
     filter_domain = fields.Char(
         string="Domain",
@@ -18,7 +22,7 @@ class ContractManuallyCreateInvoice(models.TransientModel):
         help="Filter/Domain to apply on contracts to invoice",
     )
 
-    @api.depends("invoice_date", "contract_type")
+    @api.depends("invoice_date", "contract_type", "manually_invoiced")
     def _compute_filter_domain(self):
         for wizard in self:
             domain = [
@@ -28,9 +32,8 @@ class ContractManuallyCreateInvoice(models.TransientModel):
                     fields.Datetime.to_string(wizard.invoice_date),
                 ),
                 ("contract_type", "=", wizard.contract_type),
+                ("is_manually_invoiced", "=", wizard.manually_invoiced),
             ]
-            if self.env.company.enable_contract_invoice_manually:
-                domain = expression.AND([domain, [("is_manually_invoiced", "=", True)]])
             wizard.filter_domain = str(domain)
 
     @api.depends("invoice_date", "filter_domain")

--- a/contract_invoice_manually/wizards/contract_manually_create_invoice.xml
+++ b/contract_invoice_manually/wizards/contract_manually_create_invoice.xml
@@ -9,22 +9,21 @@
             ref="contract.contract_manually_create_invoice_form_view"
         />
         <field name="arch" type="xml">
-            <xpath expr="//form/group[last()]" position="after">
-                <notebook invisible="not invoice_date">
-                    <page name="contracts" string="Contracts">
-                        <button
-                            name="action_show_contract_to_invoice"
-                            position="move"
-                        />
-                    </page>
-                    <page name="domain" string="Contract Filter">
-                        <field
-                            name="filter_domain"
-                            widget="domain"
-                            options="{'model': 'contract.contract'}"
-                        />
-                    </page>
-                </notebook>
+            <field name="invoice_date" position="after">
+                <field name="manually_invoiced" />
+            </field>
+            <xpath expr="//form/group" position="after">
+                <group
+                    string="Contract Filter"
+                    invisible="not invoice_date"
+                    groups="base.group_no_one"
+                >
+                    <field
+                        name="filter_domain"
+                        widget="domain"
+                        options="{'model': 'contract.contract'}"
+                    />
+                </group>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The wizard to invoice manually was not displayed properly.
I also allow to choose to invoice only the manually invoiced contracts or not.
I removed the button to view the contracts as this is there by default in contract module.

cc @tobiaszehntner 