### PR TITLE
[18.0][FIX] subscription_oca: correct the  recurring_next_date 

### DIFF
--- a/subscription_oca/models/sale_subscription.py
+++ b/subscription_oca/models/sale_subscription.py
@@ -218,6 +218,8 @@ class SaleSubscription(models.Model):
         else:
             type_interval = self.template_id.recurring_rule_type
             interval = int(self.template_id.recurring_interval)
+            inv_posted = self.invoice_ids.filtered(lambda ss: ss.state == "posted")
+            start_date = max(inv_posted.mapped("invoice_date"))
             self.recurring_next_date = start_date + relativedelta(
                 **{type_interval: interval}
             )


### PR DESCRIPTION
[FIX] subscription_oca: correct the  recurring_next_date when the subscription has paid invoices and change the template_id