### PR TITLE
[19.0][IMP] contract: label the date fields "Start Date" and "End Date"

### DIFF
--- a/contract/data/mail_template.xml
+++ b/contract/data/mail_template.xml
@@ -25,7 +25,7 @@
                     &amp;nbsp;&amp;nbsp;<strong>REFERENCES</strong><br />
                     &amp;nbsp;&amp;nbsp;Contract: <strong t-out="object.name" /><br />
                     <t t-if="object.date_start">
-                        &amp;nbsp;&amp;nbsp;Contract Date Start: <t
+                        &amp;nbsp;&amp;nbsp;Contract Start Date: <t
                     t-out="object.date_start or ''"
                 /><br />
                     </t>

--- a/contract/models/contract_recurring_mixin.py
+++ b/contract/models/contract_recurring_mixin.py
@@ -19,12 +19,15 @@ class ContractRecurringMixin(models.AbstractModel):
     _description = "Contract Recurring Mixin"
 
     date_start = fields.Date(
+        string="Start Date",
         index=True,
         default=lambda self: fields.Date.context_today(self),
         help="Contract activation date (first recurrence starts here)",
     )
     date_end = fields.Date(
-        index=True, help="Optional contract termination date (limits recurrence)"
+        string="End Date",
+        index=True,
+        help="Optional contract termination date (limits recurrence)",
     )
 
     # === Recurrence Rule Fields ===

--- a/contract/report/report_contract.xml
+++ b/contract/report/report_contract.xml
@@ -45,7 +45,7 @@
                                         <strong>Price</strong>
                                     </th>
                                     <th class="text-end">
-                                        <strong>Date Start</strong>
+                                        <strong>Start Date</strong>
                                     </th>
                                 </tr>
                             </thead>

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -180,8 +180,8 @@
                                         name="recurring_next_date"
                                         column_invisible="True"
                                     />
-                                    <field name="date_start" column_invisible="True" />
-                                    <field name="date_end" />
+                                    <field name="date_start" optional="hide" />
+                                    <field name="date_end" optional="show" />
                                     <field
                                         name="last_date_invoiced"
                                         groups="base.group_no_one"
@@ -264,7 +264,7 @@
                                         column_invisible="True"
                                     />
                                     <field name="date_start" required="1" />
-                                    <field name="date_end" />
+                                    <field name="date_end" optional="show" />
                                     <field
                                         name="recurring_next_date"
                                         required="next_period_date_end"

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -479,7 +479,7 @@
                     />
                     <filter
                         name="group_by_date_end"
-                        string="Date End"
+                        string="End Date"
                         domain="[]"
                         context="{'group_by':'date_end'}"
                     />

--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -106,8 +106,8 @@
                 <field name="recurring_interval" column_invisible="True" />
                 <field name="recurring_rule_type" column_invisible="True" />
                 <field name="recurring_invoicing_type" column_invisible="True" />
-                <field name="date_start" column_invisible="True" />
-                <field name="date_end" />
+                <field name="date_start" optional="hide" />
+                <field name="date_end" optional="show" />
                 <field name="recurring_next_date" column_invisible="True" />
                 <field name="last_date_invoiced" groups="base.group_no_one" />
                 <field name="create_invoice_visibility" column_invisible="True" />
@@ -154,8 +154,8 @@
                     optional="hide"
                     sum="Total Monthly Recurring"
                 />
-                <field name="date_start" />
-                <field name="date_end" />
+                <field name="date_start" optional="show" />
+                <field name="date_end" optional="show" />
                 <field name="recurring_interval" />
                 <field name="recurring_rule_type" />
                 <field name="recurring_next_date" />


### PR DESCRIPTION
## Problem

`date_start` and `date_end` on `contract.recurring.mixin` carry no `string`, so Odoo derives the label from the field name. Every contract, contract line, contract template and contract template line form therefore reads **"Date Start"** and **"Date End"**.

That is the wrong word order in English, and it is not what Odoo does with the same pair of fields where it defines them itself:

```python
# fleet/models/fleet_vehicle_assignation_log.py
date_start = fields.Date(string="Start Date")
date_end = fields.Date(string="End Date")

# event/models/event_event.py
date_end = fields.Datetime(string='End Date', ...)
```

## Change

Set `string="Start Date"` / `string="End Date"` on the mixin, so all four models that inherit it pick the labels up in one place.

Three spots spelled the old wording out by hand and are updated to match:

- the **Date End** group-by filter on the contract search view
- the **Date Start** column header in the contract PDF report
- *Contract Date Start* in the contract reference mail template

Labels only - no behaviour change, no field renames, no view restructuring.

---

## Second commit: the columns could not be hidden either

Beyond the wording, neither date could be controlled from the line lists:

- `date_end` carried no `optional` attribute, so it sat outside Odoo's column selector and was **always shown, with no way to switch it off**.
- `date_start` was `column_invisible="True"`, so it was **never shown and could not be switched on**.
- 
The recurring line list is the exception: `date_start` is `required="1"` there and stays outside the selector, since hiding a required column would leave no way to fill it in an editable list.


---

## Third commit: the line dates read as plain dates

The contract list renders `date_end` and `recurring_next_date` with the `remaining_days` widget, so a date reads as "In 5 days". The contract line lists showed plain dates - most visibly in the report view behind **Contracts > Reporting > Contract Lines**, a whole table of deadlines with no sense of which are close.

The widget now applies to `date_end` in both standalone line lists, and to `recurring_next_date` in the report view where it is visible.

The lists embedded on the contract form are left alone on purpose: they sit next to the contract's own dates and already carry the lifecycle colours, so relative dates on every line would be noise.
