### PR TITLE
[IMP] subscription_oca: compute MRR and ARR

### DIFF
--- a/subscription_oca/__manifest__.py
+++ b/subscription_oca/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Subscription management",
     "summary": "Generate recurring invoices.",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "development_status": "Beta",
     "category": "Subscription Management",
     "website": "https://github.com/OCA/contract",

--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -95,6 +95,18 @@ class SaleSubscription(models.Model):
     )
     amount_tax = fields.Monetary(compute="_compute_total", store=True)
     amount_total = fields.Monetary(compute="_compute_total", store=True)
+    recurring_monthly = fields.Monetary(
+        string="Monthly recurring revenue",
+        compute="_compute_mrr",
+        store=True,
+        help="Sum of the subscription lines normalised to a monthly amount.",
+    )
+    recurring_yearly = fields.Monetary(
+        string="Annual recurring revenue",
+        compute="_compute_mrr",
+        store=True,
+        help="Twelve times the monthly recurring revenue.",
+    )
     tag_ids = fields.Many2many(comodel_name="sale.subscription.tag", string="Tags")
     image = fields.Binary("Image", related="user_id.image_512", store=True)
     journal_id = fields.Many2one(comodel_name="account.journal", string="Journal")
@@ -178,6 +190,13 @@ class SaleSubscription(models.Model):
                     "amount_total": recurring_total + amount_tax,
                 }
             )
+
+    @api.depends("sale_subscription_line_ids.recurring_monthly")
+    def _compute_mrr(self):
+        for record in self:
+            monthly = sum(record.sale_subscription_line_ids.mapped("recurring_monthly"))
+            record.recurring_monthly = monthly
+            record.recurring_yearly = monthly * 12.0
 
     @api.depends("template_id", "code")
     def _compute_name(self):

--- a/subscription_oca/models/sale_subscription_line.py
+++ b/subscription_oca/models/sale_subscription_line.py
@@ -3,6 +3,14 @@
 from odoo import Command, api, fields, models
 from odoo.tools.misc import get_lang
 
+_AVG_DAYS_PER_MONTH = 30.4375
+_PERIOD_LENGTH_IN_MONTHS = {
+    "days": 1 / _AVG_DAYS_PER_MONTH,
+    "weeks": 7 / _AVG_DAYS_PER_MONTH,
+    "months": 1.0,
+    "years": 12.0,
+}
+
 
 class SaleSubscriptionLine(models.Model):
     _name = "sale.subscription.line"
@@ -49,6 +57,13 @@ class SaleSubscriptionLine(models.Model):
     amount_tax_line_amount = fields.Float(
         string="Taxes Amount", compute="_compute_subtotal", store=True
     )
+    recurring_monthly = fields.Monetary(
+        string="Monthly recurring revenue",
+        compute="_compute_recurring_monthly",
+        store=True,
+        help="Subtotal of this line normalised to a monthly amount, "
+        "based on the template recurrence.",
+    )
     sale_subscription_id = fields.Many2one(
         comodel_name="sale.subscription", string="Subscription"
     )
@@ -78,6 +93,26 @@ class SaleSubscriptionLine(models.Model):
                     "price_total": taxes["total_included"],
                     "price_subtotal": taxes["total_excluded"],
                 }
+            )
+
+    @api.depends(
+        "price_subtotal",
+        "sale_subscription_id.template_id.recurring_rule_type",
+        "sale_subscription_id.template_id.recurring_interval",
+    )
+    def _compute_recurring_monthly(self):
+        for record in self:
+            template = record.sale_subscription_id.template_id
+            if not template:
+                record.recurring_monthly = 0.0
+                continue
+            interval = max(template.recurring_interval or 1, 1)
+            period_months = (
+                _PERIOD_LENGTH_IN_MONTHS.get(template.recurring_rule_type, 1.0)
+                * interval
+            )
+            record.recurring_monthly = (
+                record.price_subtotal / period_months if period_months else 0.0
             )
 
     @api.depends("product_id")

--- a/subscription_oca/tests/__init__.py
+++ b/subscription_oca/tests/__init__.py
@@ -1,3 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import test_subscription_oca
+from . import test_subscription_mrr, test_subscription_oca

--- a/subscription_oca/tests/test_subscription_mrr.py
+++ b/subscription_oca/tests/test_subscription_mrr.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Domatix - Alvaro
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.base.tests.common import BaseCommon
+from odoo.addons.product.tests.common import ProductCommon
+
+
+class TestSubscriptionMRR(ProductCommon, BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.pricelist = cls.env["product.pricelist"].create({"name": "MRR pricelist"})
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "MRR test partner",
+                "property_product_pricelist": cls.pricelist.id,
+            }
+        )
+        cls.product = cls._create_product(
+            name="MRR product",
+            lst_price=120.0,
+            subscribable=True,
+            uom_id=cls.uom_unit.id,
+            taxes_id=[(6, 0, [])],
+        )
+        cls.stage_draft = cls.env["sale.subscription.stage"].search(
+            [("type", "=", "draft")], limit=1
+        )
+
+    @classmethod
+    def _create_template(cls, rule_type, interval=1):
+        return cls.env["sale.subscription.template"].create(
+            {
+                "name": f"Tmpl {rule_type} {interval}",
+                "code": f"T{rule_type[0].upper()}{interval}",
+                "recurring_rule_type": rule_type,
+                "recurring_interval": interval,
+            }
+        )
+
+    def _create_subscription(self, template, price_unit=120.0, qty=1.0):
+        subscription = self.env["sale.subscription"].create(
+            {
+                "partner_id": self.partner.id,
+                "template_id": template.id,
+                "pricelist_id": self.pricelist.id,
+                "stage_id": self.stage_draft.id,
+            }
+        )
+        self.env["sale.subscription.line"].create(
+            {
+                "sale_subscription_id": subscription.id,
+                "product_id": self.product.id,
+                "product_uom_qty": qty,
+                "price_unit": price_unit,
+                "tax_ids": [(6, 0, [])],
+            }
+        )
+        return subscription
+
+    def test_mrr_monthly_template_equals_subtotal(self):
+        tmpl = self._create_template("months", 1)
+        sub = self._create_subscription(tmpl, price_unit=120.0)
+        self.assertAlmostEqual(sub.recurring_monthly, sub.recurring_total, 2)
+
+    def test_mrr_yearly_template_is_one_twelfth(self):
+        tmpl = self._create_template("years", 1)
+        sub = self._create_subscription(tmpl, price_unit=1200.0)
+        self.assertAlmostEqual(sub.recurring_monthly, 100.0, 2)
+
+    def test_mrr_weekly_template_uses_factor(self):
+        # 1 week == 7/30.4375 months, so MRR = subtotal / (7/30.4375)
+        tmpl = self._create_template("weeks", 1)
+        sub = self._create_subscription(tmpl, price_unit=100.0)
+        self.assertAlmostEqual(sub.recurring_monthly, 100.0 * 30.4375 / 7, 2)
+
+    def test_mrr_daily_template_uses_factor(self):
+        # 1 day == 1/30.4375 months, so MRR = subtotal * 30.4375
+        tmpl = self._create_template("days", 1)
+        sub = self._create_subscription(tmpl, price_unit=10.0)
+        self.assertAlmostEqual(sub.recurring_monthly, 10.0 * 30.4375, 2)
+
+    def test_mrr_respects_recurring_interval(self):
+        # 3-month interval at 300 -> MRR == 100
+        tmpl = self._create_template("months", 3)
+        sub = self._create_subscription(tmpl, price_unit=300.0)
+        self.assertAlmostEqual(sub.recurring_monthly, 100.0, 2)
+
+    def test_mrr_aggregates_over_lines(self):
+        tmpl = self._create_template("months", 1)
+        sub = self._create_subscription(tmpl, price_unit=120.0)
+        self.env["sale.subscription.line"].create(
+            {
+                "sale_subscription_id": sub.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1.0,
+                "price_unit": 80.0,
+                "tax_ids": [(6, 0, [])],
+            }
+        )
+        self.assertAlmostEqual(sub.recurring_monthly, 200.0, 2)
+
+    def test_arr_is_12x_mrr(self):
+        tmpl = self._create_template("months", 1)
+        sub = self._create_subscription(tmpl, price_unit=150.0)
+        self.assertAlmostEqual(sub.recurring_yearly, sub.recurring_monthly * 12, 2)
+
+    def test_mrr_recomputes_after_qty_change(self):
+        tmpl = self._create_template("months", 1)
+        sub = self._create_subscription(tmpl, price_unit=100.0, qty=1.0)
+        line = sub.sale_subscription_line_ids
+        self.assertAlmostEqual(sub.recurring_monthly, 100.0, 2)
+        line.product_uom_qty = 3.0
+        self.assertAlmostEqual(sub.recurring_monthly, 300.0, 2)
+
+    def test_mrr_recomputes_after_template_recurrence_change(self):
+        tmpl_monthly = self._create_template("months", 1)
+        tmpl_yearly = self._create_template("years", 1)
+        sub = self._create_subscription(tmpl_monthly, price_unit=1200.0)
+        self.assertAlmostEqual(sub.recurring_monthly, 1200.0, 2)
+        sub.template_id = tmpl_yearly
+        self.assertAlmostEqual(sub.recurring_monthly, 100.0, 2)

--- a/subscription_oca/views/sale_subscription_views.xml
+++ b/subscription_oca/views/sale_subscription_views.xml
@@ -57,6 +57,30 @@
                                 string="Invoices"
                             />
                         </button>
+                        <button
+                            type="object"
+                            name="action_view_account_invoice_ids"
+                            class="oe_stat_button"
+                            icon="fa-line-chart"
+                            invisible="not recurring_monthly"
+                        >
+                            <div class="o_stat_info">
+                                <field
+                                    name="recurring_monthly"
+                                    widget="monetary"
+                                    options="{'currency_field': 'currency_id'}"
+                                    class="o_stat_value"
+                                />
+                                <span class="o_stat_text">MRR</span>
+                                <field
+                                    name="recurring_yearly"
+                                    widget="monetary"
+                                    options="{'currency_field': 'currency_id'}"
+                                    class="text-muted small"
+                                />
+                                <span class="text-muted small">ARR</span>
+                            </div>
+                        </button>
                     </div>
                     <widget
                         name="web_ribbon"
@@ -208,6 +232,8 @@
                 <field name="recurring_total" sum="Total subtotal" optional="show" />
                 <field name="amount_tax" sum="Total Tax" optional="show" />
                 <field name="amount_total" sum="Total" optional="show" />
+                <field name="recurring_monthly" sum="Total MRR" optional="show" />
+                <field name="recurring_yearly" sum="Total ARR" optional="hide" />
                 <field name="template_id" optional="show" />
                 <field name="stage_id" optional="show" />
             </list>
@@ -344,6 +370,11 @@
                     string="Pending subscriptions"
                     name="pendingsubs"
                     domain="[('to_renew','=', True)]"
+                />
+                <filter
+                    string="With recurring revenue"
+                    name="with_mrr"
+                    domain="[('recurring_monthly','&gt;', 0)]"
                 />
                 <separator />
                 <filter


### PR DESCRIPTION
## Problem

`sale.subscription.recurring_total` is the sum of the line `price_subtotal` without normalising to a single cadence. A yearly subscription that bills 1 200 € once a year and a monthly one that bills 100 € a month look very different in the list view even though they generate identical recurring revenue. Aggregating across cadences is impossible — the basic management question "how much do I bill per month?" can only be answered by exporting to a spreadsheet and dividing case by case.

## Solution

Add two new stored computed monetary fields on `sale.subscription`:

- `recurring_monthly` — monthly recurring revenue (MRR), summed from a per-line `recurring_monthly`.
- `recurring_yearly` — twelve times the monthly figure (ARR).

The line-level `recurring_monthly` divides `price_subtotal` by the number of months in the line's period. The factor is `1 / 30.4375` for days, `7 / 30.4375` for weeks, `1.0` for months and `12.0` for years, multiplied by `recurring_interval`. So a 100 €/week line yields ≈ 434.82 €/month, a 1 200 €/year line yields 100 €/month, a 300 € line every 3 months yields 100 €/month.

UI changes:

- Form view: new stat button showing MRR and ARR side by side.
- List view: `recurring_monthly` (`sum` footer, optional `show`) and `recurring_yearly` (optional `hide`).
- Search view: new "With recurring revenue" filter (`recurring_monthly > 0`).

No existing field is renamed, dropped or otherwise altered (see §0.4 of the internal compatibility checklist). Pure additive change.

## Migration

`-u subscription_oca` triggers a normal ORM recompute. No data script. Estimate roughly two seconds per ten thousand subscription lines on commodity hardware.

## How to test

1. Install the module and create a template with `recurring_rule_type = months`, `recurring_interval = 1`. Add a subscription line with a 100 € product → `recurring_monthly = 100`, `recurring_yearly = 1200`.
2. Switch the template to `years` → `recurring_monthly = 100 / 12 ≈ 8.33`.
3. Switch to `weeks`, interval 1 → `recurring_monthly = 100 * 30.4375 / 7 ≈ 434.82`.
4. Switch to `months`, interval 3 → `recurring_monthly = 100 / 3 ≈ 33.33`.
5. Open the subscription list view → MRR column is summable.
6. Apply the search filter "With recurring revenue" → only subscriptions with positive MRR remain.

The bundled tests in `tests/test_subscription_mrr.py` cover all of the above plus aggregation across lines and recompute after qty or template changes.