### PR TITLE
[REF] contract - pass self instead of relying on @api.model

### DIFF
--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -185,14 +185,7 @@ class ContractContract(models.Model):
                 and contract._origin.date_start != contract.date_start
                 or not recurring_next_date
             ):
-                contract.recurring_next_date = self.get_next_invoice_date(
-                    contract.next_period_date_start,
-                    contract.recurring_invoicing_type,
-                    contract.recurring_invoicing_offset,
-                    contract.recurring_rule_type,
-                    contract.recurring_interval,
-                    max_date_end=contract.date_end,
-                )
+                contract.recurring_next_date = contract.get_next_invoice_date()
             else:
                 contract.recurring_next_date = min(recurring_next_date)
 

--- a/contract/models/contract_line.py
+++ b/contract/models/contract_line.py
@@ -205,9 +205,7 @@ class ContractLine(models.Model):
 
     def _prepare_invoice_line(self):
         self.ensure_one()
-        dates = self._get_period_to_invoice(
-            self.last_date_invoiced, self.recurring_next_date
-        )
+        dates = self._get_period_to_invoice()
         name = self._insert_markers(dates[0], dates[1])
         return {
             "quantity": self._get_quantity_to_invoice(*dates),
@@ -223,11 +221,15 @@ class ContractLine(models.Model):
         }
 
     def _get_period_to_invoice(
-        self, last_date_invoiced, recurring_next_date, stop_at_date_end=True
+        self, last_date_invoiced=None, recurring_next_date=None, stop_at_date_end=True
     ):
         # TODO this method can now be removed, since
         # TODO self.next_period_date_start/end have the same values
         self.ensure_one()
+        if last_date_invoiced is None:
+            last_date_invoiced = self.last_date_invoiced
+        if recurring_next_date is None:
+            recurring_next_date = self.recurring_next_date
         if not recurring_next_date:
             return False, False, False
         first_date_invoiced = (
@@ -237,8 +239,6 @@ class ContractLine(models.Model):
         )
         last_date_invoiced = self.get_next_period_date_end(
             first_date_invoiced,
-            self.recurring_rule_type,
-            self.recurring_interval,
             max_date_end=(self.date_end if stop_at_date_end else False),
             next_invoice_date=recurring_next_date,
             recurring_invoicing_type=self.recurring_invoicing_type,

--- a/contract/models/contract_recurring_mixin.py
+++ b/contract/models/contract_recurring_mixin.py
@@ -117,11 +117,7 @@ class ContractRecurringMixin(models.AbstractModel):
     def _compute_next_period_date_end(self):
         """Compute the end date of the next billing period."""
         for rec in self:
-            rec.next_period_date_end = self.get_next_period_date_end(
-                rec.next_period_date_start,
-                rec.recurring_rule_type,
-                rec.recurring_interval,
-                max_date_end=rec.date_end,
+            rec.next_period_date_end = rec.get_next_period_date_end(
                 next_invoice_date=rec.recurring_next_date,
                 recurring_invoicing_type=rec.recurring_invoicing_type,
                 recurring_invoicing_offset=rec.recurring_invoicing_offset,
@@ -147,14 +143,7 @@ class ContractRecurringMixin(models.AbstractModel):
     def _compute_recurring_next_date(self):
         """Compute the next invoice date."""
         for rec in self:
-            rec.recurring_next_date = self.get_next_invoice_date(
-                rec.next_period_date_start,
-                rec.recurring_invoicing_type,
-                rec.recurring_invoicing_offset,
-                rec.recurring_rule_type,
-                rec.recurring_interval,
-                max_date_end=rec.date_end,
-            )
+            rec.recurring_next_date = rec.get_next_invoice_date()
 
     # === Utility Methods ===
 
@@ -176,18 +165,26 @@ class ContractRecurringMixin(models.AbstractModel):
         else:  # yearly
             return relativedelta(years=interval)
 
-    @api.model
     def get_next_period_date_end(
         self,
-        next_period_date_start,
-        recurring_rule_type,
-        recurring_interval,
-        max_date_end,
+        next_period_date_start=None,
+        recurring_rule_type=None,
+        recurring_interval=None,
+        max_date_end=None,
         next_invoice_date=False,
         recurring_invoicing_type=False,
         recurring_invoicing_offset=False,
     ):
         """Compute the end date for the next period."""
+        if next_period_date_start is None:
+            next_period_date_start = self.next_period_date_start
+        if recurring_rule_type is None:
+            recurring_rule_type = self.recurring_rule_type
+        if recurring_interval is None:
+            recurring_interval = self.recurring_interval
+        if max_date_end is None:
+            max_date_end = self.date_end
+
         if not next_period_date_start or (
             max_date_end and next_period_date_start > max_date_end
         ):
@@ -218,17 +215,29 @@ class ContractRecurringMixin(models.AbstractModel):
             next_period_date_end = max_date_end
         return next_period_date_end
 
-    @api.model
     def get_next_invoice_date(
         self,
-        next_period_date_start,
-        recurring_invoicing_type,
-        recurring_invoicing_offset,
-        recurring_rule_type,
-        recurring_interval,
-        max_date_end,
+        next_period_date_start=None,
+        recurring_invoicing_type=None,
+        recurring_invoicing_offset=None,
+        recurring_rule_type=None,
+        recurring_interval=None,
+        max_date_end=None,
     ):
         """Compute the date of the next invoice based on all parameters."""
+        if next_period_date_start is None:
+            next_period_date_start = self.next_period_date_start
+        if recurring_invoicing_type is None:
+            recurring_invoicing_type = self.recurring_invoicing_type
+        if recurring_invoicing_offset is None:
+            recurring_invoicing_offset = self.recurring_invoicing_offset
+        if recurring_rule_type is None:
+            recurring_rule_type = self.recurring_rule_type
+        if recurring_interval is None:
+            recurring_interval = self.recurring_interval
+        if max_date_end is None:
+            max_date_end = self.date_end
+
         next_period_date_end = self.get_next_period_date_end(
             next_period_date_start,
             recurring_rule_type,

--- a/contract_forecast/models/contract_line.py
+++ b/contract_forecast/models/contract_line.py
@@ -78,18 +78,12 @@ class ContractLine(models.Model):
                         )
                         values.append(new_vals)
                     period_date_start = period_date_end + relativedelta(days=1)
-                    period_date_end = self.get_next_period_date_end(
+                    period_date_end = rec.get_next_period_date_end(
                         period_date_start,
-                        rec.recurring_rule_type,
-                        rec.recurring_interval,
                         max_date_end=max_date_end,
                     )
                     recurring_next_date = rec.get_next_invoice_date(
                         period_date_start,
-                        rec.recurring_invoicing_type,
-                        rec.recurring_invoicing_offset,
-                        rec.recurring_rule_type,
-                        rec.recurring_interval,
                         max_date_end=max_date_end,
                     )
 

--- a/contract_invoice_start_end_dates/models/contract_line.py
+++ b/contract_invoice_start_end_dates/models/contract_line.py
@@ -10,9 +10,7 @@ class ContractLine(models.Model):
     def _prepare_invoice_line(self):
         vals = super()._prepare_invoice_line()
         if self.product_id.must_have_dates:
-            dates = self._get_period_to_invoice(
-                self.last_date_invoiced, self.recurring_next_date
-            )
+            dates = self._get_period_to_invoice()
             vals.update(
                 {
                     "start_date": dates[0],

--- a/contract_line_successor/models/contract_line.py
+++ b/contract_line_successor/models/contract_line.py
@@ -383,12 +383,8 @@ class ContractLine(models.Model):
                 new_date_end = rec.date_end + delay_delta
             else:
                 new_date_end = False
-            new_recurring_next_date = self.get_next_invoice_date(
+            new_recurring_next_date = rec.get_next_invoice_date(
                 new_date_start,
-                rec.recurring_invoicing_type,
-                rec.recurring_invoicing_offset,
-                rec.recurring_rule_type,
-                rec.recurring_interval,
                 max_date_end=new_date_end,
             )
             rec.write(
@@ -455,10 +451,6 @@ class ContractLine(models.Model):
         if not recurring_next_date:
             recurring_next_date = self.get_next_invoice_date(
                 date_start,
-                self.recurring_invoicing_type,
-                self.recurring_invoicing_offset,
-                self.recurring_rule_type,
-                self.recurring_interval,
                 max_date_end=date_end,
             )
         new_vals = self.read()[0]

--- a/contract_refund_on_stop/models/contract_line.py
+++ b/contract_refund_on_stop/models/contract_line.py
@@ -105,10 +105,6 @@ class ContractLine(models.Model):
             )
             invoice_date = self.get_next_invoice_date(
                 to_refund_start_date,
-                self.recurring_invoicing_type,
-                self.recurring_invoicing_offset,
-                self.recurring_rule_type,
-                self.recurring_interval,
                 max_date_end=next_period_date_end,
             )
             quantity += self.quantity * self.compute_prorated(

--- a/contract_sale_generation/models/contract_line.py
+++ b/contract_sale_generation/models/contract_line.py
@@ -22,9 +22,7 @@ class ContractLine(models.Model):
 
     def _prepare_sale_line(self, order_id=False, sale_values=False):
         self.ensure_one()
-        dates = self._get_period_to_invoice(
-            self.last_date_invoiced, self.recurring_next_date
-        )
+        dates = self._get_period_to_invoice()
         sale_line_vals = self._prepare_sale_line_vals(dates, order_id=order_id)
 
         order_line = (


### PR DESCRIPTION
Replaces `@api.model` methods with instance methods across contract methods to improve extensibility and allow overrides to access record data in `self`.

Method parameters are now optional to ensure full backward compatibility.