### PR TITLE
[18.0][FIX] contract: contracts from partners not yet invoiced

### DIFF
--- a/contract/views/res_partner_view.xml
+++ b/contract/views/res_partner_view.xml
@@ -14,7 +14,7 @@
                     groups="account.group_account_invoice"
                     icon="fa-book"
                     context="{'default_contract_type': 'sale', 'contract_type': 'sale'}"
-                    invisible="customer_rank == 0"
+                    invisible="sale_contract_count == 0"
                     help="Show the sale contracts for this partner"
                 >
                     <field
@@ -35,7 +35,7 @@
                     groups="account.group_account_invoice"
                     icon="fa-book"
                     context="{'default_contract_type': 'purchase', 'contract_type': 'purchase'}"
-                    invisible="supplier_rank == 0"
+                    invisible="purchase_contract_count == 0"
                     help="Show the purchase contracts for this partner"
                 >
                     <field


### PR DESCRIPTION
When we have a brand new customer or supplier, we could't see their contracts until those are invoiced and the customer/supplier rank counter is started. Better rely on the existing sale/purchase contracts counter.

<img width="773" height="194" alt="image" src="https://github.com/user-attachments/assets/5567e37a-a7e7-40af-8679-53750474ab3f" />


Should close:

- https://github.com/OCA/contract/issues/1412

cc @moduon MT-14364

please review @fcvalgar @Gelojr 