### PR TITLE
[19.0][IMP] contract: show the contract name in bold in the list view

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -415,7 +415,7 @@
         <field name="model">contract.contract</field>
         <field name="arch" type="xml">
             <list>
-                <field name="name" string="Name" />
+                <field name="name" string="Name" decoration-bf="1" />
                 <field name="code" />
                 <field name="journal_id" groups="account.group_account_user" />
                 <field name="partner_id" />


### PR DESCRIPTION
Spotted on the 19.0 runboat: contracts look flat next to the sale orders and bills they sit beside in the same menus.

## Problem

Odoo puts the identifying column of a document list in bold, so a row can be scanned by its name before anything else.

`sale.order`:

```xml
<field name="name" string="Number" readonly="1" decoration-bf="1"/>
```

`account.move`:

```xml
<field name="name" decoration-bf="1" .../>
```

It is a broad convention - `decoration-bf` appears 61 times across core views. `contract_contract_tree_view` is the odd one out:

```xml
<field name="name" string="Name" />
```

no `decoration-bf`, so the contract name renders in normal weight.

## Change

Add `decoration-bf="1"` to that one field.

### Not touched

The contract template and contract tag lists also have a plain `name` column, but those are configuration models rather than documents sitting next to invoices, so they are left alone. The contract line list is left alone too: there `name` is the line description, and core does not bold the description column of a document's lines either.

Independent of #1517, which touches other columns of the same list.
