### PR TITLE
[18.0][FIX] contract: flush_recordset([create_date])

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -397,6 +397,7 @@ class ContractContract(models.Model):
             if record.contract_line_ids:
                 date_start = min(record.contract_line_ids.mapped("date_start"))
             else:
+                record.flush_recordset(["create_date"])
                 date_start = record.create_date
             record.message_subscribe(
                 partner_ids=[record.partner_id.id], subtype_ids=[subtype_id.id]


### PR DESCRIPTION
### Summary

Fix a `MissingError` raised when accessing `record.create_date` inside
`_set_start_contract_modification` during a fresh database installation with
demo data.

### Root Cause

In Odoo 18, the `create()` flow was redesigned to support `precompute=True`
fields. The new sequence is:

1. A virtual `NewId` is assigned to the record (not yet in the database).
2. All `precompute=True` fields are computed in memory.
3. The SQL `INSERT` is executed, writing the record to the database.
4. Code after `super().create()` continues.

`create_date` is a database-generated value (set by PostgreSQL at INSERT time).
The ORM does **not** precompute it, and in Odoo 18 it may not be loaded into
the ORM cache automatically after the INSERT returns.

When `_set_start_contract_modification` runs immediately after
`super().create()`, and the contract has no lines yet (e.g., when contracts are
created before their lines in demo/fixture data), the code reaches:

```python
else:
    date_start = record.create_date  # MissingError: record not found in cache
