### PR TITLE
[19.0][IMP] contract: paginate contract lines on the form view

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -111,6 +111,7 @@
                                 <list
                                     decoration-info="create_invoice_visibility"
                                     editable="bottom"
+                                    limit="80"
                                 >
                                     <control>
                                         <create string="Add a line" />
@@ -194,7 +195,10 @@
                                 widget="product_label_section_and_note_field_o2m"
                                 context="{'default_contract_type': contract_type}"
                             >
-                                <list decoration-info="create_invoice_visibility">
+                                <list
+                                    decoration-info="create_invoice_visibility"
+                                    limit="80"
+                                >
                                     <control>
                                         <create string="Add a line" />
                                         <create


### PR DESCRIPTION
## Problem

The contract form loads **all** contract lines at once. The recurring and fixed line lists (`contract_line_ids` / `contract_line_fixed_ids`) had no `limit`, so opening a contract with many lines rendered every line up front — noticeably slow on contracts with 50+ lines.

## Change

Add `limit="80"` to both embedded line lists in the contract form view. 80 is Odoo's default backend list limit, so:
- Small/typical contracts (< 80 lines) are **unaffected** — no pagination shown, identical UX.
- Large contracts now load the first page instead of every line, so the form opens faster; the rest is one click away via the list pager.

Low risk, low effort — a view-only change, no Python/data changes.
