### PR TITLE
[18.0][IMP] contract_line_successor - stop() returns self in place of True

### DIFF
--- a/contract_line_successor/models/contract_line.py
+++ b/contract_line_successor/models/contract_line.py
@@ -420,7 +420,7 @@ class ContractLine(models.Model):
         Put date_end on contract line
         We don't consider contract lines that end's before the new end date
         :param date_end: new date end for contract line
-        :return: True
+        :return: the records that are stopped
         """
         if not all(self.mapped("is_stop_allowed")):
             raise ValidationError(_("Stop not allowed for this line"))
@@ -454,7 +454,7 @@ class ContractLine(models.Model):
                             "manual_renew_needed": manual_renew_needed,
                         }
                     )
-        return True
+        return self
 
     def _prepare_value_for_plan_successor(
         self, date_start, date_end, is_auto_renew, recurring_next_date=False


### PR DESCRIPTION
This allows more flexibility when overriding the method.