### PR TITLE
[18.0][FIX] subscription_oca: prevent cron crash and enforce data consistency

### DIFF
--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -287,6 +287,7 @@ class SaleSubscription(models.Model):
         )
         self.write(
             {
+                "in_progress": False,
                 "recurring_next_date": False,
                 "close_reason_id": close_reason_id,
                 "stage_id": closed_stage.id,

--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -476,6 +476,12 @@ class SaleSubscription(models.Model):
         return False
 
     def write(self, values):
+        if "stage_id" in values and "in_progress" not in values:
+            stage = values["stage_id"]
+            if isinstance(stage, int):
+                stage = self.env["sale.subscription.stage"].browse(stage)
+            if stage.type != "in_progress":
+                values["in_progress"] = False
         res = super().write(values)
         if "stage_id" in values:
             for record in self:

--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -7,7 +7,7 @@ from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
 
 from odoo import Command, api, fields, models
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +196,27 @@ class SaleSubscription(models.Model):
                     + record.date_start
                 )
                 record.recurring_rule_boundary = False
+
+    @api.constrains("in_progress", "stage_id", "recurring_next_date")
+    def _check_in_progress_consistency(self):
+        for record in self:
+            if record.in_progress and record.stage_id.type != "in_progress":
+                raise ValidationError(
+                    self.env._(
+                        "Subscription '%s': in_progress=True requires a stage of "
+                        "type 'in_progress' (current stage type: '%s')."
+                    )
+                    % (record.display_name, record.stage_id.type)
+                )
+            if record.in_progress and not record.recurring_next_date:
+                raise ValidationError(
+                    self.env._(
+                        "Subscription '%s' is marked as in-progress but has no "
+                        "next invoice date. Set a recurring next date before "
+                        "activating the subscription."
+                    )
+                    % record.display_name
+                )
 
     @api.depends("template_id")
     def _compute_terms(self):

--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -139,27 +139,35 @@ class SaleSubscription(models.Model):
     @api.model
     def cron_subscription_management(self):
         today = date.today()
-        for subscription in self.search([], order="recurring_next_date asc"):
+        domain = [("stage_id.type", "in", ["pre", "in_progress"])]
+        for subscription in self.search(domain, order="recurring_next_date asc"):
             subscription = subscription.with_company(subscription.company_id)
-            if subscription.in_progress:
-                if (
-                    subscription.recurring_next_date <= today
-                    and subscription.sale_subscription_line_ids
-                ):
-                    try:
+            try:
+                with self.env.cr.savepoint():
+                    if subscription.in_progress:
+                        if (
+                            subscription.recurring_next_date
+                            and subscription.recurring_next_date <= today
+                            and subscription.sale_subscription_line_ids
+                        ):
+                            subscription.generate_invoice()
+                        if (
+                            not subscription.recurring_rule_boundary
+                            and subscription.date
+                            and subscription.date <= today
+                        ):
+                            subscription.close_subscription()
+                    elif (
+                        subscription.date_start <= today
+                        and subscription.stage_id.type == "pre"
+                    ):
+                        subscription.action_start_subscription()
                         subscription.generate_invoice()
-                    except Exception:
-                        logger.exception("Error on subscription invoice generate")
-                if (
-                    not subscription.recurring_rule_boundary
-                    and subscription.date <= today
-                ):
-                    subscription.close_subscription()
-            elif (
-                subscription.date_start <= today and subscription.stage_id.type == "pre"
-            ):
-                subscription.action_start_subscription()
-                subscription.generate_invoice()
+            except Exception:
+                logger.exception(
+                    "Error on subscription management for subscription %s",
+                    subscription.display_name,
+                )
 
     @api.depends("sale_subscription_line_ids")
     def _compute_total(self):

--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -253,14 +253,14 @@ class SaleSubscription(models.Model):
 
     def close_subscription(self, close_reason_id=False):
         self.ensure_one()
-        self.recurring_next_date = False
         closed_stage = self.env["sale.subscription.stage"].search(
             [("type", "=", "post")], limit=1
         )
         self.write(
             {
+                "recurring_next_date": False,
                 "close_reason_id": close_reason_id,
-                "stage_id": closed_stage,
+                "stage_id": closed_stage.id,
             }
         )
 

--- a/subscription_oca/tests/test_subscription_oca.py
+++ b/subscription_oca/tests/test_subscription_oca.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from dateutil.relativedelta import relativedelta
 
 from odoo import Command, exceptions, fields
-from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -130,6 +129,12 @@ class TestSubscriptionOCA(BaseCommon):
                 "type": "pre",
             }
         )
+        cls.stage_in_progress = cls.env["sale.subscription.stage"].create(
+            {
+                "name": "Test Sub Stage In Progress",
+                "type": "in_progress",
+            }
+        )
         cls.tag = cls.env["sale.subscription.tag"].create(
             {
                 "name": "Test Tag",
@@ -176,6 +181,7 @@ class TestSubscriptionOCA(BaseCommon):
                 "pricelist_id": cls.pricelist2.id,
                 "date_start": fields.Date.today() - relativedelta(days=100),
                 "in_progress": True,
+                "stage_id": cls.stage_in_progress.id,
             }
         )
         cls.sub8 = cls.create_sub(
@@ -184,6 +190,7 @@ class TestSubscriptionOCA(BaseCommon):
                 "pricelist_id": cls.pricelist2.id,
                 "date_start": fields.Date.today() - relativedelta(days=100),
                 "in_progress": True,
+                "stage_id": cls.stage_in_progress.id,
                 "journal_id": cls.cash_journal.id,
             }
         )
@@ -192,6 +199,7 @@ class TestSubscriptionOCA(BaseCommon):
                 "template_id": cls.tmpl3.id,
                 "date_start": fields.Date.today() - relativedelta(days=100),
                 "in_progress": True,
+                "stage_id": cls.stage_in_progress.id,
                 "recurring_rule_boundary": True,
             }
         )
@@ -349,12 +357,19 @@ class TestSubscriptionOCA(BaseCommon):
         "SaleSubscription.generate_invoice"
     )
     def test_subscription_oca_sub_cron_error(self, generate_invoice_patch):
-        # Simulate something failing in generating an invoice,
-        # we expect something being logged
+        # When generate_invoice() fails the cron must NOT raise —
+        # it must log the error and continue processing other subscriptions.
         generate_invoice_patch.side_effect = exceptions.UserError("Error")
-        with mute_logger("odoo.addons.subscription_oca.models.sale_subscription"):
-            with self.assertRaises(exceptions.UserError):
-                self.sub1.cron_subscription_management()
+        with self.assertLogs(
+            "odoo.addons.subscription_oca.models.sale_subscription", level="ERROR"
+        ) as log_watcher:
+            self.sub1.cron_subscription_management()
+        self.assertTrue(
+            any(
+                "Error on subscription management for subscription" in msg
+                for msg in log_watcher.output
+            )
+        )
 
     def test_subscription_oca_sub_cron(self):
         # sale.subscription


### PR DESCRIPTION
### Problem

During a database upgrade, a subscription was found with `in_progress=True`
but no valid `recurring_next_date`. When the cron job `cron_subscription_management()`
processed this record, the comparison `False <= date.today()` raised `TypeError`,
crashing the entire cron and rolling back all invoices generated in that run.

### Root Cause (Potentially)

`close_subscription()` wrote `recurring_next_date = False` as a standalone
assignment before the `write({'stage_id': ...})` call, creating a split-write
window that left the record in an inconsistent state.

### What This Does

- Consolidates `close_subscription()` into a single atomic `write()` call
- Adds `@api.constrains` enforcing `in_progress=True` requires a consistent
  stage type and a valid `recurring_next_date`
- Hardens the cron with per-record savepoint isolation so a single failure
  never kills the entire job
- Adds a domain filter to skip closed subscriptions, tighter to
  `pre`/`in_progress` stages only
- Adds defensive guards on date comparisons to prevent `TypeError` on
  legacy bad data
- Aligns test fixtures (`sub7`/`sub8`/`sub9`) with correct `in_progress`
  semantics (stage type `"in_progress"`)
- Fixes `write()` override timing: inject `in_progress=False` before
  `super().write()` when target stage is not `"in_progress"`, so the
  constraint sees consistent state during flush

### Commits

1. `[FIX] subscription_oca: fix test fixtures and cron error test`
   Add `stage_in_progress` with correct type, update error test for new
   cron behavior.

2. `[FIX] subscription_oca: consolidate close_subscription atomic write`
   Merge all three fields into one `write()` to prevent split-write
   inconsistencies.

3. `[FIX] subscription_oca: add constraint for in_progress consistency`
   Enforce `in_progress=True` requires `stage_id.type="in_progress"`
   and a valid `recurring_next_date`.

4. `[FIX] subscription_oca: harden cron with savepoint and domain filter`
   Per-record savepoint isolation, domain filter for `pre`/`in_progress`
   stages, defensive guards on date comparisons.

5. `[FIX] subscription_oca: set in_progress=False in close_subscription`
   Ensure constraint sees consistent state during `write()`.

6. `[FIX] subscription_oca: prevent ValidationError when changing stage via write()`
   Inject `in_progress=False` before `super().write()` when the target
   stage type is not `"in_progress"`, preventing constraint errors on any
   stage change for in-progress subscriptions.

### Testing

All existing tests pass. Updated `test_subscription_oca_sub_cron_error`
to verify the cron catches and logs exceptions instead of propagating them.

@BinhexTeam T18387