### PR TITLE
[16.0][FIX] contract_forecast: Removed default values from related fields in res.config.settings

### DIFF
--- a/contract_forecast/models/res_config_settings.py
+++ b/contract_forecast/models/res_config_settings.py
@@ -10,18 +10,15 @@ class ResConfigSettings(models.TransientModel):
 
     enable_contract_forecast = fields.Boolean(
         string="Enable contract forecast",
-        default=True,
         readonly=False,
         related="company_id.enable_contract_forecast",
     )
     contract_forecast_interval = fields.Integer(
         string="Number of contract forecast Periods",
-        default=12,
         related="company_id.contract_forecast_interval",
         readonly=False,
     )
     contract_forecast_rule_type = fields.Selection(
-        default="monthly",
         related="company_id.contract_forecast_rule_type",
         readonly=False,
     )


### PR DESCRIPTION
Opening the Settings menu instanciates a new res.config.settings object, then applies the assigned values to revelant fields once we use the Save action.

The related field on these fields are intended to fetch the company values, then to apply the saved values to the related field afterwards. However, the assignment of default values on these fields means that, when creating a new res.config.settings instance, these default values are used, and then inversely applied to the related fields, meaning that if we are to use the Save action (which can happen if we quit the view), the default values always override the company values, unless we always go out of our way to the Invoicing tab and set the contract_forecast values to the desired values.

As such, we remove these default attributes, so that the res.config.settings instance doesn't override the company values whenever we open the Settings menu.

***Steps to reproduce the bug:***
1. Create a v16 instance of Odoo, with `contract_forecast` installed.
2. Go into the Settings menu
3. Go into the Invoicing tab and go to the Contract section
4. Set one of the Contract forecast to a different value (ie. disable Contract forecast, or set the forecast to 6 years)
5. Use the Save action
6. Go back to the Invoicing tab -> Contract section : the values will be reset to default