### PR TITLE
[18.0][FIX] contract: show smart buttons when partner has contracts

### DIFF
--- a/contract/views/res_partner_view.xml
+++ b/contract/views/res_partner_view.xml
@@ -14,7 +14,7 @@
                     groups="account.group_account_invoice"
                     icon="fa-book"
                     context="{'default_contract_type': 'sale', 'contract_type': 'sale'}"
-                    invisible="customer_rank == 0"
+                    invisible="customer_rank == 0 and sale_contract_count == 0"
                     help="Show the sale contracts for this partner"
                 >
                     <field
@@ -35,7 +35,7 @@
                     groups="account.group_account_invoice"
                     icon="fa-book"
                     context="{'default_contract_type': 'purchase', 'contract_type': 'purchase'}"
-                    invisible="supplier_rank == 0"
+                    invisible="supplier_rank == 0 and purchase_contract_count == 0"
                     help="Show the purchase contracts for this partner"
                 >
                     <field


### PR DESCRIPTION
## Summary
- The `Sale Contracts` and `Purchase Contracts` smart buttons on the partner form were hidden whenever `customer_rank == 0` / `supplier_rank == 0`. Partners created outside the Sales / Purchase flows (e.g. via the Contacts module) keep those ranks at 0, so users could not reach existing contracts from the partner form.
- Extended the `invisible` expression on each button to also consider `sale_contract_count` / `purchase_contract_count` (which are already rendered by the `statinfo` widget on the button). A button now shows whenever the partner has contracts of that type, regardless of rank. No change in behaviour when the rank is non-zero.

## Test plan
- [ ] Install `contract` on a clean 18.0 database.
- [ ] Create a contact from the Contacts module (do not create any sale order / vendor bill for them, so `customer_rank` and `supplier_rank` stay at 0).
- [ ] Create a sale contract for that contact → open the partner form → the `Sale Contracts` smart button is visible with count 1; the `Purchase Contracts` button stays hidden.
- [ ] Create a purchase contract for the same contact → both smart buttons are now visible with count 1.
- [ ] Verify a contact with rank 0 and no contracts still shows neither button (no regression).
- [ ] Added unit test `test_smart_button_visible_on_rank_zero_partner` in `contract/tests/test_contract.py`.

## Module maturity
- Production/Stable

Closes #1412