### PR TITLE
[19.0][FIX] subscription_oca: recompute totals on line subtotal change

### DIFF
--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -182,7 +182,10 @@ class SaleSubscription(models.Model):
                 subscription.action_start_subscription()
                 subscription.generate_invoice()
 
-    @api.depends("sale_subscription_line_ids")
+    @api.depends(
+        "sale_subscription_line_ids.price_subtotal",
+        "sale_subscription_line_ids.amount_tax_line_amount",
+    )
     def _compute_total(self):
         for record in self:
             recurring_total = amount_tax = 0.0

--- a/subscription_oca/tests/test_subscription_oca.py
+++ b/subscription_oca/tests/test_subscription_oca.py
@@ -791,3 +791,21 @@ class TestSubscriptionOCA(ProductCommon, BaseCommon):
             10.0,
             "Manual discount was lost after changing the quantity (Bug #1320)",
         )
+
+    def test_recurring_total_recomputes_on_line_price_change(self):
+        """Changing the unit price of an existing line must refresh the stored
+        subscription totals. Regression: ``_compute_total`` only depended on the
+        list of lines, so any later edit to a line's price (pricelist change,
+        manual edit, discount) left ``recurring_total`` stale."""
+        subscription = self.create_sub({})
+        line = self.create_sub_line(subscription)
+        subscription.flush_recordset()
+        before = subscription.recurring_total
+        # Edit the unit price of the already existing line.
+        line.price_unit = 1234.0
+        self.assertEqual(
+            subscription.recurring_total,
+            line.price_subtotal,
+            "Totals were not refreshed after a line price change.",
+        )
+        self.assertNotEqual(before, subscription.recurring_total)


### PR DESCRIPTION
Depends on nothing.

`_compute_total` only declared a dependency on the list of lines (`sale_subscription_line_ids`), not on the lines' subtotals. Since `recurring_total`, `amount_tax` and `amount_total` are stored, any change to an **existing** line's price (pricelist change, manual unit price edit, discount update) recomputed the line subtotals but did not trigger the parent totals, leaving them stale.

This is the root cause behind the issue reported in #1452 (change-customer wizard): when a subscription's pricelist is changed, line prices update correctly but `recurring_total` does not.

The fix declares the dependency on the aggregated line fields (`price_subtotal`, `amount_tax_line_amount`), so the subscription totals are refreshed whenever a line value changes. A regression test (edit the unit price of an existing line and assert the totals are refreshed) is included.