### PR TITLE
[18.0][FIX] contract: restore the option to hide the discount column

### DIFF
--- a/contract/README.rst
+++ b/contract/README.rst
@@ -47,8 +47,9 @@ Contracts are shown in portal.
 Configuration
 =============
 
-To view discount field in contract line, you need to set *Discount on
-lines* in user access rights.
+The discount column on contract and contract template lines is shown by
+default. To hide it, untick *Invoicing > Settings > Contract >
+Discounts*.
 
 Contracts can be viewed on the portal (list and detail) if the user
 logged into the portal is a follower of the contract.

--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -19,6 +19,7 @@
     "depends": ["base", "account", "product", "portal"],
     "development_status": "Production/Stable",
     "data": [
+        "security/contract_groups.xml",
         "security/contract_tag.xml",
         "security/ir.model.access.csv",
         "security/contract_security.xml",

--- a/contract/models/__init__.py
+++ b/contract/models/__init__.py
@@ -9,3 +9,4 @@ from . import contract_modification
 from . import account_move_line
 from . import res_partner
 from . import contract_tag
+from . import res_config_settings

--- a/contract/models/res_config_settings.py
+++ b/contract/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# Copyright 2026 bosd
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    group_discount_per_contract_line = fields.Boolean(
+        string="Discounts on contract lines",
+        implied_group="contract.group_discount_per_contract_line",
+        help="Show a discount column on contract and contract template lines.",
+    )

--- a/contract/readme/CONFIGURE.md
+++ b/contract/readme/CONFIGURE.md
@@ -1,5 +1,5 @@
-To view discount field in contract line, you need to set *Discount on
-lines* in user access rights.
+The discount column on contract and contract template lines is shown by
+default. To hide it, untick *Invoicing > Settings > Contract > Discounts*.
 
 Contracts can be viewed on the portal (list and detail) if the user
 logged into the portal is a follower of the contract.

--- a/contract/security/contract_groups.xml
+++ b/contract/security/contract_groups.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 bosd
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="group_discount_per_contract_line" model="res.groups">
+        <field name="name">Discount on contract lines</field>
+    </record>
+
+    <!-- Discounts were always shown before this group existed, so keep them on
+         by default and let the setting turn them off. -->
+    <record id="base.group_user" model="res.groups">
+        <field
+            name="implied_ids"
+            eval="[(4, ref('contract.group_discount_per_contract_line'))]"
+        />
+    </record>
+</odoo>

--- a/contract/static/description/index.html
+++ b/contract/static/description/index.html
@@ -396,8 +396,9 @@ functions. Also you can print and send by email contract report.</p>
 </div>
 <div class="section" id="configuration">
 <h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
-<p>To view discount field in contract line, you need to set <em>Discount on
-lines</em> in user access rights.</p>
+<p>The discount column on contract and contract template lines is shown by
+default. To hide it, untick <em>Invoicing &gt; Settings &gt; Contract &gt;
+Discounts</em>.</p>
 <p>Contracts can be viewed on the portal (list and detail) if the user
 logged into the portal is a follower of the contract.</p>
 </div>

--- a/contract/tests/__init__.py
+++ b/contract/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_contract
 from . import test_contract_manually_create_invoice
 from . import test_portal
 from . import test_multicompany
+from . import test_res_config_settings

--- a/contract/tests/test_res_config_settings.py
+++ b/contract/tests/test_res_config_settings.py
@@ -1,0 +1,31 @@
+# Copyright 2026 bosd
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestContractSettings(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.discount_group = cls.env.ref("contract.group_discount_per_contract_line")
+
+    @property
+    def internal_users(self):
+        return self.env.ref("base.group_user")
+
+    def _set_discounts(self, enabled):
+        self.env["res.config.settings"].create(
+            {"group_discount_per_contract_line": enabled}
+        ).execute()
+
+    def test_discounts_are_shown_by_default(self):
+        """An install that never touched the setting keeps showing discounts."""
+        self.assertIn(self.discount_group, self.internal_users.implied_ids)
+
+    def test_discounts_can_be_hidden_and_shown_again(self):
+        """Unticking the setting takes the discount column away, ticking restores it."""
+        self._set_discounts(False)
+        self.assertNotIn(self.discount_group, self.internal_users.implied_ids)
+        self._set_discounts(True)
+        self.assertIn(self.discount_group, self.internal_users.implied_ids)

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -166,7 +166,11 @@
                                         name="specific_price"
                                         column_invisible="True"
                                     />
-                                    <field name="discount" />
+                                    <field
+                                        name="discount"
+                                        groups="contract.group_discount_per_contract_line"
+                                        optional="show"
+                                    />
                                     <field name="price_subtotal" />
                                     <field
                                         name="recurring_interval"
@@ -253,7 +257,11 @@
                                         name="specific_price"
                                         column_invisible="True"
                                     />
-                                    <field name="discount" />
+                                    <field
+                                        name="discount"
+                                        groups="contract.group_discount_per_contract_line"
+                                        optional="show"
+                                    />
                                     <field name="price_subtotal" optional="hide" />
                                     <field
                                         name="recurring_interval"

--- a/contract/views/contract_line.xml
+++ b/contract/views/contract_line.xml
@@ -93,7 +93,11 @@
                 <field name="automatic_price" />
                 <field name="price_unit" readonly="automatic_price" />
                 <field name="specific_price" column_invisible="True" />
-                <field name="discount" />
+                <field
+                    name="discount"
+                    groups="contract.group_discount_per_contract_line"
+                    optional="show"
+                />
                 <field name="price_subtotal" />
                 <field
                     name="monthly_recurring"

--- a/contract/views/contract_template.xml
+++ b/contract/views/contract_template.xml
@@ -72,7 +72,11 @@
                                         name="specific_price"
                                         column_invisible="True"
                                     />
-                                    <field name="discount" />
+                                    <field
+                                        name="discount"
+                                        groups="contract.group_discount_per_contract_line"
+                                        optional="show"
+                                    />
                                     <field name="price_subtotal" />
                                     <field
                                         name="recurring_rule_type"

--- a/contract/views/contract_template_line.xml
+++ b/contract/views/contract_template_line.xml
@@ -40,7 +40,10 @@
                                     context="{'active_test': True}"
                                 />
                             </div>
-                            <field name="discount" />
+                            <field
+                                name="discount"
+                                groups="contract.group_discount_per_contract_line"
+                            />
                         </group>
                     </group>
                     <label for="name" string="Description" invisible="display_type" />

--- a/contract/views/res_config_settings.xml
+++ b/contract/views/res_config_settings.xml
@@ -11,7 +11,15 @@
                     class="row mt16 o_settings_container"
                     title="Contract"
                     name="contract"
-                />
+                >
+                    <setting
+                        id="discount_per_contract_line"
+                        string="Discounts"
+                        help="Show a discount column on contract and contract template lines."
+                    >
+                        <field name="group_discount_per_contract_line" />
+                    </setting>
+                </block>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Same fix as #1514, for 18.0 - this is the series where the regression was introduced.

## Problem

The discount column on contract lines cannot be hidden.

Up to 17.0 it could: the field carried `groups="product.group_discount_per_so_line"` in every view. The 18.0 migration (1dd820b5) dropped that attribute from all five places - Odoo had moved the group from `product` to `sale`, so the old xmlid stopped resolving - and the column has been unconditionally visible ever since.

`readme/CONFIGURE.md` was never updated and still tells users:

> To view discount field in contract line, you need to set *Discount on lines* in user access rights.

which has not been true since the migration.

## Change

`contract` depends on `product`, not `sale`, so it cannot use the core group any more without pulling in a dependency it has no other use for. It owns one instead:

- `contract.group_discount_per_contract_line`, exposed as a **Discounts** toggle in the (previously empty) Contract block of the Invoicing settings.
- `groups=` restored on the discount field in the contract form's two embedded line lists, the contract line form, the contract template and the contract template line.
- The group is granted to internal users in the data file, so **nothing changes on upgrade** - discounts stay visible until someone unticks the setting.
- `CONFIGURE.md` rewritten to describe the setting that now exists.
- Test covering the default and both directions of the toggle.


## Two levels, on purpose

The group answers *may discounts be used on this database at all* - a decision for the whole install, made once in the settings.

That is not the same question as *do I want this column right now*. Even where discounts are allowed, the column costs list width a user may prefer to spend elsewhere. So the discount field also gets `optional="show"` in the four line lists: the two embedded lists on the contract form, the contract line list and the contract template line list.

The lists look exactly as they do today; the difference is that the column can be dropped from the column selector, remembered per user. The two form views keep no `optional`, where it would mean nothing.
