### PR TITLE
[19.0][IMP] contract: notify when there is nothing to invoice

### DIFF
--- a/contract/README.rst
+++ b/contract/README.rst
@@ -80,7 +80,8 @@ Usage
 
 4. The "Generate Recurring Invoices from Contracts" cron runs daily to
    generate the invoices. If you are in debug mode, you can click on the
-   invoice creation button.
+   invoice creation button. When there is nothing left to invoice, a
+   warning notification is displayed instead of creating an invoice.
 5. The *Show recurring invoices* shortcut on contracts shows all
    invoices created from the contract.
 6. The contract report can be printed from the Print menu
@@ -161,6 +162,8 @@ Contributors
 - `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`__
 
      - Bhavesh Heliconia
+
+- bosd <ebo@stefcy.com>
 
 Maintainers
 -----------

--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Recurring - Contracts Management",
-    "version": "19.0.1.0.3",
+    "version": "19.0.1.1.0",
     "category": "Contract Management",
     "license": "AGPL-3",
     "author": "Tecnativa, ACSONE SA/NV, Odoo Community Association (OCA)",

--- a/contract/models/contract.py
+++ b/contract/models/contract.py
@@ -383,7 +383,37 @@ class ContractContract(models.Model):
             self.message_post(body=body)
         return invoices
 
+    def action_recurring_create_invoice(self):
+        """
+        Button action
+        Same as `recurring_create_invoice`, but warning the user when there is
+        nothing to invoice, as no feedback at all is confusing.
+        """
+        self.ensure_one()
+        invoices = self.recurring_create_invoice()
+        if not invoices:
+            return self._get_nothing_to_invoice_notification()
+        return invoices
+
     # === Helpers and Utilities ===
+
+    def _get_nothing_to_invoice_notification(self):
+        """Notification shown when a manual invoicing created no invoice."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "type": "warning",
+                "title": self.env._("Nothing to invoice"),
+                "message": self.env._(
+                    "No invoice has been created for %(contract)s because there "
+                    "is nothing to invoice.",
+                    contract=self.display_name,
+                ),
+                "sticky": False,
+            },
+        }
 
     def get_formview_id(self, access_uid=None):
         if self.contract_type == "sale":

--- a/contract/readme/CONTRIBUTORS.md
+++ b/contract/readme/CONTRIBUTORS.md
@@ -28,3 +28,5 @@
 
 - [Heliconia Solutions Pvt. Ltd.](https://www.heliconia.io)
   > - Bhavesh Heliconia
+
+- bosd \<<ebo@stefcy.com>\>

--- a/contract/readme/USAGE.md
+++ b/contract/readme/USAGE.md
@@ -18,7 +18,8 @@
       of next period)
 4.  The "Generate Recurring Invoices from Contracts" cron runs daily to
     generate the invoices. If you are in debug mode, you can click on
-    the invoice creation button.
+    the invoice creation button. When there is nothing left to invoice, a
+    warning notification is displayed instead of creating an invoice.
 5.  The *Show recurring invoices* shortcut on contracts shows all
     invoices created from the contract.
 6.  The contract report can be printed from the Print menu

--- a/contract/static/description/index.html
+++ b/contract/static/description/index.html
@@ -428,7 +428,8 @@ of next period)</li>
 </li>
 <li>The “Generate Recurring Invoices from Contracts” cron runs daily to
 generate the invoices. If you are in debug mode, you can click on the
-invoice creation button.</li>
+invoice creation button. When there is nothing left to invoice, a
+warning notification is displayed instead of creating an invoice.</li>
 <li>The <em>Show recurring invoices</em> shortcut on contracts shows all
 invoices created from the contract.</li>
 <li>The contract report can be printed from the Print menu</li>
@@ -512,6 +513,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Bhavesh Heliconia</li>
 </ul>
 </blockquote>
+</li>
+<li><p class="first">bosd &lt;<a class="reference external" href="mailto:ebo&#64;stefcy.com">ebo&#64;stefcy.com</a>&gt;</p>
 </li>
 </ul>
 </div>

--- a/contract/tests/test_contract.py
+++ b/contract/tests/test_contract.py
@@ -1461,6 +1461,24 @@ class TestContract(TestContractBase):
         self.contract.contract_line_ids.unlink()
         self.assertFalse(self.contract.recurring_create_invoice())
 
+    def test_action_recurring_create_invoice(self):
+        """The created invoices are returned, without any notification."""
+        invoices = self.contract.action_recurring_create_invoice()
+        self.assertEqual(invoices._name, "account.move")
+        self.assertEqual(len(invoices), 1)
+
+    def test_action_recurring_create_invoice_nothing_to_invoice(self):
+        """The user is warned when the button doesn't create any invoice."""
+        self.acct_line.is_canceled = True
+        # The button is still displayed although there's nothing left to invoice
+        self.assertTrue(self.contract.create_invoice_visibility)
+        action = self.contract.action_recurring_create_invoice()
+        self.assertEqual(action["type"], "ir.actions.client")
+        self.assertEqual(action["tag"], "display_notification")
+        self.assertEqual(action["params"]["type"], "warning")
+        self.assertIn(self.contract.display_name, action["params"]["message"])
+        self.assertEqual(self.contract.invoice_count, 0)
+
     def test_check_last_date_invoiced_before_next_invoice_date(self):
         with self.assertRaises(ValidationError):
             self.acct_line.write(

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -14,7 +14,7 @@
                         groups="base.group_user"
                     />
                     <button
-                        name="recurring_create_invoice"
+                        name="action_recurring_create_invoice"
                         type="object"
                         invisible="not create_invoice_visibility or generation_type != 'invoice'"
                         string="Create invoices"


### PR DESCRIPTION
The **Create invoices** button on a contract form stays visible while the contract has nothing left to invoice (for instance when all of its lines are canceled, so `create_invoice_visibility` is still true but no line can be invoiced).

Clicking it in that situation silently did nothing: no invoice, no message, no error. Users reasonably assume the action failed.

This PR adds `action_recurring_create_invoice`, which the button now calls. It delegates to `recurring_create_invoice` and, when no invoice was created, returns a `display_notification` warning ("Nothing to invoice") in the top right corner instead of returning nothing.

`recurring_create_invoice` itself is left untouched, so modules inheriting or calling it keep their current behaviour.

Covered by two new tests in `contract/tests/test_contract.py`.