### PR TITLE
[19.0][IMP] contract: optional Reference/Company columns + optional Payment Terms column

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -419,6 +419,7 @@
                 <field name="code" optional="show" />
                 <field name="journal_id" groups="account.group_account_user" />
                 <field name="partner_id" />
+                <field name="payment_term_id" optional="hide" />
                 <field
                     name="tag_ids"
                     widget="many2many_tags"

--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -416,7 +416,7 @@
         <field name="arch" type="xml">
             <list>
                 <field name="name" string="Name" />
-                <field name="code" />
+                <field name="code" optional="show" />
                 <field name="journal_id" groups="account.group_account_user" />
                 <field name="partner_id" />
                 <field
@@ -424,7 +424,11 @@
                     widget="many2many_tags"
                     options="{'color_field': 'color'}"
                 />
-                <field name="company_id" groups="base.group_multi_company" />
+                <field
+                    name="company_id"
+                    groups="base.group_multi_company"
+                    optional="show"
+                />
             </list>
         </field>
     </record>


### PR DESCRIPTION
Spotted on the 19.0 runboat: the contract list has columns that cannot be toggled, and lacks a payment-terms column.

## Change

- `code` (Reference) and `company_id` (Company) get `optional="show"` — they render exactly as today, but a user can now drop them from the column selector (remembered per user). Previously they sat outside the selector with no way off.
- `payment_term_id` (Payment Terms) is added as an **optional column, hidden by default**, so it is available from the selector without cluttering the list.

`payment_mode_id` has the same toggle problem but is added by `contract_payment_mode`, so it is handled separately in #1518.