### PR TITLE
[19.0][FIX] contract: exclude archived products from the line picker

### DIFF
--- a/contract/models/contract_template_line.py
+++ b/contract/models/contract_template_line.py
@@ -33,7 +33,11 @@ class ContractTemplateLine(models.Model):
         comodel_name="res.partner", related="contract_id.partner_id"
     )
     # === Product & UOM ===
-    product_id = fields.Many2one("product.product", string="Product")
+    product_id = fields.Many2one(
+        "product.product",
+        string="Product",
+        domain=[("active", "=", True)],
+    )
     name = fields.Text(
         string="Description",
         required=True,

--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -51,7 +51,9 @@
         <field name="priority" eval="20" />
         <field name="arch" type="xml">
             <field name="product_id" position="attributes">
-                <attribute name="domain">[('sale_ok', '=', True)]</attribute>
+                <attribute
+                    name="domain"
+                >[('sale_ok', '=', True), ('active', '=', True)]</attribute>
             </field>
         </field>
     </record>
@@ -65,8 +67,9 @@
         <field name="priority" eval="20" />
         <field name="arch" type="xml">
             <field name="product_id" position="attributes">
-                <attribute name="domain">[('purchase_ok', '=', True)]
-                </attribute>
+                <attribute
+                    name="domain"
+                >[('purchase_ok', '=', True), ('active', '=', True)]</attribute>
             </field>
             <field name="automatic_price" position="attributes">
                 <attribute name="invisible">True</attribute>


### PR DESCRIPTION
Split out from #1427 (per @pedrobaeza's request to break the big PR into focused ones).

Excludes archived products from the contract line product picker.

Context: the `active_test: False` on `contract_line_ids` — added in d25115df ("No contract line and invoices when contract is archived") to keep archived contract *lines* visible — leaks into the embedded product search and surfaces archived products. Because a view-level `domain` attribute *replaces* the model field domain (they don't AND together), each customer/supplier line view re-asserts `('active', '=', True)`. Happy to switch to re-asserting `active_test: True` on the product field instead if preferred.
