### PR TITLE
[19.0][IMP] contract: colour the contract list by term (expired muted, upcoming info)

### DIFF
--- a/contract/views/contract.xml
+++ b/contract/views/contract.xml
@@ -414,7 +414,13 @@
         <field name="name">contract.contract list view (in contract)</field>
         <field name="model">contract.contract</field>
         <field name="arch" type="xml">
-            <list>
+            <!-- Colour contracts by their term: an expired contract (end date in
+                 the past) is muted, one that has not started yet (start date in
+                 the future) is shown in the info colour, like a draft order. -->
+            <list
+                decoration-muted="date_end and date_end &lt; current_date"
+                decoration-info="date_start and date_start &gt; current_date"
+            >
                 <field name="name" string="Name" />
                 <field name="code" />
                 <field name="journal_id" groups="account.group_account_user" />


### PR DESCRIPTION
Spotted on the 19.0 runboat: the contract list gives no visual cue about a contract's term. An expired contract looks the same as a running one.

## Change

Colour the contract list by term, matching Odoo's draft/expired conventions:

- end date in the past → **muted** (expired)
- start date in the future → **info** (blue, like a draft order)

`date_start` / `date_end` are added as **hidden** columns so the decorations can evaluate; the visible layout is unchanged.

Companion to #1520 (which colours the contract *lines* by their lifecycle state).