### PR TITLE
[19.0][FIX] contract: do not suggest archived products in contract lines

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -132,6 +132,7 @@
                                     <field
                                         name="product_id"
                                         widget="product_label_section_and_note_field"
+                                        context="{'active_test': True}"
                                     />
                                     <field
                                         name="name"
@@ -145,7 +146,10 @@
                                         groups="analytic.group_analytic_accounting"
                                     />
                                     <field name="quantity" />
-                                    <field name="uom_id" />
+                                    <field
+                                        name="uom_id"
+                                        context="{'active_test': True}"
+                                    />
                                     <field
                                         name="automatic_price"
                                         column_invisible="parent.contract_type == 'purchase'"
@@ -215,6 +219,7 @@
                                     <field
                                         name="product_id"
                                         widget="product_label_section_and_note_field"
+                                        context="{'active_test': True}"
                                     />
                                     <field
                                         name="name"
@@ -228,7 +233,10 @@
                                         groups="analytic.group_analytic_accounting"
                                     />
                                     <field name="quantity" />
-                                    <field name="uom_id" />
+                                    <field
+                                        name="uom_id"
+                                        context="{'active_test': True}"
+                                    />
                                     <field
                                         name="automatic_price"
                                         column_invisible="parent.contract_type == 'purchase'"

--- a/contract/views/contract_template_line.xml
+++ b/contract/views/contract_template_line.xml
@@ -12,6 +12,7 @@
                             name="product_id"
                             required="display_type == 'product'"
                             invisible="display_type"
+                            context="{'active_test': True}"
                         />
                     </group>
                     <group invisible="display_type">
@@ -36,6 +37,7 @@
                                     groups="uom.group_uom"
                                     class="oe_no_button"
                                     required="not display_type"
+                                    context="{'active_test': True}"
                                 />
                             </div>
                             <field name="discount" />


### PR DESCRIPTION
The contract_line_ids and contract_line_fixed_ids one2many fields set active_test=False in their context so that archived (closed) contract lines remain visible in the contract form. The web client propagates this context to every RPC issued from within the lines, including the name_search of the product_id and uom_id many2one fields. As a result, archived products and units of measure were suggested in the dropdowns.

Restore the default behaviour by explicitly setting active_test=True on these fields in the embedded line lists and in the line form dialog.

(cherry picked from commit 6459aa9b58c365ce52eaa9ae3448914b974b7625)