### PR TITLE
[FIX] contract_line_successor: always call _prepare_value_for_stop() …

### DIFF
--- a/contract_line_successor/models/contract_line.py
+++ b/contract_line_successor/models/contract_line.py
@@ -399,21 +399,36 @@ class ContractLine(models.Model):
                 }
             )
 
-    def _prepare_value_for_stop(self, date_end, manual_renew_needed):
+    def _prepare_value_for_stop_base(self, date_end, manual_renew_needed):
+        """
+        Values that must always be applied when a line is stopped, whether
+        or not date_end itself is being pushed earlier.
+
+        This is the extension point for any module that needs to set values
+        on stop() even when the line's date_end doesn't move.
+        Modules should override this method to add their own
+        fields here rather , so those fields
+        are set in every case, not only when date_end is shortened.
+        """
         self.ensure_one()
         return {
-            "date_end": date_end,
             "is_auto_renew": False,
             "manual_renew_needed": manual_renew_needed,
-            "recurring_next_date": self.get_next_invoice_date(
-                self.next_period_date_start,
-                self.recurring_invoicing_type,
-                self.recurring_invoicing_offset,
-                self.recurring_rule_type,
-                self.recurring_interval,
-                max_date_end=date_end,
-            ),
         }
+
+    def _prepare_value_for_stop(self, date_end, manual_renew_needed):
+        self.ensure_one()
+        vals = self._prepare_value_for_stop_base(date_end, manual_renew_needed)
+        vals["date_end"] = date_end
+        vals["recurring_next_date"] = self.get_next_invoice_date(
+            self.next_period_date_start,
+            self.recurring_invoicing_type,
+            self.recurring_invoicing_offset,
+            self.recurring_rule_type,
+            self.recurring_interval,
+            max_date_end=date_end,
+        )
+        return vals
 
     def stop(self, date_end, manual_renew_needed=False, post_message=True):
         """
@@ -449,10 +464,7 @@ class ContractLine(models.Model):
                         rec.contract_id.message_post(body=msg)
                 else:
                     rec.write(
-                        {
-                            "is_auto_renew": False,
-                            "manual_renew_needed": manual_renew_needed,
-                        }
+                        rec._prepare_value_for_stop_base(date_end, manual_renew_needed)
                     )
         return True
 


### PR DESCRIPTION
…on stop()

Before, when the date_end we want to set was not smaller than the line's current date_end, stop did not call _prepare_value_for_stop. It only wrote is_auto_renew and manual_renew_needed by hand instead.

This is a problem because other modules can override _prepare_value_for_stop() to add their own logic  If stop() does not call this method, all that logic is skipped and their values are never saved.

Now _prepare_value_for_stop is always called. We still never make date_end bigger than what it already is  we just make sure the method is called in all cases so custom values from other modules are not lost.