### PR TITLE
[19.0][IMP] contract_payment_mode: hide Payment Mode by default in the contract list

### DIFF
--- a/contract_payment_mode/views/contract_view.xml
+++ b/contract_payment_mode/views/contract_view.xml
@@ -20,7 +20,7 @@
         <field name="inherit_id" ref="contract.contract_contract_tree_view" />
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
-                <field name="payment_mode_id" />
+                <field name="payment_mode_id" optional="hide" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Spotted on the 19.0 runboat, alongside #1517 - same problem, different module.

## Problem

This module adds Payment Mode to the contract list without an `optional` attribute:

```xml
<field name="partner_id" position="after">
    <field name="payment_mode_id" />
</field>
```

Without `optional`, the column sits outside Odoo's column selector. Every database that installs this glue module gets it added to the contract list permanently, with no way to switch it off.

## Change

`optional="hide"` on the list column.

The payment mode is a detail of how a contract is billed rather than something you scan a list for, and a glue module should not spend a list column by default. Users who want it turn it on from the column selector, and the choice is remembered per user.

The form and search views keep the field exactly as they are.
