### PR TITLE
[19.0][IMP] contract: restrict pricelist selection to the contract's company

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -66,7 +66,10 @@
                                 domain="['|', ('contract_type', '=', contract_type), ('contract_type', '=', False)]"
                                 context="{'default_contract_type': contract_type}"
                             />
-                            <field name="pricelist_id" />
+                            <field
+                                name="pricelist_id"
+                                domain="[('company_id', 'in', (company_id, False))]"
+                            />
 
                             <field
                                 name="company_id"

--- a/contract/views/contract_template.xml
+++ b/contract/views/contract_template.xml
@@ -23,7 +23,10 @@
                         </group>
                         <group name="group_main_right">
                             <field name="journal_id" />
-                            <field name="pricelist_id" />
+                            <field
+                                name="pricelist_id"
+                                domain="[('company_id', 'in', (company_id, False))]"
+                            />
                             <field
                                 name="company_id"
                                 options="{'no_create': True}"


### PR DESCRIPTION
### Problem
`pricelist_id` on `contract.contract` and `contract.template` has **no company domain**, so a pricelist belonging to **any** company can be selected on a contract — including a company whose pricelists the contract's users can't read. That silently creates cross-company records which later raise a `product pricelist company rule` access error (typically when a line's price is computed and the foreign-company pricelist is read).

### Fix
Add the same company domain Odoo's `sale.order.pricelist_id` uses:

```xml
<field name="pricelist_id" domain="[('company_id', 'in', (company_id, False))]"/>
```

on both the contract form and the contract-template form — restricting selection to the record's **own company** or a **shared** (company-less) pricelist. `company_id` is auto-included by the view for the domain (as it is for `sale.order`).

Preventive only — it doesn't migrate existing mismatched data; that's a one-off data fix.