### PR TITLE
[19.0][IMP] subscription_oca: add multi-company security rules

### DIFF
--- a/subscription_oca/__manifest__.py
+++ b/subscription_oca/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Subscription management",
     "summary": "Generate recurring invoices.",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "development_status": "Beta",
     "category": "Subscription Management",
     "website": "https://github.com/OCA/contract",
@@ -22,6 +22,7 @@
         "data/ir_cron.xml",
         "data/sale_subscription_data.xml",
         "wizard/close_subscription_wizard.xml",
+        "security/subscription_security.xml",
         "security/ir.model.access.csv",
     ],
     "installable": True,

--- a/subscription_oca/security/subscription_security.xml
+++ b/subscription_oca/security/subscription_security.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 Domatix - Alvaro Domatix
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="sale_subscription_company_rule" model="ir.rule">
+        <field name="name">Subscription: multi-company rule</field>
+        <field name="model_id" ref="model_sale_subscription" />
+        <field name="global" eval="True" />
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+
+    <record id="sale_subscription_line_company_rule" model="ir.rule">
+        <field name="name">Subscription Line: multi-company rule</field>
+        <field name="model_id" ref="model_sale_subscription_line" />
+        <field name="global" eval="True" />
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+</odoo>

--- a/subscription_oca/tests/__init__.py
+++ b/subscription_oca/tests/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_subscription_oca
+from . import test_subscription_security

--- a/subscription_oca/tests/test_subscription_security.py
+++ b/subscription_oca/tests/test_subscription_security.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Domatix - Alvaro Domatix
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import AccessError
+from odoo.tests.common import new_test_user
+
+from odoo.addons.base.tests.common import BaseCommon
+
+
+class TestSubscriptionSecurity(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        cls.company_a = cls.env["res.company"].create({"name": "Company A"})
+        cls.company_b = cls.env["res.company"].create({"name": "Company B"})
+
+        cls.user_company_a = new_test_user(
+            cls.env,
+            login="subscription_oca_user_company_a",
+            groups="sales_team.group_sale_salesman",
+            company_id=cls.company_a.id,
+            company_ids=[(6, 0, [cls.company_a.id])],
+        )
+        cls.user_company_b = new_test_user(
+            cls.env,
+            login="subscription_oca_user_company_b",
+            groups="sales_team.group_sale_salesman",
+            company_id=cls.company_b.id,
+            company_ids=[(6, 0, [cls.company_b.id])],
+        )
+
+        cls.pricelist_a = cls.env["product.pricelist"].create(
+            {"name": "Pricelist A", "company_id": cls.company_a.id}
+        )
+        cls.pricelist_b = cls.env["product.pricelist"].create(
+            {"name": "Pricelist B", "company_id": cls.company_b.id}
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Multi-company partner"})
+        cls.template = cls.env["sale.subscription.template"].create(
+            {
+                "name": "Multi-company template",
+                "code": "MC-TMPL",
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {"name": "Multi-company product", "subscribable": True}
+        )
+
+        cls.subscription_a = cls.env["sale.subscription"].create(
+            {
+                "company_id": cls.company_a.id,
+                "partner_id": cls.partner.id,
+                "template_id": cls.template.id,
+                "pricelist_id": cls.pricelist_a.id,
+            }
+        )
+        cls.subscription_b = cls.env["sale.subscription"].create(
+            {
+                "company_id": cls.company_b.id,
+                "partner_id": cls.partner.id,
+                "template_id": cls.template.id,
+                "pricelist_id": cls.pricelist_b.id,
+            }
+        )
+        cls.line_a = cls.env["sale.subscription.line"].create(
+            {
+                "sale_subscription_id": cls.subscription_a.id,
+                "product_id": cls.product.id,
+            }
+        )
+        cls.line_b = cls.env["sale.subscription.line"].create(
+            {
+                "sale_subscription_id": cls.subscription_b.id,
+                "product_id": cls.product.id,
+            }
+        )
+
+    def test_user_can_read_own_company_subscription(self):
+        subscription = self.subscription_a.with_user(self.user_company_a)
+        subscription.read(["name"])
+
+    def test_user_cannot_read_other_company_subscription(self):
+        subscription = self.subscription_b.with_user(self.user_company_a)
+        with self.assertRaises(AccessError):
+            subscription.read(["name"])
+
+    def test_user_cannot_search_other_company_subscription(self):
+        found = (
+            self.env["sale.subscription"]
+            .with_user(self.user_company_a)
+            .search([("id", "=", self.subscription_b.id)])
+        )
+        self.assertFalse(found)
+
+    def test_user_cannot_read_other_company_subscription_line(self):
+        line = self.line_b.with_user(self.user_company_a)
+        with self.assertRaises(AccessError):
+            line.read(["name"])
+
+    def test_user_can_read_own_company_subscription_line(self):
+        line = self.line_a.with_user(self.user_company_a)
+        line.read(["name"])
+
+    def test_user_cannot_write_other_company_subscription(self):
+        # The rule applies to write too, not only read/search.
+        subscription = self.subscription_b.with_user(self.user_company_a)
+        with self.assertRaises(AccessError):
+            subscription.write({"description": "hack"})
+
+    def test_company_b_user_cannot_read_company_a_subscription(self):
+        # Symmetry: isolation works both ways.
+        subscription = self.subscription_a.with_user(self.user_company_b)
+        with self.assertRaises(AccessError):
+            subscription.read(["name"])


### PR DESCRIPTION
The module ships ACLs but no record rules, so in a multi-company setup a salesman from company A can read and edit the subscriptions of company B.

This adds the usual multi-company record rules for `sale.subscription` and `sale.subscription.line` (lines follow the company of their subscription), with tests checking that users only see subscriptions of their allowed companies.
