### PR TITLE
[FIX] contract_sale_generation: Sale line violates check constraint

### DIFF
--- a/contract_sale_generation/models/contract.py
+++ b/contract_sale_generation/models/contract.py
@@ -16,6 +16,13 @@ class ContractContract(models.Model):
 
     sale_count = fields.Integer(compute="_compute_sale_count")
 
+    @api.constrains(
+        "generation_type",
+    )
+    def _constrain_sale_generation_type_line_product(self):
+        """If the contract generates a sale, its lines must comply with sale order lines."""
+        self.contract_line_ids._constrain_sale_product_display()
+
     def _prepare_sale(self, date_ref):
         self.ensure_one()
         sale = self.env["sale.order"].new(

--- a/contract_sale_generation/models/contract_line.py
+++ b/contract_sale_generation/models/contract_line.py
@@ -1,11 +1,35 @@
 # Copyright (C) 2020 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import _, api, exceptions, models
 
 
 class ContractLine(models.Model):
     _inherit = "contract.line"
+
+    @api.constrains(
+        "display_type",
+        "product_id",
+    )
+    def _constrain_sale_product_display(self):
+        """If the contract generates a sale, its lines must comply with sale order lines."""
+        sale_contract_lines = self.filtered(
+            lambda line: line.contract_id.generation_type == "sale"
+        )
+        for line in sale_contract_lines:
+            # Stay aligned with accountable_required_fields SQL constraint:
+            # CHECK(
+            #   display_type IS NOT NULL
+            #   OR (product_id IS NOT NULL AND product_uom IS NOT NULL)
+            # )
+            if not (line.display_type or (line.product_id and line.uom_id)):
+                raise exceptions.ValidationError(
+                    _(
+                        "The line %(name)s must set a Product/UoM "
+                        "or have a different display type",
+                        name=line.name,
+                    )
+                )
 
     def _prepare_sale_line_vals(self, dates, order_id=False):
         sale_line_vals = {

--- a/contract_sale_generation/tests/test_contract_sale.py
+++ b/contract_sale_generation/tests/test_contract_sale.py
@@ -3,7 +3,7 @@
 # Copyright 2017 Angel Moya <angel.moya@pesol.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields
+from odoo import exceptions, fields
 from odoo.exceptions import ValidationError
 from odoo.tests.common import SavepointCase
 
@@ -112,3 +112,38 @@ class TestContractSale(ContractSaleCommon, SavepointCase):
         orders = self.env["sale.order"].browse()
         orders |= self.contract.recurring_create_sale()
         self.assertEqual(self.analytic_account, orders.mapped("analytic_account_id"))
+
+    def test_constrain_sale_contract_line(self):
+        """If the contract generates a sale, its lines must have a product."""
+        # Arrange
+        contract = self.contract.copy(
+            default={
+                "generation_type": "sale",
+            }
+        )
+        # pre-condition
+        self.assertEqual(contract.generation_type, "sale")
+
+        # Act
+        with self.assertRaises(exceptions.ValidationError) as ve:
+            contract.contract_line_ids.product_id = False
+
+        # Assert
+        exc_message = ve.exception.args[0]
+        self.assertIn("must set a Product", exc_message)
+
+    def test_constrain_sale_contract(self):
+        """If the lines do not have a product, the contract cannot generate sales."""
+        # Arrange
+        contract = self.contract
+        contract.contract_line_ids.product_id = False
+        # pre-condition
+        self.assertNotEqual(contract.generation_type, "sale")
+
+        # Act
+        with self.assertRaises(exceptions.ValidationError) as ve:
+            contract.generation_type = "sale"
+
+        # Assert
+        exc_message = ve.exception.args[0]
+        self.assertIn("must set a Product", exc_message)


### PR DESCRIPTION
Steps:
1. Create a contract with "Sale" generation type
2. Add a line without a product
3. Generate a sale from the contract

Before this change:
The sale cannot be created because it raises:
> ValueError: <class 'psycopg2.errors.CheckViolation'>: "new row for relation "sale_order_line" violates check constraint "sale_order_line_accountable_required_fields"

After this change:
The line must have a product in order to save the contract.

Additional context:
The same issue was also addressed in #1100 but from a UI point of view