### PR TITLE
[IMP] subscription_oca:set invoice currency to subscription pricelist and ensure company context in create_invoice

### DIFF
--- a/subscription_oca/__manifest__.py
+++ b/subscription_oca/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Subscription management",
     "summary": "Generate recurring invoices.",
-    "version": "19.0.1.1.3",
+    "version": "19.0.1.1.4",
     "development_status": "Beta",
     "category": "Subscription Management",
     "website": "https://github.com/OCA/contract",
@@ -24,6 +24,7 @@
         "wizard/close_subscription_wizard.xml",
         "security/subscription_security.xml",
         "security/ir.model.access.csv",
+        "security/security.xml",
     ],
     "installable": True,
     "application": True,

--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -374,6 +374,7 @@ class SaleSubscription(models.Model):
         }
         if self.journal_id:
             values["journal_id"] = self.journal_id.id
+        values["currency_id"] = self.pricelist_id.currency_id.id
         return values
 
     def create_invoice(self):
@@ -382,6 +383,7 @@ class SaleSubscription(models.Model):
                 self.check_access("write")
             except AccessError:
                 return self.env["account.move"]
+        self = self.with_company(self.company_id)
         line_ids = []
         for line in self.sale_subscription_line_ids:
             line_values = line._prepare_account_move_line()

--- a/subscription_oca/security/security.xml
+++ b/subscription_oca/security/security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+    <record id="subscription_multi_company_rule" model="ir.rule">
+        <field name="name">Multi-Company Subscription Management</field>
+        <field name="model_id" ref="subscription_oca.model_sale_subscription" />
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+    </record>
+</odoo>

--- a/subscription_oca/tests/test_subscription_oca.py
+++ b/subscription_oca/tests/test_subscription_oca.py
@@ -791,3 +791,58 @@ class TestSubscriptionOCA(ProductCommon, BaseCommon):
             10.0,
             "Manual discount was lost after changing the quantity (Bug #1320)",
         )
+
+    def test_prepare_account_move_sets_pricelist_currency(self):
+        """Test that the invoice currency matches
+        the subscription pricelist currency."""
+        subscription = self.create_sub(
+            {
+                "pricelist_id": self.pricelist2.id,
+            }
+        )
+        vals = subscription._prepare_account_move([])
+        expected_currency_id = subscription.pricelist_id.currency_id.id
+        self.assertIn("currency_id", vals)
+        self.assertEqual(
+            vals["currency_id"],
+            expected_currency_id,
+            "The currency_id field must be equal to the currency of the pricelist.",
+        )
+
+    def test_create_invoice_uses_subscription_company(self):
+        """Test that the invoice is created in the subscription's company
+        and with the correct currency."""
+        company_alt = self.env["res.company"].create(
+            {"name": "Another Company", "currency_id": self.env.ref("base.USD").id}
+        )
+        sale_journal_alt = self.env["account.journal"].create(
+            {
+                "name": "Sale Journal Alt",
+                "type": "sale",
+                "code": "SALT",
+                "company_id": company_alt.id,
+            }
+        )
+        pricelist = self.env["product.pricelist"].create(
+            {"name": "Pricelist EUR", "currency_id": self.env.ref("base.EUR").id}
+        )
+        subscription = self.create_sub(
+            {
+                "company_id": company_alt.id,
+                "pricelist_id": pricelist.id,
+                "journal_id": sale_journal_alt.id,
+            }
+        )
+        invoice = subscription.create_invoice()
+        self.assertTrue(invoice, "The invoice should have been created successfully.")
+        self.assertEqual(
+            invoice.company_id,
+            subscription.company_id,
+            "The invoice must belong to the subscription's company (with_company).",
+        )
+        self.assertEqual(
+            invoice.currency_id,
+            subscription.pricelist_id.currency_id,
+            """The invoice must have the currency of the pricelist
+            defined in the subscription.""",
+        )

--- a/subscription_oca/views/sale_subscription_views.xml
+++ b/subscription_oca/views/sale_subscription_views.xml
@@ -343,6 +343,7 @@
                 <field name="to_renew" />
                 <field name="name" />
                 <field name="partner_id" />
+                <field name="code" />
                 <field name="template_id" />
                 <field name="user_id" />
                 <field name="date_start" />
@@ -353,11 +354,31 @@
                     name="pendingsubs"
                     domain="[('to_renew','=', True)]"
                 />
+                <filter
+                    name="active"
+                    string="Active"
+                    domain="[('active', '=', True)]"
+                />
+                <filter
+                    name="inactive"
+                    string="Inactive"
+                    domain="[('active', '=', False)]"
+                />
+                <filter
+                    name="in_progress"
+                    string="In Progress"
+                    domain="[('in_progress', '=', True)]"
+                />
                 <separator />
                 <filter
                     name="month_recurring_next_date"
                     string="Next invoice date"
                     date="recurring_next_date"
+                />
+                <filter
+                    name="filter_date_start"
+                    string="Start Date"
+                    date="date_start"
                 />
                 <group>
                     <filter


### PR DESCRIPTION
In multi-company and multi-currency setups, invoices generated from subscriptions may not consistently enforce:

The subscription pricelist currency on the created invoice.

The subscription company context during invoice creation.
This can lead to inconsistent invoice values or cross-company context issues in downstream implementations.

Describe the solution you'd like
Implement the following in subscription_oca:

1. Ensure invoice values explicitly set currency_id from subscription.pricelist_id.currency_id when preparing account.move values.

2. Ensure create_invoice runs under subscription.company_id context (with_company) before creating the invoice.

Also add unit tests to validate:

1. Invoice currency matches subscription pricelist currency.

2. Invoice company matches subscription company in multi-company scenarios.

3. Multi-Company Security: Ensure proper record rules are defined so users in multi-company environments don't face access errors or leakages.

4. Add search view in module

Describe alternatives you've considered

1. Keep this behavior in downstream custom modules only.

2. Override invoice creation in each deployment that needs strict multi-company/multi-currency behavior.

These alternatives duplicate logic across projects and increase maintenance cost compared to handling it upstream.

Additional context
I can submit a PR for 19.0 including implementation and tests.