### PR TITLE
[18.0][FIX] contract: do not suggest archived products in contract lines

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -132,6 +132,7 @@
                                     <field
                                         name="product_id"
                                         widget="product_label_section_and_note_field"
+                                        context="{'active_test': True}"
                                     />
                                     <field
                                         name="name"
@@ -149,7 +150,10 @@
                                         groups="analytic.group_analytic_accounting"
                                     />
                                     <field name="quantity" />
-                                    <field name="uom_id" />
+                                    <field
+                                        name="uom_id"
+                                        context="{'active_test': True}"
+                                    />
                                     <field
                                         name="automatic_price"
                                         column_invisible="parent.contract_type == 'purchase'"
@@ -219,6 +223,7 @@
                                     <field
                                         name="product_id"
                                         widget="product_label_section_and_note_field"
+                                        context="{'active_test': True}"
                                     />
                                     <field
                                         name="name"
@@ -232,7 +237,10 @@
                                         groups="analytic.group_analytic_accounting"
                                     />
                                     <field name="quantity" />
-                                    <field name="uom_id" />
+                                    <field
+                                        name="uom_id"
+                                        context="{'active_test': True}"
+                                    />
                                     <field
                                         name="automatic_price"
                                         column_invisible="parent.contract_type == 'purchase'"

--- a/contract/views/contract_template_line.xml
+++ b/contract/views/contract_template_line.xml
@@ -12,6 +12,7 @@
                             name="product_id"
                             required="display_type == 'product'"
                             invisible="display_type"
+                            context="{'active_test': True}"
                         />
                     </group>
                     <group invisible="display_type">
@@ -36,6 +37,7 @@
                                     groups="uom.group_uom"
                                     class="oe_no_button"
                                     required="not display_type"
+                                    context="{'active_test': True}"
                                 />
                             </div>
                             <field name="discount" />


### PR DESCRIPTION
The contract_line_ids / contract_line_fixed_ids one2many fields define context={"active_test": False} so that archived (closed) contract lines stay visible in the contract form. 

However, the web client propagates this context to every RPC issued from within the lines — including name_search on the product_id and uom_id many2one fields. As a result, archived products and UoMs show up in the dropdowns when adding or editing a contract line.

Steps to reproduce: 
archive a product → open a contract → add a line → search the product: the archived product is suggested.

This PR restores the default behaviour by explicitly setting active_test: True on those fields in the embedded line lists and in the line form dialog, while archived contract lines remain visible as intended.