### PR TITLE
[19.0][FIX] contract: start portal tour from portal home

### DIFF
--- a/contract/static/src/js/contract_portal_tour.esm.js
+++ b/contract/static/src/js/contract_portal_tour.esm.js
@@ -1,7 +1,7 @@
 import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("contract_portal_tour", {
-    url: "/",
+    url: "/my",
     steps: () => [
         {
             content: "Go to Contracts menu",


### PR DESCRIPTION
Start the portal tour from `/my` instead of `/`.

When `website` is installed, the home page does not expose the portal navigation directly, causing the tour to fail because the Contracts menu entry is not visible.

@Tecnativa TT63167

@pedrobaeza @victoralmau please review