### PR TITLE
[18.0][IMP] contract: add monthly_recurring field to contracts and lines

### DIFF
--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -11,6 +11,17 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
+# Months equivalent per recurrence unit (to normalise amounts to monthly)
+_MONTHS_PER_RULE = {
+    "daily": 1.0 / 30.0,
+    "weekly": 7.0 / 30.0,
+    "monthly": 1.0,
+    "monthlylastday": 1.0,
+    "quarterly": 3.0,
+    "semesterly": 6.0,
+    "yearly": 12.0,
+}
+
 
 class ContractLine(models.Model):
     _name = "contract.line"
@@ -306,6 +317,28 @@ class ContractLine(models.Model):
             elif default_contract_type == "sale":
                 view_id = self.env.ref("contract.contract_line_customer_form_view").id
         return super().get_view(view_id, view_type, **options)
+
+    monthly_recurring = fields.Monetary(
+        compute="_compute_monthly_recurring",
+        store=True,
+        currency_field="currency_id",
+    )
+
+    @api.depends(
+        "display_type",
+        "price_subtotal",
+        "recurring_rule_type",
+        "recurring_interval",
+    )
+    def _compute_monthly_recurring(self):
+        for line in self:
+            if line.display_type:
+                line.monthly_recurring = 0.0
+                continue
+            months = _MONTHS_PER_RULE.get(line.recurring_rule_type, 1.0) * (
+                line.recurring_interval or 1
+            )
+            line.monthly_recurring = line.price_subtotal / months if months else 0.0
 
     def _get_quantity_to_invoice(
         self, period_first_date, period_last_date, invoice_date

--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -95,6 +95,11 @@
                 <field name="specific_price" column_invisible="True" />
                 <field name="discount" />
                 <field name="price_subtotal" />
+                <field
+                    name="monthly_recurring"
+                    optional="hide"
+                    sum="Total Monthly Recurring"
+                />
                 <field name="recurring_interval" column_invisible="True" />
                 <field name="recurring_rule_type" column_invisible="True" />
                 <field name="recurring_invoicing_type" column_invisible="True" />
@@ -127,6 +132,7 @@
         <field name="model">contract.line</field>
         <field name="arch" type="xml">
             <list>
+                <field name="currency_id" column_invisible="True" />
                 <field name="contract_id" />
                 <field name="partner_id" />
                 <field name="product_id" />
@@ -140,6 +146,11 @@
                 <field name="price_unit" />
                 <field name="discount" groups="base.group_no_one" />
                 <field name="price_subtotal" />
+                <field
+                    name="monthly_recurring"
+                    optional="hide"
+                    sum="Total Monthly Recurring"
+                />
                 <field name="date_start" />
                 <field name="date_end" />
                 <field name="recurring_interval" />
@@ -163,6 +174,17 @@
                 <field name="date_end" />
                 <field name="recurring_next_date" />
                 <field name="last_date_invoiced" />
+                <filter
+                    string="In progress"
+                    name="in_progress"
+                    domain="[
+                        ('is_canceled', '=', False),
+                        ('date_start', '&lt;=', context_today().strftime('%Y-%m-%d')),
+                        '|',
+                        ('date_end', '=', False),
+                        ('date_end', '&gt;=', context_today().strftime('%Y-%m-%d')),
+                    ]"
+                />
                 <separator />
                 <group expand="0" string="Group By...">
                     <filter
@@ -213,9 +235,7 @@
         <field name="arch" type="xml">
             <pivot>
                 <field name="contract_id" type="row" />
-                <field name="date_start" interval="month" type="col" />
-                <field name="quantity" type="measure" />
-                <field name="specific_price" type="measure" />
+                <field name="monthly_recurring" type="measure" />
             </pivot>
         </field>
     </record>
@@ -228,7 +248,7 @@
         <field name="path">supplier-contract-lines</field>
         <field name="domain">[('contract_id.contract_type', '=', 'purchase')]</field>
         <field name="context">
-            {'search_default_group_by_contract': 1}
+            {'search_default_group_by_contract': 1, 'search_default_in_progress': 1}
         </field>
         <field name="search_view_id" ref="contract_line_search_view" />
         <field name="view_id" ref="contract_line_report_tree_view" />
@@ -241,7 +261,7 @@
         <field name="path">customer-contract-lines</field>
         <field name="domain">[('contract_id.contract_type', '=', 'sale')]</field>
         <field name="context">
-            {'search_default_group_by_contract': 1}
+            {'search_default_group_by_contract': 1, 'search_default_in_progress': 1}
         </field>
         <field name="search_view_id" ref="contract_line_search_view" />
         <field name="view_id" ref="contract_line_report_tree_view" />


### PR DESCRIPTION
Add a new stored monetary field `monthly_recurring` on `contract.line` and `contract.contract` that normalises each line's amount to its monthly equivalent based on its recurrence rule and interval.

It is optional (hidden by default) in all list views and shows a sum in the footer, allowing users to see the total recurring monthly amount across all contracts and lines at a glance. Non-active lines can be excluded using the existing "In progress" filter.

@Tecnativa TT62575
@pedrobaeza @christian-ramos-tecnativa 