### PR TITLE
[18.0] [FIX] subscription_oca: add migration script for subscription_template_id field on product.template model 

### DIFF
--- a/subscription_oca/upgrades/18.0.1.0.0/pre-migration.py
+++ b/subscription_oca/upgrades/18.0.1.0.0/pre-migration.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Binhex (<https://www.binhex.cloud>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # PR OCA/contract#1060 made subscription_template_id a company-dependent field on
+    # product.template, but was never forward-ported beyond the version it targeted
+    # (v14). In Odoo 18.0, company-dependent fields are stored in a jsonb column instead
+    # of ir_property records. Since the forward-port never happened, the migration from
+    # ir_property to jsonb was not performed automatically, leaving the field empty.
+    # This query backfills product_template.subscription_template_id from the legacy
+    # ir_property rows so no data is lost after the upgrade.
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE product_template pt
+        SET subscription_template_id = split_part(ip.value_reference, ',', 2)::integer
+        FROM ir_property ip
+        WHERE ip.name = 'subscription_template_id'
+          AND pt.id = split_part(ip.res_id, ',', 2)::integer
+        """,
+    )


### PR DESCRIPTION
## Context

We discovered this issue during a customer migration from v14 to v18: the `subscription_template_id` field value for product templates is lost after upgrading to v18.

## Root Cause

#1060 made `subscription_template_id` a company-dependent field on `product.template`, but this change was never forward-ported beyond its target version (v14).

In Odoo 18.0, company-dependent fields are stored in a JSONB column instead of `ir_property` records. Since the forward-port never happened, the automatic migration from `ir_property` to JSONB did not occur, leaving the field empty after upgrade.

## Solution

This pull request adds a pre-migration script for Odoo 18.0 that backfills `product_template.subscription_template_id` from legacy `ir_property` records, ensuring existing data is preserved during the upgrade.

## Scope

This fix applies in a way that **only** instances affected by the company-dependent implementation of the `subscription_template_id` field will be targeted. Nothing changes or backfires if you're not affected.

## Migration and Data Integrity

- Added `pre-migration.py` to backfill `product_template.subscription_template_id` from legacy `ir_property` records
- Documented the root cause and provided context about the storage change for company-dependent fields