### PR TITLE
[16.0][FIX] Upgrade pre-commit dependency setuptools-odoo to v3.3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,7 +140,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements


### PR DESCRIPTION
That version avoids `ModuleNotFoundError: No module named 'pkg_resources'` when running the Git pre-commit hook, which causes an error in all CI runs.

See #1402 or #1419 for examples of 16.0 PRs failing because of this error, and acsone/setuptools-odoo#126 for some context on the error (caused by the recent removal on `pkg_resources` from `setuptools`) and how `setuptools-odoo` v3.3.2 fixes it.

Pre-commit hook configurations for 17.0 and 18.0 don't seem to depend on `setuptools-odoo`.  Similar changes may be ported back to 16.0 as a more stable fix, but the current one is a very simple, low-impact fix that may help unlock PRs right now.