### PR TITLE
[18.0][FIX] product_contract: Use the correct language in the sale order line to translate terms correctly

### DIFF
--- a/product_contract/models/sale_order_line.py
+++ b/product_contract/models/sale_order_line.py
@@ -212,6 +212,9 @@ class SaleOrderLine(models.Model):
         res = super()._compute_name()
         for line in self:
             if line.is_contract:
+                lang = line.order_id._get_lang()
+                if lang != self.env.lang:
+                    line = line.with_context(lang=lang)
                 if line.contract_start_date_method == "manual":
                     date_text = f"{line.date_start}"
                     if line.date_end:


### PR DESCRIPTION
When a product has a translated name, it is not correctly stored in the sale.order.line name field because the language context is lost in this function.

TT63447
@Tecnativa @pedrobaeza @CarlosRoca13 could you please review this?