### PR TITLE
[19.0][FIX] subscription_oca: fall back to journal account when product has no income account

### DIFF
--- a/subscription_oca/models/sale_subscription_line.py
+++ b/subscription_oca/models/sale_subscription_line.py
@@ -304,7 +304,7 @@ class SaleSubscriptionLine(models.Model):
             self.product_id.property_account_income_id
             or self.product_id.categ_id.property_account_income_categ_id
         )
-        return {
+        vals = {
             "product_id": self.product_id.id,
             "name": self.name,
             "quantity": self.product_uom_qty,
@@ -313,6 +313,8 @@ class SaleSubscriptionLine(models.Model):
             "price_subtotal": self.price_subtotal,
             "tax_ids": [Command.set(self.tax_ids.ids)],
             "product_uom_id": self.product_id.uom_id.id,
-            "account_id": account.id,
             "analytic_distribution": self.analytic_distribution,
         }
+        if account:
+            vals["account_id"] = account.id
+        return vals

--- a/subscription_oca/tests/test_subscription_oca.py
+++ b/subscription_oca/tests/test_subscription_oca.py
@@ -376,6 +376,38 @@ class TestSubscriptionOCA(ProductCommon, BaseCommon):
         move_res = self.sub_line._prepare_account_move_line()
         self.assertIsInstance(move_res, dict)
 
+    def test_subscription_invoice_without_product_income_account(self):
+        category = self.env["product.category"].create(
+            {"name": "Category without income account"}
+        )
+        category.property_account_income_categ_id = False
+        product = self._create_product(
+            name="product_without_income_account",
+            lst_price=10.0,
+            subscribable=True,
+            categ_id=category.id,
+        )
+        self.assertFalse(product.property_account_income_id)
+        self.assertFalse(product.categ_id.property_account_income_categ_id)
+        journal = self.sale_journal
+        self.assertTrue(journal.default_account_id)
+        subscription = self.create_sub(
+            {
+                "journal_id": journal.id,
+                "template_id": self.tmpl2.id,
+                "date_start": fields.Date.today() - relativedelta(days=10),
+                "recurring_next_date": fields.Date.today() - relativedelta(days=1),
+                "in_progress": True,
+            }
+        )
+        self.create_sub_line(subscription, product.id)
+        invoice = subscription.create_invoice()
+        line = invoice.invoice_line_ids.filtered(
+            lambda move_line: move_line.product_id == product
+        )
+        self.assertEqual(len(line), 1)
+        self.assertEqual(line.account_id, journal.default_account_id)
+
     @patch(
         "odoo.addons.subscription_oca.models.sale_subscription."
         "SaleSubscription.generate_invoice"


### PR DESCRIPTION
A subscription line on a product without income account (neither the product nor its category defines one) previously forced account_id=False on the generated invoice line, which violates the database constraint account_move_line_check_accountable_required_fields (account_id IS NOT NULL). The management cron then failed five times in a row and Odoo deactivated it silently.

With this change, when no income account is found the key is omitted so the standard fallback applies: the line gets the journal default account, like any other sale invoice line.

- [x] Module installs and upgrades cleanly on 19.0
- [x] Existing tests pass (0 failed, 0 error)
- [ ] Reviewed by a maintainer
