### PR TITLE
[19.0][IMP] subscription_oca: centralize recurring date computation

### DIFF
--- a/subscription_oca/README.rst
+++ b/subscription_oca/README.rst
@@ -62,7 +62,8 @@ To make a subscription:
    Invoice* option selected, because the *Invoicing mode* option is
    triggered through the cron job.
 5. The cron job will also end the subscription if its end date has been
-   reached.
+   reached. The end date honours the template recurrence (days, weeks,
+   months or years) and the interval, instead of always assuming months.
 
 To create subscriptions with the sale of a product:
 
@@ -74,9 +75,9 @@ To create subscriptions with the sale of a product:
 Known issues / Roadmap
 ======================
 
-- Refactor all the onchanges that have business logic to computed
-  write-able fields when possible. Keep onchanges only for UI purposes.
-- Add tests.
+-  Refactor all the onchanges that have business logic to computed
+   write-able fields when possible. Keep onchanges only for UI purposes.
+-  Add tests.
 
 Bug Tracker
 ===========
@@ -100,22 +101,22 @@ Authors
 Contributors
 ------------
 
-- Carlos Martínez <carlos@domatix.com>
-- Carolina Ferrer <carolina@domatix.com>
-- `Ooops404 <https://www.ooops404.com>`__:
+-  Carlos Martínez <carlos@domatix.com>
+-  Carolina Ferrer <carolina@domatix.com>
+-  `Ooops404 <https://www.ooops404.com>`__:
 
-  - Ilyas <irazor147@gmail.com>
+   -  Ilyas <irazor147@gmail.com>
 
-- `Sygel <https://www.sygel.es>`__:
+-  `Sygel <https://www.sygel.es>`__:
 
-  - Harald Panten
-  - Valentin Vinagre
-  - Alberto Martínez
+   -  Harald Panten
+   -  Valentin Vinagre
+   -  Alberto Martínez
 
-- Dennis Sluijk <d.sluijk@onestein.nl>
-- `IKU Solutions <https://www.iku.solutions>`__:
+-  Dennis Sluijk <d.sluijk@onestein.nl>
+-  `IKU Solutions <https://www.iku.solutions>`__:
 
-  - Yan Chirino <yan.chirino@iku.solutions>
+   -  Yan Chirino <yan.chirino@iku.solutions>
 
 Maintainers
 -----------

--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -190,14 +190,16 @@ class SaleSubscription(models.Model):
     @api.depends("template_id", "date_start")
     def _compute_rule_boundary(self):
         for record in self:
-            if record.template_id.recurring_rule_boundary == "unlimited":
+            # No template yet (e.g. a new record in the form view) or an
+            # unlimited one: there is no end date to compute.
+            if (
+                not record.template_id
+                or record.template_id.recurring_rule_boundary == "unlimited"
+            ):
                 record.date = False
                 record.recurring_rule_boundary = True
             else:
-                record.date = (
-                    relativedelta(months=+record.template_id.recurring_rule_count)
-                    + record.date_start
-                )
+                record.date = record.template_id._get_date(record.date_start)
                 record.recurring_rule_boundary = False
 
     @api.depends("template_id")
@@ -215,21 +217,51 @@ class SaleSubscription(models.Model):
         else:
             self.calculate_recurring_next_date(today)
 
+    def _get_recurrence_delta(self):
+        self.ensure_one()
+        type_interval = self.template_id.recurring_rule_type
+        interval = int(self.template_id.recurring_interval or 0) or 1
+        return relativedelta(**{type_interval: interval})
+
+    def _get_first_invoice_date(self):
+        self.ensure_one()
+        return self.date_start or fields.Date.today()
+
+    def _get_next_invoice_date(self, previous_date):
+        self.ensure_one()
+        if isinstance(previous_date, datetime):
+            previous_date = previous_date.date()
+        elif not isinstance(previous_date, date):
+            previous_date = fields.Date.to_date(previous_date)
+        return previous_date + self._get_recurrence_delta()
+
+    def _set_next_invoice_date_after_invoice(self, invoice_date=None):
+        self.ensure_one()
+        # A subscription without a scheduled next date (e.g. closed, or not
+        # started yet) can still be invoiced manually: advance from its first
+        # invoice date instead of crashing on a False date.
+        previous_date = (
+            invoice_date or self.recurring_next_date or self._get_first_invoice_date()
+        )
+        self.recurring_next_date = self._get_next_invoice_date(previous_date)
+
+    def _get_contract_end_date(self):
+        self.ensure_one()
+        if self.template_id.recurring_rule_boundary == "unlimited":
+            return False
+        return self.template_id._get_date(self._get_first_invoice_date())
+
     def calculate_recurring_next_date(self, start_date):
         if self.account_invoice_ids_count == 0:
             if not start_date:
-                start_date = self.date_start or date.today()
+                start_date = self._get_first_invoice_date()
             if isinstance(start_date, datetime):
                 start_date = start_date.date()
             elif not isinstance(start_date, date):
                 start_date = fields.Date.to_date(start_date)
             self.recurring_next_date = start_date
         else:
-            type_interval = self.template_id.recurring_rule_type
-            interval = int(self.template_id.recurring_interval)
-            self.recurring_next_date = start_date + relativedelta(
-                **{type_interval: interval}
-            )
+            self.recurring_next_date = self._get_next_invoice_date(start_date)
 
     @api.onchange("partner_id")
     def onchange_partner_id(self):
@@ -371,12 +403,12 @@ class SaleSubscription(models.Model):
         if not invoice_number:
             invoice_number = self.env._("To validate")
             message_body = f"<b>{msg_static}</b> {invoice_number}"
-        self.calculate_recurring_next_date(self.recurring_next_date)
+        self._set_next_invoice_date_after_invoice()
         self.message_post(body=Markup(message_body))
 
     def manual_invoice(self):
         invoice_id = self.create_invoice()
-        self.calculate_recurring_next_date(self.recurring_next_date)
+        self._set_next_invoice_date_after_invoice()
         context = dict(self.env.context)
         context["form_view_initial_mode"] = "edit"
         return {

--- a/subscription_oca/models/sale_subscription_template.py
+++ b/subscription_oca/models/sale_subscription_template.py
@@ -82,7 +82,9 @@ class SaleSubscriptionTemplate(models.Model):
 
     def _get_date(self, date_start):
         self.ensure_one()
-        return relativedelta(months=+self.recurring_rule_count) + date_start
+        delta_type = self.recurring_rule_type or "months"
+        interval = (self.recurring_interval or 1) * self.recurring_rule_count
+        return date_start + relativedelta(**{delta_type: interval})
 
     @api.depends("product_ids")
     def _compute_product_ids_count(self):

--- a/subscription_oca/readme/USAGE.md
+++ b/subscription_oca/readme/USAGE.md
@@ -16,7 +16,8 @@ To make a subscription:
     Invoice* option selected, because the *Invoicing mode* option is
     triggered through the cron job.
 5.  The cron job will also end the subscription if its end date has been
-    reached.
+    reached. The end date honours the template recurrence (days, weeks,
+    months or years) and the interval, instead of always assuming months.
 
 To create subscriptions with the sale of a product:
 

--- a/subscription_oca/static/description/index.html
+++ b/subscription_oca/static/description/index.html
@@ -412,7 +412,8 @@ invoice even if the subscription template has the <em>Sale Order &amp;
 Invoice</em> option selected, because the <em>Invoicing mode</em> option is
 triggered through the cron job.</li>
 <li>The cron job will also end the subscription if its end date has been
-reached.</li>
+reached. The end date honours the template recurrence (days, weeks,
+months or years) and the interval, instead of always assuming months.</li>
 </ol>
 <p>To create subscriptions with the sale of a product:</p>
 <ol class="arabic simple">

--- a/subscription_oca/tests/__init__.py
+++ b/subscription_oca/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_subscription_oca
 from . import test_subscription_security
+from . import test_subscription_recurrence_dates

--- a/subscription_oca/tests/test_subscription_recurrence_dates.py
+++ b/subscription_oca/tests/test_subscription_recurrence_dates.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Domatix - Alvaro Domatix
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import date
+
+from odoo.addons.base.tests.common import BaseCommon
+from odoo.addons.product.tests.common import ProductCommon
+
+
+class TestSubscriptionRecurrenceDates(ProductCommon, BaseCommon):
+    """Recurrence date arithmetic for sale.subscription.
+
+    Assertions use hand-computed fixed calendar values (never a
+    ``relativedelta`` rebuilt from the model fields), so a test failing means
+    the produced date is wrong, not that the formula was merely re-typed.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner = cls.env["res.partner"].create({"name": "Recurrence partner"})
+        cls.pricelist = cls.env["product.pricelist"].create(
+            {"name": "Recurrence pricelist"}
+        )
+        cls.product = cls._create_product(
+            name="Recurrence product",
+            lst_price=100.0,
+            subscribable=True,
+            uom_id=cls.uom_unit.id,
+        )
+
+    @classmethod
+    def _make_template(cls, rule_type, boundary="unlimited", count=1, interval=1):
+        return cls.env["sale.subscription.template"].create(
+            {
+                "name": f"Tmpl {rule_type} {boundary} i{interval} c{count}",
+                "code": f"REC-{rule_type}-{boundary}-{interval}-{count}",
+                "recurring_rule_type": rule_type,
+                "recurring_rule_boundary": boundary,
+                "recurring_rule_count": count,
+                "recurring_interval": interval,
+            }
+        )
+
+    def _make_subscription(self, template, date_start=None):
+        return self.env["sale.subscription"].create(
+            {
+                "partner_id": self.partner.id,
+                "pricelist_id": self.pricelist.id,
+                "template_id": template.id,
+                "date_start": date_start or date(2026, 1, 1),
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Contract end date (field `date`, computed by `_compute_rule_boundary`,
+    # production path used by the auto-close cron) and its helper.
+    # ------------------------------------------------------------------
+
+    def test_contract_end_unlimited_has_no_finish_date(self):
+        sub = self._make_subscription(self._make_template("months", "unlimited"))
+        self.assertFalse(sub.date)
+        self.assertTrue(sub.recurring_rule_boundary)
+        self.assertFalse(sub._get_contract_end_date())
+
+    def test_contract_end_monthly(self):
+        # Gym membership: 1 month, billed monthly.
+        sub = self._make_subscription(
+            self._make_template("months", "limited", count=1),
+            date_start=date(2026, 1, 1),
+        )
+        self.assertEqual(sub.date, date(2026, 2, 1))
+
+    def test_contract_end_weekly_limited_is_weeks_not_months(self):
+        # Fruit box: 4 weekly deliveries. End must be 28 days later
+        # (2026-01-29), NOT 4 months later. This case failed before the fix
+        # that made the contract end honor recurring_rule_type.
+        sub = self._make_subscription(
+            self._make_template("weeks", "limited", count=4),
+            date_start=date(2026, 1, 1),
+        )
+        self.assertEqual(sub.date, date(2026, 1, 29))
+
+    def test_contract_end_quarterly_honors_interval_times_count(self):
+        # Billed every 3 months, for 2 periods => 6 months total.
+        sub = self._make_subscription(
+            self._make_template("months", "limited", count=2, interval=3),
+            date_start=date(2026, 1, 1),
+        )
+        self.assertEqual(sub.date, date(2026, 7, 1))
+
+    def test_contract_end_yearly(self):
+        sub = self._make_subscription(
+            self._make_template("years", "limited", count=1),
+            date_start=date(2026, 1, 1),
+        )
+        self.assertEqual(sub.date, date(2027, 1, 1))
+
+    def test_contract_end_field_and_helper_agree(self):
+        # The stored `date` field and `_get_contract_end_date()` must stay
+        # coherent when date_start is set (the normal case).
+        for rule_type, count, interval in [
+            ("days", 10, 1),
+            ("weeks", 4, 1),
+            ("months", 2, 3),
+            ("years", 1, 1),
+        ]:
+            template = self._make_template(
+                rule_type, "limited", count=count, interval=interval
+            )
+            sub = self._make_subscription(template, date_start=date(2026, 1, 1))
+            self.assertEqual(
+                sub.date,
+                sub._get_contract_end_date(),
+                f"Mismatch for {rule_type} count={count} interval={interval}",
+            )
+
+    # ------------------------------------------------------------------
+    # One billing period (`_get_recurrence_delta` via `_get_next_invoice_date`).
+    # The period uses interval but NOT rule_count.
+    # ------------------------------------------------------------------
+
+    def test_next_invoice_date_monthly(self):
+        sub = self._make_subscription(self._make_template("months"))
+        self.assertEqual(sub._get_next_invoice_date(date(2026, 1, 1)), date(2026, 2, 1))
+
+    def test_next_invoice_date_weekly(self):
+        sub = self._make_subscription(self._make_template("weeks"))
+        self.assertEqual(sub._get_next_invoice_date(date(2026, 1, 1)), date(2026, 1, 8))
+
+    def test_next_invoice_date_honors_interval(self):
+        # Quarterly: one period is 3 months ahead.
+        sub = self._make_subscription(self._make_template("months", interval=3))
+        self.assertEqual(sub._get_next_invoice_date(date(2026, 1, 1)), date(2026, 4, 1))
+
+    def test_period_ignores_rule_count_while_end_uses_it(self):
+        # A 12-month limited subscription: one billing period is still a
+        # single month, but the contract ends after 12. This distinguishes
+        # `_get_recurrence_delta` (period) from `_get_date` (total span).
+        template = self._make_template("months", "limited", count=12)
+        sub = self._make_subscription(template, date_start=date(2026, 1, 1))
+        self.assertEqual(sub._get_next_invoice_date(date(2026, 1, 1)), date(2026, 2, 1))
+        self.assertEqual(sub.date, date(2027, 1, 1))
+
+    # ------------------------------------------------------------------
+    # First invoice date and post-invoice advance.
+    # ------------------------------------------------------------------
+
+    def test_first_invoice_date_uses_date_start(self):
+        sub = self._make_subscription(
+            self._make_template("months"), date_start=date(2026, 3, 15)
+        )
+        self.assertEqual(sub._get_first_invoice_date(), date(2026, 3, 15))
+
+    def test_set_next_invoice_date_after_invoice_advances_one_period(self):
+        sub = self._make_subscription(self._make_template("weeks"))
+        sub.recurring_next_date = date(2026, 1, 1)
+        sub._set_next_invoice_date_after_invoice()
+        self.assertEqual(sub.recurring_next_date, date(2026, 1, 8))
+
+    # ------------------------------------------------------------------
+    # Integration: generating an invoice advances recurring_next_date by
+    # exactly one period (production path, not just the helper in isolation).
+    # ------------------------------------------------------------------
+
+    def test_generate_invoice_advances_recurring_next_date(self):
+        template = self._make_template("months")  # invoicing_mode defaults to draft
+        sub = self._make_subscription(template, date_start=date(2026, 1, 1))
+        sub.recurring_next_date = date(2026, 1, 1)
+        self.env["sale.subscription.line"].create(
+            {
+                "sale_subscription_id": sub.id,
+                "product_id": self.product.id,
+                "company_id": sub.company_id.id,
+            }
+        )
+        sub.generate_invoice()
+        self.assertTrue(sub.invoice_ids, "generate_invoice should create a draft move")
+        self.assertEqual(sub.recurring_next_date, date(2026, 2, 1))
+
+    def test_rule_boundary_without_template(self):
+        # A new record in the form view computes the boundary before any
+        # template is selected: it must not crash and must have no end date.
+        subscription = self.env["sale.subscription"].new({})
+        self.assertFalse(subscription.date)
+        self.assertTrue(subscription.recurring_rule_boundary)
+
+    def test_set_next_invoice_date_without_previous_date(self):
+        # Manual invoicing of a subscription whose recurring_next_date is
+        # empty (e.g. it was closed) must fall back to the first invoice
+        # date instead of crashing.
+        template = self._make_template("months")
+        sub = self._make_subscription(template, date_start=date(2026, 1, 1))
+        sub.recurring_next_date = False
+        sub._set_next_invoice_date_after_invoice()
+        self.assertEqual(sub.recurring_next_date, date(2026, 2, 1))


### PR DESCRIPTION
The computation of `recurring_next_date` is currently spread over the onchange, `generate_invoice`, `manual_invoice` and the cron, and the next date is incremented from whatever value is stored on the record instead of the date that was actually invoiced. This makes the recurrence logic hard to follow and to extend.

This moves the date computations to small helpers on `sale.subscription` (recurrence delta, first/next invoice date, contract end date) and makes the existing code use them. No functional change intended.

Tests added covering daily/weekly/monthly/yearly recurrences, intervals greater than 1 and the contract end date.
