### PR TITLE
[FIX] [18.0] subscription_oca: Restoring `invoice_send` functionality

### DIFF
--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -334,10 +334,11 @@ class SaleSubscription(models.Model):
             invoice = self.create_invoice()
             if self.template_id.invoicing_mode != "draft":
                 invoice.action_post()
-                mail_template = self.template_id.invoice_mail_template_id
-                self.env["account.move.send"]._generate_and_send_invoices(
-                    invoice, mail_template=mail_template, sending_methods=["email"]
-                )
+                if self.template_id.invoicing_mode == "invoice_send":
+                    mail_template = self.template_id.invoice_mail_template_id
+                    self.env["account.move.send"]._generate_and_send_invoices(
+                        invoice, mail_template=mail_template, sending_methods=["email"]
+                    )
                 invoice_number = invoice.name
                 message_body = (
                     f"<b>{msg_static}</b> "


### PR DESCRIPTION
Restore subscription template's `invoice_send` functionality. A much cleaner approach for invoice generation and sharing, this ensure that the state of the invoice is in `"invoice_send"` to generate and share invoice to the customer rather than generating and sharing it when `"!draft"`.